### PR TITLE
fix(infra): pin alekc/kubectl to ~> 2.1.3 to avoid 2.2.0 schema regression

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/alekc/kubectl" {
   version     = "2.1.3"
-  constraints = "~> 2.0"
+  constraints = "~> 2.1.3"
   hashes = [
     "h1:poWSAAtK4FI1x79C2OyLaNrvWUGTQdr1ZT58edDz+Rs=",
     "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",

--- a/infra/platform/.terraform.lock.hcl
+++ b/infra/platform/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/alekc/kubectl" {
   version     = "2.1.3"
-  constraints = "~> 2.0"
+  constraints = "~> 2.1.3"
   hashes = [
     "h1:poWSAAtK4FI1x79C2OyLaNrvWUGTQdr1ZT58edDz+Rs=",
     "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",

--- a/infra/platform/main.tf
+++ b/infra/platform/main.tf
@@ -21,8 +21,14 @@ terraform {
       version = "~> 2.12"
     }
     kubectl = {
-      source  = "alekc/kubectl"
-      version = "~> 2.0"
+      source = "alekc/kubectl"
+      # Pin to 2.1.x — v2.2.0 ships an incompatible provider schema
+      # (gRPC v6 attributes nil → fully populated) that surfaces in
+      # CodeBuild as: "Invalid Provider Server Combination: differing
+      # provider schema implementations across providers". CodeBuild runs
+      # `terraform init -upgrade` which ignores the lockfile, so the
+      # constraint here must exclude 2.2.x.
+      version = "~> 2.1.3"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary

CodeBuild deploys fail with:

\`\`\`
Error: Failed to load plugin schemas
Could not load the schema for provider
registry.terraform.io/alekc/kubectl: failed to retrieve schema from
provider "registry.terraform.io/alekc/kubectl": Invalid Provider Server
Combination: The combined provider has differing provider schema
implementations across providers.
\`\`\`

Pin \`alekc/kubectl\` to \`~> 2.1.3\` (was \`~> 2.0\`) to exclude the broken 2.2.0.

## Root cause

- \`alekc/kubectl\` v2.2.0 ships a schema migration where the gRPC v6 \`Block.Attributes\` field flips from \`nil\` to a fully populated list. The provider plugin server returns different schemas on different calls, triggering Terraform's \"identical schemas\" invariant check.
- The platform layer had \`version = \"~> 2.0\"\` which allows \`2.0.0\` through \`2.x.x\` including \`2.2.0\`.
- The lockfile pinned \`2.1.3\` correctly, but \`buildspec-scripts/deploy.sh\` runs \`terraform init -upgrade\` which **ignores the lockfile** and pulls the highest version matching the constraint — \`2.2.0\`.
- 2.1.x works fine; the bug is specific to 2.2.0.

## Changes

- \`infra/platform/main.tf\`: \`version = \"~> 2.0\"\` → \`version = \"~> 2.1.3\"\`
- \`infra/.terraform.lock.hcl\`, \`infra/platform/.terraform.lock.hcl\`: update \`constraints\` field to match
- Added a comment in main.tf explaining why the constraint is tighter than the surrounding providers, so the next person isn't tempted to relax it

## Why \`~> 2.1.3\` (not \`= 2.1.3\`)

Tilde-arrow allows patch updates within 2.1.x (e.g. 2.1.4, 2.1.5, 2.1.6), so the next legitimate alekc/kubectl release in this line can be picked up. It excludes 2.2.x where the schema regression lives.

## Test plan

- [x] \`grep\`-verified there's only one declaration of the \`alekc/kubectl\` provider in the infra (\`infra/platform/main.tf\`)
- [x] Lockfile constraints updated to match so \`terraform init\` won't complain about lockfile drift
- [ ] Post-merge: rerun \`./deploy.sh\` against \`main\` and confirm CodeBuild gets past Phase 4 platform-layer \`terraform apply\`

## Scope

This is an infra-only fix — no application code touched, no behavior change in the eval-mcp or web app. Unrelated to PR #62 (Data Library); that PR's changes don't touch any \`infra/\` files, so this is shippable independently and in either order.