### PR TITLE
Apply mcp-builder best practices + add phase 4 evaluation

### DIFF
--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -12,8 +12,12 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Annotated
+
+from pydantic import Field
 
 from mcp.server import FastMCP
+from mcp.types import ToolAnnotations
 
 from eval_mcp.core.bedrock_client import BedrockClient
 from eval_mcp.core.user_storage import list_user_document_paths
@@ -56,6 +60,135 @@ mcp = FastMCP("eval-server", port=port, host=host)
 bedrock = BedrockClient(region=region)
 
 
+# Tool annotation presets. These are hints (not security boundaries) that
+# help MCP clients reason about side effects and concurrency.
+READ_LOCAL = ToolAnnotations(
+    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+)
+READ_REMOTE = ToolAnnotations(
+    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
+)
+CREATE_LOCAL = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+)
+CREATE_REMOTE = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True
+)
+RUN_REMOTE = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True
+)
+
+
+# Reusable Annotated types. Constraints turn into JSON-schema bounds the
+# client sees during tool discovery; examples show up in the generated
+# input_schema so agents get concrete shape hints.
+LimitParam = Annotated[
+    int,
+    Field(ge=1, le=200, description="Page size (1-200).", examples=[20]),
+]
+OffsetParam = Annotated[
+    int,
+    Field(ge=0, description="Page start offset, 0-based.", examples=[0, 20]),
+]
+ResponseFormat = Annotated[
+    str,
+    Field(
+        pattern="^(markdown|json)$",
+        description="Output shape: 'markdown' for humans, 'json' for programmatic use.",
+        examples=["markdown", "json"],
+    ),
+]
+NumSamples = Annotated[
+    int,
+    Field(
+        ge=1,
+        le=500,
+        description="How many QA samples / test cases to generate.",
+        examples=[10, 15, 50],
+    ),
+]
+NumPersonas = Annotated[
+    int,
+    Field(ge=1, le=50, description="Personas to synthesize from.", examples=[3, 5]),
+]
+MonthlyVolume = Annotated[
+    int,
+    Field(
+        ge=1,
+        description="Projected monthly call volume for cost projections.",
+        examples=[1000, 10000, 100000],
+    ),
+]
+ProvidersList = Annotated[
+    list,
+    Field(
+        description=(
+            "Target model IDs to evaluate. Use ids returned by list_available_models, "
+            "e.g. ['bedrock/us.anthropic.claude-sonnet-4-6']."
+        ),
+        examples=[["bedrock/us.anthropic.claude-sonnet-4-6"]],
+    ),
+]
+DatasetName = Annotated[
+    str,
+    Field(
+        description="Dataset name from list_datasets.",
+        examples=["dataset_qa_20260317_152233"],
+    ),
+]
+JudgeName = Annotated[
+    str,
+    Field(
+        description="Judge name from list_judges.",
+        examples=["judge_general_20260317_152233"],
+    ),
+]
+ConfigName = Annotated[
+    str,
+    Field(
+        description="Eval config name from create_eval_config or analyze_agent_path.",
+        examples=["eval_config_20260317_152233"],
+    ),
+]
+AgentImageURI = Annotated[
+    str,
+    Field(
+        description="Container image URI (ECR/DockerHub/GHCR).",
+        examples=["123456.dkr.ecr.us-east-2.amazonaws.com/my-agent:latest"],
+    ),
+]
+AgentPath = Annotated[
+    str,
+    Field(
+        description="Absolute path to a local Python agent file.",
+        examples=["/Users/me/my-agent/agent.py"],
+    ),
+]
+EvalId = Annotated[
+    str,
+    Field(description="Evaluation run ID from list_evaluations.", examples=["run-abc123"]),
+]
+GroupId = Annotated[
+    str,
+    Field(description="Evaluation runId returned by run_evaluation.", examples=["run-abc123"]),
+]
+VenvPython = Annotated[
+    str,
+    Field(
+        description="Absolute path to the agent venv's python binary.",
+        examples=["/Users/me/my-agent/.venv/bin/python"],
+    ),
+]
+SourceFilter = Annotated[
+    str,
+    Field(
+        pattern="^(all|bedrock|external)$",
+        description="Source filter for model listing.",
+        examples=["all", "bedrock", "external"],
+    ),
+]
+
+
 def _user(user_id: str = None) -> str:
     return user_id or DEFAULT_USER
 
@@ -75,7 +208,7 @@ def _auto_pull(user_id: str = None) -> None:
 # Dataset tools
 # ============================================================
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 async def analyze_dataset(
     file_path: str = None,
     file_content: str = None,
@@ -116,7 +249,7 @@ async def analyze_dataset(
     return json.dumps({"success": True, "filename": filename, "analysis": analysis}, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_LOCAL)
 async def save_dataset(
     column_mapping: dict,
     file_path: str = None,
@@ -161,10 +294,17 @@ from eval_mcp.tools.bedrock_models import (
 )
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 def list_bedrock_models(
     provider: str = "all",
-    limit: int = 0,
+    limit: Annotated[
+        int,
+        Field(
+            ge=0,
+            description="Max models to return; 0 = unlimited.",
+            examples=[0, 20, 50],
+        ),
+    ] = 0,
     text_only: bool = True,
 ) -> str:
     """
@@ -185,10 +325,10 @@ def list_bedrock_models(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 def list_available_models(
     provider: str = "all",
-    source: str = "all",
+    source: SourceFilter = "all",
 ) -> str:
     """
     List all models available for evaluations, across Bedrock and external providers.
@@ -211,8 +351,15 @@ def list_available_models(
 # ============================================================
 
 
-@mcp.tool()
-def install_otel(venv_python: str) -> str:
+@mcp.tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
+def install_otel(venv_python: VenvPython) -> str:
     """
     Install the 3 OpenTelemetry packages eval-mcp needs into the user's
     agent venv. Called after run_evaluation_and_report returns
@@ -235,14 +382,14 @@ def install_otel(venv_python: str) -> str:
     return json.dumps({"success": result.success, "message": result.message})
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_REMOTE)
 async def generate_qa_pairs(
     user_id: str = None,
     prompt: str = None,
     documents: list = None,
     instructions: str = None,
-    numSamples: int = 10,
-    numPersonas: int = 5,
+    numSamples: NumSamples = 10,
+    numPersonas: NumPersonas = 5,
 ) -> str:
     """
     Generate question-answer pairs with golden answers for LLM-as-judge evaluation.
@@ -274,34 +421,73 @@ async def generate_qa_pairs(
     return result[0].text
 
 
-@mcp.tool()
-async def list_documents(user_id: str = None) -> str:
+@mcp.tool(annotations=READ_LOCAL)
+async def list_documents(
+    user_id: str = None,
+    limit: LimitParam = 50,
+    offset: OffsetParam = 0,
+    response_format: ResponseFormat = "json",
+) -> str:
     """
-    List all uploaded documents available for the user.
+    List uploaded documents available for the user.
 
     Use this to discover existing documents that can be used with generate_qa_pairs.
     Returns document paths that can be passed to generate_qa_pairs(documents=[...]).
 
+    Args:
+        limit: Page size (default 50).
+        offset: Page start (default 0).
+        response_format: "json" (default) or "markdown".
+
     Returns:
-        JSON with list of document paths
+        JSON or markdown listing with pagination metadata.
     """
     try:
-        paths = list_user_document_paths(_user(user_id))
+        all_paths = list_user_document_paths(_user(user_id))
+        total = len(all_paths)
+        limit = max(1, int(limit or 50))
+        offset = max(0, int(offset or 0))
+        page = all_paths[offset : offset + limit]
+        has_more = offset + len(page) < total
+        next_offset = offset + len(page) if has_more else None
+
+        if (response_format or "json").lower() == "markdown":
+            if total == 0:
+                return "No documents uploaded. Place files under the user's documents/ directory."
+            lines = [f"Found {total} document(s) — showing {offset + 1}-{offset + len(page)}:\n"]
+            lines += [f"- {p}" for p in page]
+            if has_more:
+                lines.append(f"\nMore available — pass offset={next_offset} to see the next page.")
+            lines.append(
+                "\nHint: pass any of these paths to generate_qa_pairs(documents=[...])."
+            )
+            return "\n".join(lines)
+
         return json.dumps({
             "success": True,
-            "documents": paths,
-            "count": len(paths),
-            "hint": "Pass these paths to generate_qa_pairs(documents=[...]) to generate QA pairs from documents",
+            "total": total,
+            "count": len(page),
+            "offset": offset,
+            "has_more": has_more,
+            "next_offset": next_offset,
+            "documents": page,
+            "hint": "Pass these paths to generate_qa_pairs(documents=[...]).",
         })
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)})
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_REMOTE)
 async def generate_judge(
-    dataset: str,
+    dataset: DatasetName,
     user_id: str = None,
-    domain: str = "general",
+    domain: Annotated[
+        str,
+        Field(
+            description="Domain hint guiding criterion selection.",
+            examples=["general", "medical", "legal", "technical", "customer-support"],
+        ),
+    ] = "general",
 ) -> str:
     """
     Generate an LLM judge configuration tailored to your dataset.
@@ -325,11 +511,11 @@ async def generate_judge(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_LOCAL)
 async def create_eval_config(
-    dataset: str,
-    providers: list,
-    judge: str,
+    dataset: DatasetName,
+    providers: ProvidersList,
+    judge: JudgeName,
     user_id: str = None,
     prompts: str | list = "{question}",
     description: str = None,
@@ -378,11 +564,11 @@ async def create_eval_config(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_LOCAL)
 async def create_agent_eval_config(
-    dataset: str,
-    judge: str,
-    agentImage: str,
+    dataset: DatasetName,
+    judge: JudgeName,
+    agentImage: AgentImageURI,
     user_id: str = None,
     agentCmd: list = None,
     model: str = None,
@@ -430,11 +616,11 @@ async def create_agent_eval_config(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_REMOTE)
 async def analyze_agent_image(
-    agentImage: str,
+    agentImage: AgentImageURI,
     user_id: str = None,
-    numSamples: int = 15,
+    numSamples: NumSamples = 15,
     agentCmd: list = None,
     model: str = None,
     context: str = None,
@@ -471,12 +657,12 @@ async def analyze_agent_image(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_REMOTE)
 async def analyze_agent_path(
-    agentPath: str,
+    agentPath: AgentPath,
     user_id: str = None,
     agentEntry: str = "run_agent",
-    numSamples: int = 15,
+    numSamples: NumSamples = 15,
     context: str = None,
 ) -> str:
     """
@@ -517,10 +703,13 @@ async def analyze_agent_path(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def list_datasets(
     user_id: str = None,
     searchTerm: str = None,
+    limit: LimitParam = 20,
+    offset: OffsetParam = 0,
+    response_format: ResponseFormat = "markdown",
 ) -> str:
     """
     List available datasets.
@@ -529,21 +718,33 @@ async def list_datasets(
     Dataset names can be used with generate_judge and create_eval_config.
 
     Args:
-        searchTerm: Optional search term to filter datasets by name
+        searchTerm: Optional case-insensitive filter on dataset name.
+        limit: Page size (default 20).
+        offset: Page start (default 0).
+        response_format: "markdown" (default) for humans, "json" for programmatic use.
 
     Returns:
-        Formatted list of datasets with details
+        Formatted list with pagination metadata.
     """
     _auto_pull(user_id)
-    args = {"user_id": _user(user_id), "searchTerm": searchTerm}
+    args = {
+        "user_id": _user(user_id),
+        "searchTerm": searchTerm,
+        "limit": limit,
+        "offset": offset,
+        "response_format": response_format,
+    }
     result = await handle_list_datasets(args)
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def list_judges(
     user_id: str = None,
     searchTerm: str = None,
+    limit: LimitParam = 20,
+    offset: OffsetParam = 0,
+    response_format: ResponseFormat = "markdown",
 ) -> str:
     """
     List available LLM judges.
@@ -552,21 +753,32 @@ async def list_judges(
     Judge names can be used with create_eval_config.
 
     Args:
-        searchTerm: Optional search term to filter judges by name
+        searchTerm: Optional case-insensitive filter on judge name.
+        limit: Page size (default 20).
+        offset: Page start (default 0).
+        response_format: "markdown" (default) for humans, "json" for programmatic use.
 
     Returns:
-        Formatted list of judges with details
+        Formatted list with pagination metadata.
     """
     _auto_pull(user_id)
-    args = {"user_id": _user(user_id), "searchTerm": searchTerm}
+    args = {
+        "user_id": _user(user_id),
+        "searchTerm": searchTerm,
+        "limit": limit,
+        "offset": offset,
+        "response_format": response_format,
+    }
     result = await handle_list_judges(args)
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def list_evaluations(
     user_id: str = None,
-    limit: int = 20,
+    limit: LimitParam = 20,
+    offset: OffsetParam = 0,
+    response_format: ResponseFormat = "json",
 ) -> str:
     """
     List completed evaluations.
@@ -578,20 +790,27 @@ async def list_evaluations(
         Factual, Coverage, Reasoning — whatever the judge emitted)
 
     Args:
-        limit: Maximum number of evaluations to return (default: 20)
+        limit: Page size (default 20).
+        offset: Page start (default 0).
+        response_format: "json" (default — eval payloads are heavy) or "markdown".
 
     Returns:
-        JSON with list of evaluations and their aggregated scores.
+        JSON or markdown listing with pagination metadata (total, has_more, next_offset).
     """
     _auto_pull(user_id)
-    args = {"user_id": _user(user_id), "limit": limit}
+    args = {
+        "user_id": _user(user_id),
+        "limit": limit,
+        "offset": offset,
+        "response_format": response_format,
+    }
     result = await handle_list_evaluations(args)
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def get_evaluation_details(
-    evalId: str,
+    evalId: EvalId,
     user_id: str = None,
 ) -> str:
     """
@@ -611,9 +830,9 @@ async def get_evaluation_details(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=RUN_REMOTE)
 async def run_evaluation(
-    configName: str,
+    configName: ConfigName,
     user_id: str = None,
 ) -> str:
     """
@@ -645,7 +864,7 @@ async def run_evaluation(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=RUN_REMOTE)
 async def run_evaluation_and_report(
     user_id: str = None,
     # Standard / prompt-comparison eval inputs (all optional — missing pieces are generated)
@@ -659,74 +878,42 @@ async def run_evaluation_and_report(
     # Agent eval inputs (alternative path)
     agent_path: str = None,
     agent_entry: str = "run_agent",
-    num_samples: int = 15,
+    num_samples: NumSamples = 15,
     # Expert mode: user-authored Inspect AI task.py
     task_path: str = None,
     # Shared
     context: str = None,
-    monthly_volume: int = 10000,
+    monthly_volume: MonthlyVolume = 10000,
 ) -> str:
     """
-    DEFAULT entry point for running an eval. Use this for any "run an eval" request.
+    DEFAULT entry point for running an eval. One call, auto-generates missing
+    pieces (dataset, judge, config), writes a PDF report.
 
-    Pass `providers=["bedrock/..."]` and, optionally, `dataset` / `judge`.
-    Anything you omit is auto-generated: QA pairs, judge, config. Writes a
-    PDF report at the end. One call — no need to chain list_datasets +
-    list_judges + create_eval_config + run_evaluation.
+    Modes — pick by which arg you set:
+      • agent_path → agentic eval (everything generated from code)
+      • task_path → expert mode: run a user-authored Inspect AI task.py
+      • providers (+ optional prompts=[...]) → standard or prompt-comparison eval
 
-    Minimal call for a sample eval:
+    Minimal call:
         run_evaluation_and_report(providers=["bedrock/us.anthropic.claude-sonnet-4-6"])
 
-    Modes (reference — you only pass what distinguishes the mode):
-
-    A. Agent eval:
-         agent_path (+ agent_entry, num_samples, context)
-         Everything else (dataset, judge, pipeline) is generated from the code.
-
-    B. Standard eval:
-         providers
-         If `dataset` omitted: generate_qa_pairs runs first (uses `documents`
-         if provided, otherwise synthesizes from `context`).
-         If `judge` omitted: generate_judge runs on the resulting dataset.
-
-    C. Prompt comparison:
-         providers + prompts=[list of templates]
-         Same auto-generation of dataset/judge as B.
-
-    D. Expert mode — user-authored Inspect AI task:
-         task_path (+ optional providers, context)
-         Runs your own `task.py` with whatever Inspect AI scorers/solvers you
-         chose (exact_match, model_graded_qa, pass_at_k, etc.). The tool runs
-         `inspect eval <task_path>`, captures the log, generates a report, and
-         opens the viewer. Use this when the jury-scoring pipeline isn't what
-         you want. Check `inspect --help` and inspect_ai source for available
-         scorers and task helpers.
-
     Args:
-        providers: Target model IDs, e.g. ["bedrock/us.anthropic.claude-sonnet-4-6"].
-            Required for modes B/C.
-        dataset: Name of an existing dataset (from list_datasets). Optional —
-            auto-generated when omitted.
-        judge: Name of an existing judge (from list_judges). Optional —
-            auto-generated from the dataset + context when omitted.
-        prompts: Single prompt template, or list of prompts for a comparison.
-            Use {question} or {prompt} as the placeholder. Default: "{question}"
+        providers: Target model IDs (required for non-agent modes).
+        dataset: Existing dataset name; auto-generated from `documents`/`context` if omitted.
+        judge: Existing judge name; auto-generated from the dataset if omitted.
+        prompts: Prompt template or list of templates for comparison. Use `{question}`.
         description: Optional description recorded in the eval.
         judge_models: Optional override list of judge model IDs.
-        documents: Optional list of document paths to ground dataset generation
-            (PDFs, markdown, etc.) when auto-generating a dataset.
-
-        agent_path: Path to the user's Python agent file (mode A).
-        agent_entry: Entry function name (default: "run_agent").
-        num_samples: Number of test cases (default: 15).
-
-        context: Short description of what the user is evaluating and why.
-            Used to tailor auto-generated datasets/judges AND the report narrative.
-        monthly_volume: Projected monthly call volume for cost projections.
+        documents: Doc paths used to ground auto-generated datasets (PDFs/markdown).
+        agent_path: Local Python agent file (agentic mode).
+        agent_entry: Agent entry function (default: "run_agent").
+        num_samples: Test cases when auto-generating (default: 15).
+        task_path: Path to a user-authored Inspect AI task.py (expert mode).
+        context: Brief description of what's being evaluated; tailors dataset/judge/report.
+        monthly_volume: Projected monthly calls for cost projections (default: 10000).
 
     Returns:
-        JSON combining eval results, the auto-generated configName, any
-        auto-generated dataset/judge names, and the report download URL.
+        JSON with eval results, configName, autoGenerated dataset/judge, and report URL.
     """
     uid = _user(user_id)
     generated: dict = {}  # track what was auto-created so the caller can see
@@ -895,7 +1082,7 @@ async def run_evaluation_and_report(
     return json.dumps(eval_data, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations=RUN_REMOTE)
 async def retry_evaluation(
     user_id: str = None,
 ) -> str:
@@ -913,11 +1100,11 @@ async def retry_evaluation(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(annotations=CREATE_REMOTE)
 async def generate_report(
-    group_id: str,
+    group_id: GroupId,
     context: str = None,
-    monthly_volume: int = 10000,
+    monthly_volume: MonthlyVolume = 10000,
     user_id: str = None,
 ) -> str:
     """
@@ -950,7 +1137,14 @@ async def generate_report(
     return result[0].text
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    )
+)
 async def explore_eval_data(
     user_id: str = None,
     code: str = "",
@@ -1036,7 +1230,8 @@ def main():
     if transport == "http":
         import uvicorn
         from starlette.routing import Route
-        from starlette.responses import JSONResponse
+        from starlette.responses import JSONResponse, Response
+        from starlette.middleware.base import BaseHTTPMiddleware
 
         async def cancel_handler(request):
             user_id = request.path_params["user_id"]
@@ -1047,7 +1242,34 @@ def main():
             user_id = request.path_params["user_id"]
             return JSONResponse(get_running_eval_info(user_id))
 
+        # DNS-rebinding protection: reject browser requests whose Origin isn't
+        # in our allowlist. Same-origin (no Origin header, or matching host)
+        # is always allowed. Override with EVAL_MCP_ALLOWED_ORIGINS=a,b,c.
+        default_allowed = {
+            f"http://{host}:{port}",
+            f"http://localhost:{port}",
+            f"http://127.0.0.1:{port}",
+        }
+        env_allowed = os.environ.get("EVAL_MCP_ALLOWED_ORIGINS", "").strip()
+        allowed_origins = (
+            {o.strip() for o in env_allowed.split(",") if o.strip()}
+            if env_allowed
+            else default_allowed
+        )
+
+        class OriginValidationMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                origin = request.headers.get("origin")
+                if origin and origin not in allowed_origins:
+                    return Response(
+                        f"Forbidden: Origin {origin!r} not in allowlist. "
+                        f"Set EVAL_MCP_ALLOWED_ORIGINS to permit it.",
+                        status_code=403,
+                    )
+                return await call_next(request)
+
         app = mcp.streamable_http_app()
+        app.add_middleware(OriginValidationMiddleware)
         app.routes.insert(0, Route("/eval-info/{user_id}", eval_info_handler, methods=["GET"]))
         app.routes.insert(0, Route("/cancel/{user_id}", cancel_handler, methods=["POST"]))
 

--- a/eval_mcp/tools/list_datasets.py
+++ b/eval_mcp/tools/list_datasets.py
@@ -8,16 +8,45 @@ from mcp.types import TextContent
 from eval_mcp.core.user_storage import list_datasets_from_db
 
 
-async def handle_list_datasets(args: Dict[str, Any]) -> List[TextContent]:
-    """Handle list_datasets tool call.
+def _dataset_preview(dataset: Dict[str, Any]) -> Dict[str, Any]:
+    tests = dataset.get("tests", [])
+    num_samples = dataset.get("num_samples", len(tests) if isinstance(tests, list) else 0)
+    preview = ""
+    if isinstance(tests, list) and len(tests) > 0:
+        first_item = tests[0]
+        if isinstance(first_item, dict):
+            preview = (
+                first_item.get("vars", {}).get("question")
+                or first_item.get("question")
+                or str(first_item)[:100]
+            )
+            preview = preview[:100]
+            if len(preview) == 100:
+                preview += "..."
+    return {
+        "id": dataset.get("id"),
+        "name": dataset.get("name"),
+        "num_samples": num_samples,
+        "preview": preview or None,
+    }
 
-    Lists all datasets from the user's database.
-    Returns details about each dataset including number of samples and preview.
+
+async def handle_list_datasets(args: Dict[str, Any]) -> List[TextContent]:
+    """List datasets with pagination and optional JSON format.
+
+    Args (from `args` dict):
+        user_id: required
+        searchTerm: optional case-insensitive name filter
+        limit: page size, default 20
+        offset: page start, default 0
+        response_format: "markdown" (default) or "json"
     """
     try:
-        # Get required user_id and optional search filter
         user_id = args.get("user_id")
         search_term = (args.get("searchTerm") or "").lower()
+        limit = max(1, int(args.get("limit", 20) or 20))
+        offset = max(0, int(args.get("offset", 0) or 0))
+        response_format = (args.get("response_format") or "markdown").lower()
 
         if not user_id:
             return [
@@ -27,38 +56,48 @@ async def handle_list_datasets(args: Dict[str, Any]) -> List[TextContent]:
                 )
             ]
 
-        # Get datasets from database
-        datasets = list_datasets_from_db(user_id, search_term)
+        all_datasets = list_datasets_from_db(user_id, search_term)
+        total = len(all_datasets)
+        page = all_datasets[offset : offset + limit]
+        has_more = offset + len(page) < total
+        next_offset = offset + len(page) if has_more else None
 
-        if not datasets:
-            msg = f"No datasets found matching '{search_term}'" if search_term else "No datasets found. Create your first dataset with save_dataset."
+        if response_format == "json":
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": True,
+                            "total": total,
+                            "count": len(page),
+                            "offset": offset,
+                            "has_more": has_more,
+                            "next_offset": next_offset,
+                            "items": [_dataset_preview(d) for d in page],
+                        },
+                        indent=2,
+                    ),
+                )
+            ]
+
+        if not all_datasets:
+            msg = (
+                f"No datasets found matching '{search_term}'"
+                if search_term
+                else "No datasets found. Create your first dataset with save_dataset."
+            )
             return [TextContent(type="text", text=msg)]
 
-        # Format output
-        output = f"Found {len(datasets)} dataset(s):\n\n"
-
-        for dataset in datasets:
-            tests = dataset.get("tests", [])
-            num_samples = dataset.get("num_samples", len(tests) if isinstance(tests, list) else 0)
-
-            # Get first question as preview
-            preview = ""
-            if isinstance(tests, list) and len(tests) > 0:
-                first_item = tests[0]
-                if isinstance(first_item, dict):
-                    preview = (
-                        first_item.get("vars", {}).get("question")
-                        or first_item.get("question")
-                        or str(first_item)[:100]
-                    )
-                    preview = preview[:100]
-                    if len(preview) == 100:
-                        preview += "..."
-
-            output += f"📊 **{dataset['name']}**\n"
-            output += f"   ID: {dataset['id'][:16]}...\n"
-            output += f"   Samples: {num_samples}\n"
-            output += f"   Preview: {preview or 'No preview available'}\n\n"
+        output = f"Found {total} dataset(s) — showing {offset + 1}-{offset + len(page)}:\n\n"
+        for dataset in page:
+            p = _dataset_preview(dataset)
+            output += f"📊 **{p['name']}**\n"
+            output += f"   ID: {(p['id'] or '')[:16]}...\n"
+            output += f"   Samples: {p['num_samples']}\n"
+            output += f"   Preview: {p['preview'] or 'No preview available'}\n\n"
+        if has_more:
+            output += f"More available — pass offset={next_offset} to see the next page.\n"
 
         return [TextContent(type="text", text=output)]
 

--- a/eval_mcp/tools/list_evaluations.py
+++ b/eval_mcp/tools/list_evaluations.py
@@ -13,10 +13,19 @@ from eval_mcp.core.user_storage import get_user_log_dir, load_eval_detail
 
 
 async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
-    """List evaluations by reading .eval log files from the user's logs directory."""
+    """List evaluations with pagination and optional markdown format.
+
+    Args (from `args` dict):
+        user_id: required
+        limit: page size, default 20
+        offset: page start, default 0
+        response_format: "json" (default — eval payloads are heavy) or "markdown"
+    """
     try:
         user_id = args.get("user_id")
-        limit = args.get("limit", 20)
+        limit = max(1, int(args.get("limit", 20) or 20))
+        offset = max(0, int(args.get("offset", 0) or 0))
+        response_format = (args.get("response_format") or "json").lower()
 
         if not user_id:
             return [
@@ -30,16 +39,26 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
         eval_log_infos = await list_eval_logs_async(log_dir)
 
         if not eval_log_infos:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({
-                        "success": True,
-                        "evaluations": [],
-                        "message": "No evaluations found. Run an evaluation first.",
-                    }),
-                )
-            ]
+            empty_text = (
+                json.dumps({
+                    "success": True,
+                    "total": 0,
+                    "count": 0,
+                    "offset": offset,
+                    "has_more": False,
+                    "next_offset": None,
+                    "evaluations": [],
+                    "message": "No evaluations found. Run an evaluation first.",
+                })
+                if response_format == "json"
+                else "No evaluations found. Run an evaluation first."
+            )
+            return [TextContent(type="text", text=empty_text)]
+
+        total = len(eval_log_infos)
+        page_infos = eval_log_infos[offset : offset + limit]
+        has_more = offset + len(page_infos) < total
+        next_offset = offset + len(page_infos) if has_more else None
 
         # Cache pre-computed details per group so multi-model groups only
         # deserialize once (same summary UI/PDF consume).
@@ -54,7 +73,7 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
             return detail_cache[run_id]
 
         evaluations = []
-        for info in eval_log_infos[:limit]:
+        for info in page_infos:
             try:
                 log = await read_eval_log_async(info.name, header_only=True)
 
@@ -97,11 +116,36 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
             except Exception:
                 continue
 
-        return [TextContent(type="text", text=json.dumps({
-            "success": True,
-            "evaluations": evaluations,
-            "total": len(evaluations),
-        }, indent=2))]
+        if response_format == "markdown":
+            output = f"Found {total} evaluation(s) — showing {offset + 1}-{offset + len(evaluations)}:\n\n"
+            for e in evaluations:
+                overall = e["score"]["metrics"].get("overall")
+                overall_str = f"{overall:.2f}" if isinstance(overall, (int, float)) else "—"
+                output += f"🧪 **{e['task']}** ({e['model']})\n"
+                output += f"   ID: {e['id']}\n"
+                output += f"   Status: {e['status']} · Samples: {e['totalSamples']} · Overall: {overall_str}\n"
+                output += f"   Created: {e['createdAt']}\n\n"
+            if has_more:
+                output += f"More available — pass offset={next_offset} to see the next page.\n"
+            return [TextContent(type="text", text=output)]
+
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "success": True,
+                        "total": total,
+                        "count": len(evaluations),
+                        "offset": offset,
+                        "has_more": has_more,
+                        "next_offset": next_offset,
+                        "evaluations": evaluations,
+                    },
+                    indent=2,
+                ),
+            )
+        ]
 
     except Exception as e:
         return [

--- a/eval_mcp/tools/list_judges.py
+++ b/eval_mcp/tools/list_judges.py
@@ -8,16 +8,34 @@ from mcp.types import TextContent
 from eval_mcp.core.user_storage import list_judges_from_db
 
 
-async def handle_list_judges(args: Dict[str, Any]) -> List[TextContent]:
-    """Handle list_judges tool call.
+def _judge_summary(judge: Dict[str, Any]) -> Dict[str, Any]:
+    config = judge.get("config") or {}
+    criteria = config.get("criteria") or []
+    return {
+        "id": judge.get("id"),
+        "name": judge.get("name"),
+        "domain": config.get("domain", "unknown"),
+        "criteria_count": len(criteria),
+        "criteria_names": [c.get("name", "") for c in criteria],
+    }
 
-    Lists all LLM judges from the user's database.
-    Returns details about each judge including domain and criteria.
+
+async def handle_list_judges(args: Dict[str, Any]) -> List[TextContent]:
+    """List LLM judges with pagination and optional JSON format.
+
+    Args (from `args` dict):
+        user_id: required
+        searchTerm: optional case-insensitive name filter
+        limit: page size, default 20
+        offset: page start, default 0
+        response_format: "markdown" (default) or "json"
     """
     try:
-        # Get required user_id and optional search filter
         user_id = args.get("user_id")
         search_term = (args.get("searchTerm") or "").lower()
+        limit = max(1, int(args.get("limit", 20) or 20))
+        offset = max(0, int(args.get("offset", 0) or 0))
+        response_format = (args.get("response_format") or "markdown").lower()
 
         if not user_id:
             return [
@@ -27,31 +45,52 @@ async def handle_list_judges(args: Dict[str, Any]) -> List[TextContent]:
                 )
             ]
 
-        # Get judges from database
-        judges = list_judges_from_db(user_id, search_term)
+        all_judges = list_judges_from_db(user_id, search_term)
+        total = len(all_judges)
+        page = all_judges[offset : offset + limit]
+        has_more = offset + len(page) < total
+        next_offset = offset + len(page) if has_more else None
 
-        if not judges:
-            msg = f"No judges found matching '{search_term}'" if search_term else "No judges found. Create your first judge with generate_judge."
+        if response_format == "json":
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": True,
+                            "total": total,
+                            "count": len(page),
+                            "offset": offset,
+                            "has_more": has_more,
+                            "next_offset": next_offset,
+                            "items": [_judge_summary(j) for j in page],
+                        },
+                        indent=2,
+                    ),
+                )
+            ]
+
+        if not all_judges:
+            msg = (
+                f"No judges found matching '{search_term}'"
+                if search_term
+                else "No judges found. Create your first judge with generate_judge."
+            )
             return [TextContent(type="text", text=msg)]
 
-        # Format output
-        output = f"Found {len(judges)} judge(s):\n\n"
-
-        for judge in judges:
-            config = judge["config"]
-            domain = config.get("domain", "unknown")
-            criteria = config.get("criteria", [])
-            criteria_count = len(criteria)
-
-            # Format criteria preview
-            criteria_preview = ", ".join([c.get("name", "") for c in criteria[:3]])
-            if len(criteria) > 3:
-                criteria_preview += f" (+{len(criteria) - 3} more)"
-
-            output += f"⚖️  **{judge['name']}**\n"
-            output += f"   ID: {judge['id']}\n"
-            output += f"   Domain: {domain}\n"
-            output += f"   Criteria ({criteria_count}): {criteria_preview}\n\n"
+        output = f"Found {total} judge(s) — showing {offset + 1}-{offset + len(page)}:\n\n"
+        for judge in page:
+            s = _judge_summary(judge)
+            names = s["criteria_names"]
+            criteria_preview = ", ".join(names[:3])
+            if len(names) > 3:
+                criteria_preview += f" (+{len(names) - 3} more)"
+            output += f"⚖️  **{s['name']}**\n"
+            output += f"   ID: {s['id']}\n"
+            output += f"   Domain: {s['domain']}\n"
+            output += f"   Criteria ({s['criteria_count']}): {criteria_preview}\n\n"
+        if has_more:
+            output += f"More available — pass offset={next_offset} to see the next page.\n"
 
         return [TextContent(type="text", text=output)]
 

--- a/tests/mcp_eval/questions.xml
+++ b/tests/mcp_eval/questions.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  MCP-builder Phase 4 evaluation for eval-mcp.
+
+  Grading is per the runner in `runner.py`:
+    <answer_must_contain><fact>...</fact></answer_must_contain>
+      → an LLM judge marks each fact pass/fail; question passes if all
+        facts pass.
+    <expected_tools><tool>name</tool></expected_tools>
+      → at least one of the listed tools must appear in the trace.
+        Omit entirely when no specific tool call is required.
+
+  Questions are intentionally state-independent (no fixture data needed)
+  so the runner works against a clean user dir on every run.
+-->
+<evaluation>
+  <qa_pair>
+    <question>I have a Python agent at /home/user/agent.py that calls Bedrock. I want to evaluate it end-to-end and get a PDF report. Which single eval-mcp tool should I call, and what's the minimum argument I need to pass?</question>
+    <answer_must_contain>
+      <fact>recommends run_evaluation_and_report as the single tool to call</fact>
+      <fact>says the minimum argument is agent_path (set to the file path)</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>List the Anthropic models available in Bedrock for evaluations. Are Claude Sonnet 4.5 or 4.6 in the list?</question>
+    <answer_must_contain>
+      <fact>mentions at least one Claude Sonnet model (sonnet-4-5 or sonnet-4-6)</fact>
+      <fact>presents the result as a list of Anthropic models</fact>
+    </answer_must_contain>
+    <expected_tools>
+      <tool>list_bedrock_models</tool>
+      <tool>list_available_models</tool>
+    </expected_tools>
+  </qa_pair>
+
+  <qa_pair>
+    <question>What's the difference between analyze_agent_image and analyze_agent_path? When would I use one over the other?</question>
+    <answer_must_contain>
+      <fact>analyze_agent_image is for agents packaged as container images (Docker / ECR / etc.)</fact>
+      <fact>analyze_agent_path is for local Python agent files on disk</fact>
+      <fact>explains that the choice depends on how the agent is packaged or deployed</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>I called run_evaluation_and_report and the response came back with needs_action set to "install_otel" and a venv_python path. What is the next tool I should call, and what do I pass to it?</question>
+    <answer_must_contain>
+      <fact>recommends calling install_otel</fact>
+      <fact>says to pass the venv_python path returned in the previous response</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>Why does create_eval_config auto-generate the config name instead of letting me pick it? What downside would picking my own name have?</question>
+    <answer_must_contain>
+      <fact>says the name is auto-generated from a timestamp</fact>
+      <fact>explains that auto-generation prevents accidentally reusing or overwriting a stale config with the same name</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>I have a CSV at /tmp/qa.csv with question/answer columns. Walk me through the minimum sequence of eval-mcp tool calls needed to evaluate Claude Sonnet 4.6 against that CSV and get a PDF report at the end.</question>
+    <answer_must_contain>
+      <fact>mentions analyze_dataset or save_dataset to load the CSV</fact>
+      <fact>explains that a judge gets used — either via an explicit generate_judge call OR by noting that run_evaluation_and_report auto-generates one</fact>
+      <fact>ends with running an evaluation (run_evaluation or run_evaluation_and_report)</fact>
+      <fact>references a specific Sonnet 4.6 model id (e.g. bedrock/us.anthropic.claude-sonnet-4-6)</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>Check what datasets currently exist in eval-mcp for this user. If there are none, tell me which tool I would call next to create one from a free-text prompt without uploading any documents.</question>
+    <answer_must_contain>
+      <fact>reports whether any datasets currently exist (or explicitly that there are none)</fact>
+      <fact>recommends generate_qa_pairs as the way to create one from a prompt</fact>
+    </answer_must_contain>
+    <expected_tools>
+      <tool>list_datasets</tool>
+    </expected_tools>
+  </qa_pair>
+
+  <qa_pair>
+    <question>What does the openTelemetry installation enable for eval-mcp, and which kind of evaluation requires it? Give a one-line summary plus the trigger.</question>
+    <answer_must_contain>
+      <fact>says OpenTelemetry / OTel is used to capture the agent's Bedrock calls during evaluation</fact>
+      <fact>indicates that agentic evaluations (run_evaluation_and_report with agent_path, or analyze_agent_path) are the ones that need it</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>I want a list of every evaluation I have run so far, sorted by recency, but only the five most recent. How would I call list_evaluations to get that?</question>
+    <answer_must_contain>
+      <fact>says to set limit to 5 (or limit=5) on list_evaluations</fact>
+      <fact>indicates that results come back in recency order by default</fact>
+    </answer_must_contain>
+  </qa_pair>
+
+  <qa_pair>
+    <question>I keep getting an error from list_bedrock_models that mentions "models are not accessible" and tells me to check something in my AWS account. What is the most likely cause and what should I do to fix it?</question>
+    <answer_must_contain>
+      <fact>identifies the cause as Bedrock model access not being enabled for the AWS account / region</fact>
+      <fact>recommends enabling model access in the Bedrock console (or otherwise granting access in AWS)</fact>
+    </answer_must_contain>
+  </qa_pair>
+</evaluation>

--- a/tests/mcp_eval/runner.py
+++ b/tests/mcp_eval/runner.py
@@ -1,0 +1,391 @@
+"""mcp-builder Phase 4 evaluation runner for eval-mcp.
+
+Connects a Claude (Bedrock Sonnet) agent to the eval-mcp server via stdio,
+asks it each XML question, captures the trace + final answer, and grades
+the answer with a separate Sonnet judge call against the
+`<answer_must_contain>` facts.
+
+Why Bedrock rather than the eval-mcp judge:
+    The point of the mcp-builder eval is independent verification of the
+    MCP layer. Reusing eval-mcp's own judge infrastructure would couple
+    the test to the very thing we're testing. We use Bedrock Converse
+    directly with prompt caching for efficiency.
+
+Usage:
+    python -m tests.mcp_eval.runner              # all 10 questions
+    python -m tests.mcp_eval.runner --question 3 # one question
+    python -m tests.mcp_eval.runner --json out.json  # machine-readable result
+
+Skip-on-no-Bedrock: the pytest wrapper at tests/test_mcp_eval.py guards
+against missing AWS credentials. Run that directly if you don't want to
+think about creds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Sonnet 4.6 — fast, cheap, strong tool use. Sonnet 4.5 inference profile
+# is the most-widely-available fallback if 4.6 isn't enabled in the user's
+# AWS account.
+AGENT_MODEL = os.environ.get(
+    "EVAL_MCP_EVAL_MODEL", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+)
+JUDGE_MODEL = os.environ.get("EVAL_MCP_JUDGE_MODEL", AGENT_MODEL)
+MAX_AGENT_TURNS = 8
+
+QUESTIONS_PATH = Path(__file__).parent / "questions.xml"
+
+
+# ---------------------------------------------------------------------------
+# Question parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Question:
+    index: int
+    text: str
+    facts: list[str]
+    expected_tools: list[str]
+
+
+def load_questions(path: Path = QUESTIONS_PATH) -> list[Question]:
+    tree = ET.parse(path)
+    out = []
+    for i, qa in enumerate(tree.findall(".//qa_pair"), start=1):
+        q = (qa.find("question").text or "").strip()
+        facts = [
+            (f.text or "").strip()
+            for f in qa.findall("answer_must_contain/fact")
+            if (f.text or "").strip()
+        ]
+        et_node = qa.find("expected_tools")
+        tools = (
+            [(t.text or "").strip() for t in et_node.findall("tool")]
+            if et_node is not None
+            else []
+        )
+        out.append(Question(index=i, text=q, facts=facts, expected_tools=tools))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QuestionResult:
+    index: int
+    question: str
+    answer: str
+    tools_called: list[str]
+    fact_results: list[tuple[str, bool]] = field(default_factory=list)
+    expected_tool_satisfied: bool | None = None
+    error: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        if self.error:
+            return False
+        if not self.fact_results:
+            return False
+        if any(not ok for _, ok in self.fact_results):
+            return False
+        if self.expected_tool_satisfied is False:
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Bedrock helpers — single client, prompt-cached tool list
+# ---------------------------------------------------------------------------
+
+
+def _bedrock_client():
+    import boto3  # imported lazily so the module loads without AWS creds
+
+    return boto3.client(
+        "bedrock-runtime", region_name=os.environ.get("AWS_REGION", "us-west-2")
+    )
+
+
+def _mcp_tools_to_bedrock(mcp_tools: list[Any]) -> list[dict]:
+    """Convert MCP Tool objects into Bedrock Converse tool specs."""
+    specs = []
+    for t in mcp_tools:
+        specs.append(
+            {
+                "toolSpec": {
+                    "name": t.name,
+                    "description": t.description or "",
+                    "inputSchema": {"json": t.inputSchema},
+                }
+            }
+        )
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Agent loop — Claude answers one question using the MCP tools
+# ---------------------------------------------------------------------------
+
+
+async def run_question(
+    session,
+    bedrock,
+    tool_specs: list[dict],
+    question: Question,
+) -> QuestionResult:
+    """Have Claude attempt one question via the MCP session. Returns the
+    final text answer + the trace of MCP tools the agent called."""
+
+    system_prompt = (
+        "You are evaluating the eval-mcp MCP server. Answer the user's "
+        "question using only the tools available from eval-mcp when you "
+        "need live data. For conceptual or workflow questions, you may "
+        "answer from the tool descriptions without invoking a tool. "
+        "When you are done, produce a final text response (no further "
+        "tool calls). Be concise — one short paragraph is plenty."
+    )
+
+    messages: list[dict] = [
+        {"role": "user", "content": [{"text": question.text}]}
+    ]
+    tools_called: list[str] = []
+    final_answer = ""
+
+    for _ in range(MAX_AGENT_TURNS):
+        resp = bedrock.converse(
+            modelId=AGENT_MODEL,
+            messages=messages,
+            system=[{"text": system_prompt}],
+            toolConfig={"tools": tool_specs},
+            inferenceConfig={"maxTokens": 1024, "temperature": 0.0},
+        )
+        output_msg = resp["output"]["message"]
+        messages.append(output_msg)
+
+        tool_uses = [b["toolUse"] for b in output_msg["content"] if "toolUse" in b]
+        stop_reason = resp.get("stopReason")
+
+        if not tool_uses:
+            for b in output_msg["content"]:
+                if "text" in b:
+                    final_answer = b["text"].strip()
+                    break
+            break
+
+        # Execute each tool call via the MCP session, feed results back.
+        tool_result_blocks = []
+        for tu in tool_uses:
+            tools_called.append(tu["name"])
+            try:
+                result = await session.call_tool(tu["name"], tu.get("input", {}) or {})
+                text = result.content[0].text if result.content else ""
+            except Exception as e:
+                text = json.dumps({"error": str(e)})
+            tool_result_blocks.append(
+                {
+                    "toolResult": {
+                        "toolUseId": tu["toolUseId"],
+                        "content": [{"text": text[:6000]}],
+                    }
+                }
+            )
+        messages.append({"role": "user", "content": tool_result_blocks})
+
+        if stop_reason == "end_turn":
+            break
+
+    return QuestionResult(
+        index=question.index,
+        question=question.text,
+        answer=final_answer,
+        tools_called=tools_called,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Judge — score the agent's answer against the expected facts
+# ---------------------------------------------------------------------------
+
+
+_JUDGE_INSTR = (
+    "You are grading an answer to a technical question about an MCP server. "
+    "For each fact listed below, decide whether the answer supports that "
+    "fact. Be strict: the answer must clearly state the fact, not merely "
+    "imply it. Respond ONLY with a JSON array of booleans, one per fact, "
+    "in order. Example: [true, true, false]."
+)
+
+
+def grade_answer(bedrock, question: Question, answer: str) -> list[bool]:
+    if not question.facts:
+        return []
+    prompt = (
+        f"Question: {question.text}\n\n"
+        f"Answer: {answer}\n\n"
+        f"Facts ({len(question.facts)}):\n"
+        + "\n".join(f"{i}. {f}" for i, f in enumerate(question.facts, start=1))
+    )
+    resp = bedrock.converse(
+        modelId=JUDGE_MODEL,
+        messages=[{"role": "user", "content": [{"text": prompt}]}],
+        system=[{"text": _JUDGE_INSTR}],
+        inferenceConfig={"maxTokens": 200, "temperature": 0.0},
+    )
+    text = resp["output"]["message"]["content"][0]["text"]
+    m = re.search(r"\[[^\]]*\]", text)
+    if not m:
+        return [False] * len(question.facts)
+    try:
+        parsed = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return [False] * len(question.facts)
+    # Coerce to length-matched bools.
+    out = []
+    for i in range(len(question.facts)):
+        if i < len(parsed):
+            out.append(bool(parsed[i]))
+        else:
+            out.append(False)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main runner — spawns eval-mcp via stdio, runs each question, grades each
+# ---------------------------------------------------------------------------
+
+
+async def run(question_indices: list[int] | None = None) -> list[QuestionResult]:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    questions = load_questions()
+    if question_indices is not None:
+        questions = [q for q in questions if q.index in question_indices]
+
+    bedrock = _bedrock_client()
+
+    # Isolated fixture user dir so the MCP starts with a clean slate every
+    # run. Auto-pull/auto-push are no-ops without an S3 bucket configured.
+    with tempfile.TemporaryDirectory(prefix="eval_mcp_eval_") as tmp:
+        env = {
+            **os.environ,
+            "EVAL_MCP_USER": "eval_test_fixture",
+            "USER_STORAGE_BASE": tmp,
+            "EVAL_MCP_TRANSPORT": "stdio",
+        }
+
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "eval_mcp.server"],
+            env=env,
+        )
+
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tools_resp = await session.list_tools()
+                tool_specs = _mcp_tools_to_bedrock(tools_resp.tools)
+
+                results: list[QuestionResult] = []
+                for q in questions:
+                    try:
+                        r = await run_question(session, bedrock, tool_specs, q)
+                    except Exception as e:
+                        r = QuestionResult(
+                            index=q.index,
+                            question=q.text,
+                            answer="",
+                            tools_called=[],
+                            error=f"{type(e).__name__}: {e}",
+                        )
+                    if not r.error:
+                        flags = grade_answer(bedrock, q, r.answer)
+                        r.fact_results = list(zip(q.facts, flags))
+                        if q.expected_tools:
+                            r.expected_tool_satisfied = any(
+                                t in r.tools_called for t in q.expected_tools
+                            )
+                    results.append(r)
+                return results
+
+
+def format_summary(results: list[QuestionResult]) -> str:
+    lines = []
+    passed = sum(1 for r in results if r.passed)
+    lines.append(f"\n=== eval-mcp evaluation: {passed}/{len(results)} passed ===\n")
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        lines.append(f"[{status}] Q{r.index}: {r.question[:90]}{'…' if len(r.question) > 90 else ''}")
+        if r.error:
+            lines.append(f"        error: {r.error}")
+            continue
+        for fact, ok in r.fact_results:
+            mark = "✓" if ok else "✗"
+            lines.append(f"        {mark} {fact}")
+        if r.expected_tool_satisfied is not None:
+            mark = "✓" if r.expected_tool_satisfied else "✗"
+            lines.append(f"        {mark} called one of expected tools")
+        lines.append(f"        tools_called: {r.tools_called or 'none'}")
+        if not r.answer:
+            lines.append("        (no final answer text)")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Run the eval-mcp MCP evaluation.")
+    p.add_argument(
+        "--question",
+        "-q",
+        type=int,
+        action="append",
+        help="Run only the given question index (1-based). Repeatable.",
+    )
+    p.add_argument("--json", help="Write machine-readable results to this path.")
+    args = p.parse_args()
+
+    results = asyncio.run(run(question_indices=args.question))
+    print(format_summary(results))
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                [
+                    {
+                        "index": r.index,
+                        "question": r.question,
+                        "answer": r.answer,
+                        "tools_called": r.tools_called,
+                        "fact_results": [
+                            {"fact": f, "passed": ok} for f, ok in r.fact_results
+                        ],
+                        "expected_tool_satisfied": r.expected_tool_satisfied,
+                        "passed": r.passed,
+                        "error": r.error,
+                    }
+                    for r in results
+                ],
+                indent=2,
+            )
+        )
+
+    failed = sum(1 for r in results if not r.passed)
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_eval.py
+++ b/tests/test_mcp_eval.py
@@ -1,0 +1,51 @@
+"""Pytest wrapper for the mcp-builder Phase 4 evaluation.
+
+The actual logic lives in `tests/mcp_eval/runner.py` — this just runs it
+and asserts on the pass rate. Skipped automatically when AWS Bedrock isn't
+reachable, so contributors without Bedrock access can still run the rest
+of the suite.
+
+Run only this:    uv run pytest tests/test_mcp_eval.py -v -s
+Run from runner:  uv run python -m tests.mcp_eval.runner
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from tests.mcp_eval.runner import format_summary, run
+
+
+def _bedrock_reachable() -> bool:
+    """True iff boto3 can resolve AWS credentials. The runner will surface
+    a Bedrock-specific failure (model not enabled, etc.) when it actually
+    invokes the model — this check just keeps contributors-without-creds
+    from seeing scary auth tracebacks."""
+    try:
+        import boto3
+
+        session = boto3.Session(region_name=os.environ.get("AWS_REGION", "us-west-2"))
+        creds = session.get_credentials()
+        return creds is not None and creds.access_key is not None
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _bedrock_reachable(),
+    reason="Bedrock / AWS credentials not available — skipping live MCP eval.",
+)
+def test_mcp_eval_pass_rate():
+    """Run the 10-question eval. Expect at least 7/10 to pass — leaves
+    headroom for the LLM judge's occasional false-negative without
+    masking a real regression in tool descriptions."""
+    results = asyncio.run(run())
+    summary = format_summary(results)
+    print(summary)
+    passed = sum(1 for r in results if r.passed)
+    assert passed >= 7, (
+        f"Only {passed}/{len(results)} questions passed.\n{summary}"
+    )

--- a/tests/test_mcp_schema.py
+++ b/tests/test_mcp_schema.py
@@ -1,0 +1,199 @@
+"""Schema-level tests for the eval-mcp server.
+
+These tests don't exercise Bedrock or storage — they only check that the
+MCP layer is wired correctly: every registered tool advertises annotations,
+read-only tools say so, list tools accept pagination + response_format
+parameters, and pagination metadata is returned in the expected shape.
+
+Run with: uv run pytest tests/test_mcp_schema.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from eval_mcp import server as srv
+
+
+# ---------------------------------------------------------------------------
+# Tool annotations are present on every tool
+# ---------------------------------------------------------------------------
+
+
+def _registered_tools():
+    return srv.mcp._tool_manager.list_tools()
+
+
+def test_every_tool_has_annotations():
+    """All MCP tools must advertise annotations so clients can decide
+    whether a call is safe to auto-invoke."""
+    missing = [t.name for t in _registered_tools() if t.annotations is None]
+    assert missing == [], f"Tools without annotations: {missing}"
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "list_datasets",
+        "list_judges",
+        "list_evaluations",
+        "list_documents",
+        "list_bedrock_models",
+        "list_available_models",
+        "get_evaluation_details",
+        "analyze_dataset",
+    ],
+)
+def test_read_only_tools_claim_read_only(tool_name: str):
+    """Tools that don't mutate state should set readOnlyHint=True so
+    clients can route them through cheap-path auto-approve."""
+    tool = srv.mcp._tool_manager.get_tool(tool_name)
+    assert tool is not None, f"Tool {tool_name} not registered"
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True, (
+        f"{tool_name} should declare readOnlyHint=True"
+    )
+    assert tool.annotations.destructiveHint is False
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "save_dataset",
+        "generate_qa_pairs",
+        "generate_judge",
+        "create_eval_config",
+        "run_evaluation",
+        "run_evaluation_and_report",
+        "retry_evaluation",
+    ],
+)
+def test_write_tools_are_not_read_only(tool_name: str):
+    tool = srv.mcp._tool_manager.get_tool(tool_name)
+    assert tool is not None, f"Tool {tool_name} not registered"
+    assert tool.annotations.readOnlyHint is False
+
+
+def test_no_tool_declares_destructive_hint():
+    """The eval server doesn't have any delete/drop semantics today. If
+    that changes, update the corresponding tool's annotation explicitly
+    rather than relying on the default."""
+    destructive = [
+        t.name for t in _registered_tools() if t.annotations and t.annotations.destructiveHint
+    ]
+    assert destructive == [], f"Unexpected destructive tools: {destructive}"
+
+
+# ---------------------------------------------------------------------------
+# Pagination params are exposed on the right tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["list_datasets", "list_judges", "list_evaluations", "list_documents"],
+)
+def test_list_tools_expose_pagination_params(tool_name: str):
+    """Every list_* tool must accept limit, offset, and response_format
+    so callers can page large result sets and pick markdown vs json."""
+    tool = srv.mcp._tool_manager.get_tool(tool_name)
+    assert tool is not None
+    schema = tool.parameters  # JSON schema dict from FastMCP
+    props = schema.get("properties", {})
+    for required_param in ("limit", "offset", "response_format"):
+        assert required_param in props, (
+            f"{tool_name} is missing pagination param `{required_param}`. "
+            f"Has: {sorted(props.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pagination behavior on list_datasets (handler-level, no DB needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_datasets(monkeypatch):
+    """Substitute a fake DB result so we can drive the handler directly."""
+    fake = [
+        {"id": f"id-{i:02d}", "name": f"dataset-{i:02d}", "tests": [{"vars": {"question": f"q{i}"}}]}
+        for i in range(25)
+    ]
+
+    from eval_mcp.tools import list_datasets as ld
+
+    monkeypatch.setattr(ld, "list_datasets_from_db", lambda user_id, search_term: list(fake))
+    return fake
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_list_datasets_json_pagination_shape(fake_datasets):
+    """First page should report total/has_more/next_offset correctly."""
+    from eval_mcp.tools.list_datasets import handle_list_datasets
+
+    result = _run(
+        handle_list_datasets(
+            {"user_id": "u1", "limit": 10, "offset": 0, "response_format": "json"}
+        )
+    )
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["total"] == 25
+    assert payload["count"] == 10
+    assert payload["offset"] == 0
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 10
+    assert len(payload["items"]) == 10
+    assert payload["items"][0]["name"] == "dataset-00"
+
+
+def test_list_datasets_last_page_marks_no_more(fake_datasets):
+    """The final page sets has_more=False and next_offset=None."""
+    from eval_mcp.tools.list_datasets import handle_list_datasets
+
+    result = _run(
+        handle_list_datasets(
+            {"user_id": "u1", "limit": 10, "offset": 20, "response_format": "json"}
+        )
+    )
+    payload = json.loads(result[0].text)
+    assert payload["count"] == 5
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
+
+
+def test_list_datasets_markdown_shows_range_and_hint(fake_datasets):
+    """Markdown output advertises the visible range and tells the agent
+    how to fetch the next page when one exists."""
+    from eval_mcp.tools.list_datasets import handle_list_datasets
+
+    result = _run(
+        handle_list_datasets(
+            {"user_id": "u1", "limit": 5, "offset": 0, "response_format": "markdown"}
+        )
+    )
+    text = result[0].text
+    assert "Found 25 dataset(s)" in text
+    assert "showing 1-5" in text
+    assert "offset=5" in text  # next-page hint
+
+
+def test_list_datasets_rejects_missing_user_id():
+    """Defensive check — user_id gating shouldn't break with pagination args."""
+    from eval_mcp.tools.list_datasets import handle_list_datasets
+
+    result = _run(
+        handle_list_datasets(
+            {"limit": 10, "offset": 0, "response_format": "json"}
+        )
+    )
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert "user_id" in payload["error"]


### PR DESCRIPTION
## Summary

Ran the `example-skills:mcp-builder` skill against `eval-mcp` end-to-end. Two commits:

1. **`feat(mcp): apply mcp-builder best practices to eval-mcp tools`** — annotations, pagination, response_format, Pydantic Field constraints, Origin header validation, trimmed mega-docstring, 25 schema tests. No tool-name or argument-name changes — backwards-compatible with every installed user.
2. **`test(mcp): add mcp-builder phase 4 evaluation against eval-mcp`** — 10-question XML eval + Bedrock-Sonnet runner + pytest wrapper. 10/10 passing.

## What changed

### Tool annotations (21 tools)
Each tool now advertises `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` via 5 reusable presets (`READ_LOCAL`, `READ_REMOTE`, `CREATE_LOCAL`, `CREATE_REMOTE`, `RUN_REMOTE`) plus 2 custom for `install_otel` (idempotent) and `explore_eval_data` (exec-based).

### Pagination + response_format
`list_datasets`, `list_judges`, `list_evaluations`, `list_documents` now accept `limit`, `offset`, and `response_format` (`markdown` / `json`). JSON responses include `{total, count, offset, has_more, next_offset, items}`. Markdown responses include a "Showing X-Y of N" range and a next-page hint.

### Pydantic Field constraints
Reusable `Annotated[Type, Field(...)]` aliases (`LimitParam`, `OffsetParam`, `ResponseFormat`, `NumSamples`, `ProvidersList`, `DatasetName`, `JudgeName`, `ConfigName`, `AgentImageURI`, `AgentPath`, `EvalId`, `GroupId`, `VenvPython`, `SourceFilter`, `MonthlyVolume`) flow constraints, examples, and descriptions into the JSON schema agents see.

### Security
HTTP transport now validates the `Origin` header against an allowlist (defaults: localhost / 127.0.0.1; override via `EVAL_MCP_ALLOWED_ORIGINS`). DNS-rebinding defense.

### Docstring trim
`run_evaluation_and_report` went from 60 lines to 25 — modes A/B/C/D collapsed into bullets, per-arg docs kept concise.

### Tests
- 25 schema tests (`tests/test_mcp_schema.py`) covering annotation presence, read-only hints, no destructive hints, pagination params on every list tool, pagination behavior for list_datasets.
- 10-question phase 4 eval (`tests/mcp_eval/`) — Sonnet 4.5 agent driven via stdio, judged by separate Sonnet call against `<answer_must_contain>` facts and optional `<expected_tools>` trajectory checks. Independent of eval-mcp's own judge infra so a bug in scoring can't mask itself. Skips cleanly without AWS creds.

## Test plan

- [x] `uv run pytest tests/test_mcp_schema.py` — 25 passed
- [x] `uv run pytest tests/test_bedrock_models.py tests/test_canary.py tests/test_run_eval_fail_loud.py` — no regressions, 17 passed
- [x] `uv run python -m tests.mcp_eval.runner` — 10/10 passed in ~80s, single-digit-cents Bedrock spend
- [x] `uv run pytest tests/test_mcp_eval.py -v -s` — passed
- [x] Verified annotations flow through to client schema via `mcp._tool_manager.list_tools()`
- [x] Verified Annotated/Field constraints flow into JSON schema (`numSamples` shows `minimum: 1, maximum: 500, examples: [10,15,50]`)

## Explicitly skipped

- **Internal `eval_` tool-name prefix** — would rename every public tool, breaking every installed user's prompts. The client-side `mcp__eval__` namespace already handles collision.
- **`outputSchema` / `structuredContent`** — requires switching every tool's `-> str` return type to Pydantic models, which would break the internal pattern where `run_evaluation_and_report` chains tools via `result[0].text` + `json.loads`. Worth its own conversation.