### PR TITLE
fix(release): force tag version + strip local identifier in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,19 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Verify tag matches the commit
+      - name: Force version from tag
         run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          echo "Building for tag v$TAG (setuptools-scm will derive version from git)"
+          # Tag-driven CI publishing: bypass setuptools-scm's working-tree
+          # inspection so the published version is exactly the tag, never
+          # a dev-suffixed derivative. Required because build steps (e.g.
+          # the frontend `npm run build:viewer`) can write into tracked
+          # paths and trip setuptools-scm's dirty-tree detection — without
+          # this override we ship things like 0.3.6.dev0 instead of 0.3.5.
+          # Per setuptools-scm docs the dist-name-scoped env var is the
+          # recommended way to do this in CI.
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LLM_EVALUATION_SYSTEM=$VERSION" >> "$GITHUB_ENV"
+          echo "Forcing build version to $VERSION (from tag $GITHUB_REF)"
 
       - name: Build viewer frontend
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,11 +87,15 @@ requires = ["setuptools>=68.0.0", "setuptools-scm>=8.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-# Version is derived from the latest `v*` git tag. When building on a tagged
-# commit the version is clean (e.g. "0.3.5"); off-tag commits get a dev
-# version (e.g. "0.3.6.dev3+gabc1234"). `fallback_version` covers sdist
-# builds and shallow clones where git history isn't available.
-fallback_version = "0.0.0+unknown"
+# Version is derived from the latest `v*` git tag. When building on a
+# tagged commit the version is clean (e.g. "0.3.5"); off-tag commits
+# get a dev version (e.g. "0.3.6.dev3"). `local_scheme = "no-local-version"`
+# strips the "+gHASH.dDATE" suffix so the result is always PyPI-acceptable
+# (PEP 440 forbids local version identifiers on public indexes).
+# `fallback_version` covers sdist builds and shallow clones where git
+# history isn't available.
+local_scheme = "no-local-version"
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Fixes the v0.3.5 publish failure. PyPI rejected the upload because
setuptools-scm produced \`0.3.6.dev0+g7e9e85604.d20260517\` instead of
\`0.3.5\` — the frontend build step modifies tracked files before
\`python -m build\` runs, so setuptools-scm saw a dirty tree and bumped
to a dev version with a PEP 440 local identifier (which PyPI forbids).

## Fix

Two complementary changes, both per [setuptools-scm's documented best practice](https://setuptools-scm.readthedocs.io/en/latest/usage/) and [PEP 440 PyPI compatibility guidance](https://github.com/pypa/setuptools-scm/issues/322):

1. **\`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LLM_EVALUATION_SYSTEM\`** set from the git tag in \`publish.yml\`. Bypasses setuptools-scm's tree inspection; the version is exactly the tag.
2. **\`local_scheme = \"no-local-version\"\`** in \`pyproject.toml\` as defense — strips the \`+gHASH.dDATE\` suffix even if (1) ever fails or someone builds locally and uploads.

The \`fallback_version\` also drops its \`+unknown\` suffix to stay PEP 440 strict.

## Test plan

- [x] \`setuptools-scm\` reads tag correctly on the new branch
- [x] Local off-tag build no longer produces \`+gHASH\` suffix
- [ ] Post-merge: re-tag \`v0.3.5\` → workflow publishes \`llm-evaluation-system==0.3.5\` to PyPI cleanly

## Cleanup already done

- Bad \`v0.3.5\` tag deleted from origin (\`git push origin --delete v0.3.5\`)
- No PyPI version was published from the failed run, so no PyPI yank needed