### PR TITLE
docs: document PyPI release workflow + add CLAUDE.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,21 @@ Update both files:
 | `eval_mcp/provider_pricing.json` | Source of truth for model pricing |
 | `eval_mcp/core/judge_config.py` | Default judge models and criteria |
 | `Makefile` | Local dev commands (`make dev`, `make run`, `make stop`) |
+
+## Releasing
+
+After merging a PR with user-visible changes, publish to PyPI from main:
+
+```bash
+git checkout main && git pull
+make release         # patch bump (0.3.0 → 0.3.1) — bug fixes only
+make release-minor   # minor bump (0.3.0 → 0.4.0) — new features, backwards-compat
+make release-major   # major bump (0.3.0 → 1.0.0) — breaking changes
+```
+
+Each target bumps `pyproject.toml`, commits, tags `vX.Y.Z`, and pushes.
+The `publish.yml` GitHub workflow takes over from the tag push and
+publishes to PyPI via trusted publisher. Don't tag manually.
+
+Pick the bump from semver: new public API = minor, only bug fixes =
+patch, backwards-incompatible = major.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+Contributor and agent-facing instructions for this repo live in
+[AGENTS.md](./AGENTS.md). That file is the canonical source — read it
+first. Same convention is used by Codex, Cursor, and other agentic
+tools, so we keep a single file rather than splitting per-tool docs.


### PR DESCRIPTION
## Summary

- **AGENTS.md** — adds a `Releasing` section so contributors know that PyPI releases happen via `make release` / `make release-minor` / `make release-major` from main, which the existing `publish.yml` workflow picks up via tag push.
- **CLAUDE.md** — stub that points to AGENTS.md so Claude Code finds the canonical instructions. AGENTS.md is the cross-tool convention (Codex, Cursor, etc. read it too).

No code changes — docs only.

## Test plan

- [x] AGENTS.md renders correctly on GitHub
- [x] CLAUDE.md renders correctly on GitHub
- [x] Release commands referenced match the actual Makefile targets (`release`, `release-minor`, `release-major`)