### PR TITLE
feat(judge): critic-led iteration for generate_judge criteria

### DIFF
--- a/eval_mcp/core/judge_config.py
+++ b/eval_mcp/core/judge_config.py
@@ -36,8 +36,9 @@ DEFAULT_CRITERIA: List[Dict[str, str]] = [
     },
 ]
 
-# Maximum criteria allowed (5 or fewer recommended for clearest signal)
-MAX_CRITERIA = 10
+# Maximum criteria allowed. The critic loop in generate_judge.py picks
+# the final count within this ceiling — most domains converge around 6–10.
+MAX_CRITERIA = 15
 
 # Minimum responses for reliable scoring
 MIN_RESPONSES_FOR_JURY = 50

--- a/eval_mcp/tools/generate_judge.py
+++ b/eval_mcp/tools/generate_judge.py
@@ -1,14 +1,45 @@
-"""Generate custom evaluation criteria for Jury multi-judge evaluation."""
+"""Generate custom evaluation criteria for Jury multi-judge evaluation.
+
+Two-stage pipeline:
+  1. ``generate_judge`` — one LLM call analyses the dataset and proposes
+     binary criteria (wide net, redundancy allowed).
+  2. ``refine_criteria_loop`` — up to ``CRITIC_MAX_ITERATIONS`` passes
+     score a sample of QA pairs against the current criteria, then ask a
+     critic LLM to drop redundant criteria, rewrite vague ones, and add
+     anything missing. Exits early once the critic returns
+     ``no_changes_needed``.
+
+The asymmetry is intentional: the eval-time **jury**
+(``backend/core/jury_scoring.py``) uses 3 judges to smooth measurement
+noise. The design-time **critic** is a single judge call because it's a
+craft judgment, and the user reviews the final criteria anyway.
+"""
 
 import asyncio
 import json
-from typing import Any, Dict, List
+import logging
+import os
+import random
+from typing import Any, Dict, List, Optional
 
 from mcp.types import TextContent
 
 from eval_mcp.core.bedrock_client import BedrockClient
 from eval_mcp.core.user_storage import save_judge_to_db, get_dataset_by_name
 from eval_mcp.core.judge_config import MAX_CRITERIA, DEFAULT_CRITERIA
+
+logger = logging.getLogger(__name__)
+
+# How many critic refinement passes after the initial generation. Each
+# pass costs ~CRITIC_SAMPLE_SIZE judge calls + one critic call. Most
+# domains converge by iteration 2; 3 leaves headroom without burning
+# tokens on diminishing returns.
+CRITIC_MAX_ITERATIONS = int(os.environ.get("EVAL_MCP_CRITIC_MAX_ITERATIONS", "3"))
+
+# QA pairs scored per refinement pass to give the critic enough signal
+# to spot per-criterion patterns (always-passes, redundancy with another
+# criterion) without ballooning iteration cost.
+CRITIC_SAMPLE_SIZE = 10
 
 # Tool schema for structured criteria output
 CRITERIA_TOOL = {
@@ -34,8 +65,8 @@ CRITERIA_TOOL = {
                     "required": ["name", "description"]
                 },
                 "minItems": 3,
-                "maxItems": 5,
-                "description": "Evaluation criteria for judging responses (around 5 ideal, up to 10)"
+                "maxItems": 15,
+                "description": "Evaluation criteria for judging responses. Aim for coverage of what distinguishes good answers from bad — the critic loop will drop redundant ones afterwards."
             }
         },
         "required": ["criteria"]
@@ -70,7 +101,7 @@ async def generate_judge(
 Your task is to analyze question-answer pairs and create binary (0 or 1) evaluation criteria.
 
 Guidelines:
-- Create criteria that capture what matters for this domain (around 5 is ideal, up to 10 if needed)
+- Create criteria that capture what matters for this domain — favor coverage over brevity, a downstream critic will prune redundancies
 - Each criterion must be binary: "1 if [specific condition], 0 otherwise"
 - Focus on what actually matters based on the QA examples
 - Use snake_case for criterion names (e.g., factual_accuracy, completeness)
@@ -92,7 +123,7 @@ Here are example criteria to use as inspiration (adapt to the domain, don't copy
 {qa_examples}
 </QA_Examples>
 
-Based on these examples, design binary evaluation criteria that capture what makes a good response in this domain (around 5 is ideal, up to 10 if needed).
+Based on these examples, design binary evaluation criteria that capture what makes a good response in this domain. Cast a wide net — a downstream critic will trim redundancies and rewrite vague ones.
 
 Consider:
 - What factual elements must be correct?
@@ -121,6 +152,391 @@ Call the submit_criteria tool with your criteria."""
 
     # Fallback if no tool use found
     raise ValueError("Failed to generate structured criteria")
+
+
+# ---------------------------------------------------------------------------
+# Critic-led refinement loop
+# ---------------------------------------------------------------------------
+
+
+# Forced-tool schema for scoring a single (question, golden) against
+# the current criteria. Inline rather than imported from
+# backend/core/judge_tools.py because eval_mcp/ should not depend on
+# backend/, and the schema is small enough that duplication is cheaper
+# than introducing a new shared module.
+def _build_scoring_tool(criteria: List[Dict[str, str]]) -> Dict[str, Any]:
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for c in criteria:
+        properties[c["name"]] = {
+            "type": "object",
+            "properties": {
+                "score": {
+                    "type": "integer",
+                    "enum": [0, 1],
+                    "description": c["description"],
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One short sentence — why this score.",
+                },
+            },
+            "required": ["score", "reason"],
+        }
+        required.append(c["name"])
+    return {
+        "name": "submit_scores",
+        "description": "Score each criterion 0 or 1 against the reference answer with a brief reason.",
+        "input_schema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        },
+    }
+
+
+# Forced-tool schema for the critic. It can drop / keep / rewrite
+# existing criteria and propose net-new ones. ``no_changes_needed`` is
+# the loop's natural exit signal.
+CRITIC_TOOL: Dict[str, Any] = {
+    "name": "submit_critique",
+    "description": "Submit your critique of the current criteria set.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "no_changes_needed": {
+                "type": "boolean",
+                "description": "True if the criteria set is good and the loop should exit.",
+            },
+            "criteria_updates": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The existing criterion name this update applies to.",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["keep", "drop", "rewrite"],
+                        },
+                        "new_name": {
+                            "type": "string",
+                            "description": "Required when action is 'rewrite' — the replacement snake_case name.",
+                        },
+                        "new_description": {
+                            "type": "string",
+                            "description": "Required when action is 'rewrite' — binary '1 if X, 0 otherwise' form.",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "One short sentence — why this change.",
+                        },
+                    },
+                    "required": ["name", "action", "reason"],
+                },
+                "description": "Per-criterion actions. Omit a criterion to leave it unchanged.",
+            },
+            "new_criteria": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": ["name", "description"],
+                },
+                "description": "Brand-new criteria to add to the set.",
+            },
+        },
+        "required": ["no_changes_needed"],
+    },
+}
+
+
+async def _score_qa_pair(
+    bedrock: BedrockClient,
+    criteria: List[Dict[str, str]],
+    qa_pair: Dict[str, str],
+) -> Dict[str, Dict[str, Any]]:
+    """Score one QA pair against the criteria. Returns
+    ``{criterion_name: {"score": 0|1, "reason": "..."}}``.
+
+    Forces the ``submit_scores`` tool so the response is always valid
+    JSON matching the schema — no text-parsing failure modes.
+    """
+    scoring_tool = _build_scoring_tool(criteria)
+    criteria_lines = "\n".join(
+        f"- {c['name']}: {c['description']}" for c in criteria
+    )
+    user_prompt = (
+        "Score the reference answer against each criterion. You are NOT "
+        "comparing two answers — you're checking whether the reference "
+        "satisfies each criterion definition.\n\n"
+        f"Criteria:\n{criteria_lines}\n\n"
+        f"[Question]\n{qa_pair['question']}\n\n"
+        f"[Reference Answer]\n{qa_pair['golden_answer']}\n\n"
+        "Call submit_scores with your assessment."
+    )
+    response = await asyncio.to_thread(
+        bedrock.create_message,
+        messages=[{"role": "user", "content": user_prompt}],
+        tools=[scoring_tool],
+        tool_choice={"type": "tool", "name": "submit_scores"},
+        max_tokens=2048,
+        temperature=0,
+    )
+    for block in response.get("content", []):
+        if block.get("type") == "tool_use" and block.get("name") == "submit_scores":
+            return block.get("input", {})
+    raise ValueError("Judge call returned no submit_scores tool_use")
+
+
+async def _score_samples(
+    bedrock: BedrockClient,
+    criteria: List[Dict[str, str]],
+    samples: List[Dict[str, str]],
+) -> List[Dict[str, Any]]:
+    """Score every sample in parallel and return scored rows shaped for
+    the critic prompt: ``{"question", "golden", "scores"}``.
+
+    Failures on individual samples don't abort — they're dropped from
+    the batch so the critic gets whatever signal we managed to collect.
+    Catastrophic empty result is caller's problem.
+    """
+    tasks = [_score_qa_pair(bedrock, criteria, s) for s in samples]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    scored: List[Dict[str, Any]] = []
+    for sample, result in zip(samples, results):
+        if isinstance(result, Exception):
+            logger.warning("Skipping sample during critic scoring: %s", result)
+            continue
+        scored.append(
+            {
+                "question": sample["question"],
+                "golden": sample["golden_answer"],
+                "scores": result,
+            }
+        )
+    return scored
+
+
+def _format_scored_for_critic(scored: List[Dict[str, Any]]) -> str:
+    """Render scored samples as a compact text block for the critic."""
+    lines: List[str] = []
+    for i, row in enumerate(scored, start=1):
+        lines.append(f"Sample {i}:")
+        lines.append(f"  Q: {row['question'][:200]}")
+        lines.append(f"  Golden: {row['golden'][:300]}")
+        lines.append("  Scores:")
+        for name, payload in row["scores"].items():
+            score = payload.get("score") if isinstance(payload, dict) else payload
+            reason = payload.get("reason", "") if isinstance(payload, dict) else ""
+            lines.append(f"    - {name}: {score} ({reason})")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _criterion_pass_rates(
+    scored: List[Dict[str, Any]],
+    criteria: List[Dict[str, str]],
+) -> Dict[str, str]:
+    """Per-criterion pass rate summary, e.g. ``{"factual_accuracy": "5/5"}``.
+
+    Surfaced separately to the critic because the aggregate is what
+    reveals "always passes" / "always fails" — patterns that are easy
+    to miss when scrolling through per-sample scores.
+    """
+    out: Dict[str, str] = {}
+    for c in criteria:
+        name = c["name"]
+        total = 0
+        passes = 0
+        for row in scored:
+            payload = row["scores"].get(name)
+            if payload is None:
+                continue
+            total += 1
+            score = payload.get("score") if isinstance(payload, dict) else payload
+            if score == 1:
+                passes += 1
+        out[name] = f"{passes}/{total}" if total else "0/0"
+    return out
+
+
+_CRITIC_SYSTEM_PROMPT = (
+    "You are critiquing a set of binary (0/1) evaluation criteria used to "
+    "judge LLM answers against golden answers. You see how each criterion "
+    "scored across a handful of golden answers plus the judge's reasons.\n\n"
+    "Your job is to make the criteria set better:\n"
+    "- DROP criteria that duplicate another criterion (measuring the same thing).\n"
+    "- DROP or REWRITE criteria that always pass or always fail on the "
+    "samples — they carry no signal as written.\n"
+    "- REWRITE criteria that are vague or whose 'reason' lines show the "
+    "judge guessing — tighten the definition.\n"
+    "- ADD missing criteria for failure modes the current set wouldn't catch.\n\n"
+    "If the set is already good, set no_changes_needed=true and skip the "
+    "rest. Otherwise call submit_critique with your changes. Per-criterion "
+    "actions default to 'keep' if you omit them — only list the ones you "
+    "want to drop or rewrite."
+)
+
+
+async def _critique_criteria(
+    bedrock: BedrockClient,
+    criteria: List[Dict[str, str]],
+    scored: List[Dict[str, Any]],
+    domain: str,
+) -> Dict[str, Any]:
+    """Run one critic pass. Returns the parsed ``submit_critique`` payload.
+
+    Raises ``ValueError`` if the model failed to call the tool — caller
+    should treat that as an iteration failure and bail to last-good.
+    """
+    criteria_block = "\n".join(
+        f"- {c['name']}: {c['description']}" for c in criteria
+    )
+    pass_rates = _criterion_pass_rates(scored, criteria)
+    pass_rate_block = "\n".join(
+        f"  - {name}: {rate} samples passed" for name, rate in pass_rates.items()
+    )
+    user_prompt = (
+        f"Domain: {domain}\n\n"
+        f"Current criteria ({len(criteria)}):\n{criteria_block}\n\n"
+        f"Per-criterion pass rate across {len(scored)} sampled golden answers:\n"
+        f"{pass_rate_block}\n\n"
+        f"Per-sample scoring detail:\n{_format_scored_for_critic(scored)}\n"
+        "Call submit_critique with your decision."
+    )
+    response = await asyncio.to_thread(
+        bedrock.create_message,
+        messages=[{"role": "user", "content": user_prompt}],
+        system=_CRITIC_SYSTEM_PROMPT,
+        tools=[CRITIC_TOOL],
+        tool_choice={"type": "tool", "name": "submit_critique"},
+        max_tokens=3000,
+        temperature=0,
+    )
+    for block in response.get("content", []):
+        if block.get("type") == "tool_use" and block.get("name") == "submit_critique":
+            return block.get("input", {})
+    raise ValueError("Critic call returned no submit_critique tool_use")
+
+
+def _apply_updates(
+    criteria: List[Dict[str, str]],
+    critique: Dict[str, Any],
+) -> List[Dict[str, str]]:
+    """Walk ``criteria`` and apply the critique's drop/rewrite/new actions.
+
+    Pure function — no Bedrock calls. Returns a new list; does not
+    mutate the input. Caller is responsible for capping at
+    ``MAX_CRITERIA`` if the additions push over.
+
+    Update semantics:
+      - Action ``drop``: criterion removed from output.
+      - Action ``rewrite``: criterion replaced in place (preserves
+        order) using ``new_name`` / ``new_description`` if provided,
+        else left unchanged with a warning.
+      - Action ``keep`` or missing entry: criterion kept as-is.
+      - Anything in ``new_criteria`` appended to the end with name +
+        description fields only (other keys discarded).
+    """
+    updates_by_name: Dict[str, Dict[str, Any]] = {
+        u.get("name"): u for u in critique.get("criteria_updates", []) if u.get("name")
+    }
+
+    result: List[Dict[str, str]] = []
+    for c in criteria:
+        update = updates_by_name.get(c["name"])
+        if update is None or update.get("action") == "keep":
+            result.append({"name": c["name"], "description": c["description"]})
+            continue
+        action = update.get("action")
+        if action == "drop":
+            continue
+        if action == "rewrite":
+            new_name = update.get("new_name") or c["name"]
+            new_desc = update.get("new_description") or c["description"]
+            result.append({"name": new_name, "description": new_desc})
+            continue
+        # Unknown action — keep, don't lose data.
+        logger.warning("Unknown critic action %r for criterion %r; keeping unchanged.", action, c["name"])
+        result.append({"name": c["name"], "description": c["description"]})
+
+    for new in critique.get("new_criteria", []):
+        name = new.get("name")
+        desc = new.get("description")
+        if name and desc:
+            result.append({"name": name, "description": desc})
+
+    return result
+
+
+async def refine_criteria_loop(
+    bedrock: BedrockClient,
+    criteria: List[Dict[str, str]],
+    qa_pairs: List[Dict[str, str]],
+    domain: str,
+    max_iter: int = CRITIC_MAX_ITERATIONS,
+    sample_size: int = CRITIC_SAMPLE_SIZE,
+) -> List[Dict[str, str]]:
+    """Iteratively refine criteria using critic feedback on scored samples.
+
+    Exits early when the critic returns ``no_changes_needed``. On any
+    exception inside an iteration (Bedrock outage, malformed tool
+    output, etc.), returns the last-good criteria so a flaky round
+    can't wipe out a usable set.
+
+    Args:
+        bedrock: Bedrock client singleton (already pinned to the user's
+            chosen Claude model).
+        criteria: Starting criteria from the initial generation pass.
+        qa_pairs: Full dataset of ``{question, golden_answer}`` rows;
+            sampled per iteration.
+        domain: Domain string from the user — passed to the critic for
+            context.
+        max_iter: Hard ceiling on iterations. Reaching it exits silently.
+        sample_size: QA pairs scored per iteration.
+
+    Returns:
+        Refined criteria list, capped at ``MAX_CRITERIA``.
+    """
+    if not criteria or not qa_pairs or max_iter <= 0:
+        return criteria
+
+    last_good = criteria
+    for i in range(1, max_iter + 1):
+        try:
+            sample_n = min(sample_size, len(qa_pairs))
+            samples = random.sample(qa_pairs, sample_n) if sample_n < len(qa_pairs) else list(qa_pairs)
+
+            scored = await _score_samples(bedrock, last_good, samples)
+            if not scored:
+                logger.warning("Critic iter %d: all scoring calls failed; stopping with last-good criteria.", i)
+                return last_good
+
+            critique = await _critique_criteria(bedrock, last_good, scored, domain)
+            if critique.get("no_changes_needed"):
+                logger.info("Critic iter %d: converged (no changes needed).", i)
+                return last_good
+
+            updated = _apply_updates(last_good, critique)
+            if len(updated) > MAX_CRITERIA:
+                logger.warning(
+                    "Critic iter %d proposed %d criteria; capping at MAX_CRITERIA=%d.",
+                    i, len(updated), MAX_CRITERIA,
+                )
+                updated = updated[:MAX_CRITERIA]
+            last_good = updated
+        except Exception as e:  # noqa: BLE001 — broad on purpose; loop must never poison the result
+            logger.warning("Critic iter %d failed: %s. Returning last-good criteria.", i, e)
+            return last_good
+
+    return last_good
 
 
 async def handle_generate_judge(
@@ -207,6 +623,12 @@ async def handle_generate_judge(
                     }),
                 )
             ]
+
+        # Refine via critic-led loop: scores a sample, prunes redundancy,
+        # adds missing failure modes. Crash-safe — any iteration error
+        # returns the last-good set, so the user never gets fewer criteria
+        # than the initial generation produced.
+        criteria = await refine_criteria_loop(bedrock, criteria, qa_pairs, domain)
 
         # Save to user's database
         safe_name = "".join(c if c.isalnum() or c in (' ', '-', '_') else '_' for c in domain[:50])

--- a/tests/test_generate_judge_iter.py
+++ b/tests/test_generate_judge_iter.py
@@ -1,0 +1,441 @@
+"""Tests for the critic-led refinement loop in generate_judge.
+
+Two layers:
+  - Pure-function tests for _apply_updates and the loop's exit logic
+    (mocked _score_samples + _critique_criteria, no Bedrock calls).
+  - One integration test gated on Bedrock reachability that proves the
+    full path produces more than the old 5-criterion ceiling.
+
+Run unit tests only:
+    uv run pytest tests/test_generate_judge_iter.py -v -k "not integration"
+
+Run everything (requires AWS creds + Bedrock model access):
+    uv run pytest tests/test_generate_judge_iter.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from eval_mcp.tools.generate_judge import (
+    CRITIC_MAX_ITERATIONS,
+    _apply_updates,
+    refine_criteria_loop,
+)
+from eval_mcp.core.judge_config import MAX_CRITERIA
+
+
+# ---------------------------------------------------------------------------
+# _apply_updates — pure function, no mocks needed
+# ---------------------------------------------------------------------------
+
+
+def _criteria(*names: str) -> list[dict]:
+    return [{"name": n, "description": f"1 if {n}, 0 otherwise"} for n in names]
+
+
+def test_apply_updates_keeps_unchanged_when_no_updates():
+    starting = _criteria("a", "b", "c")
+    out = _apply_updates(starting, {"criteria_updates": [], "new_criteria": []})
+    assert out == starting
+
+
+def test_apply_updates_drops_named_criterion():
+    starting = _criteria("a", "b", "c")
+    critique = {
+        "criteria_updates": [{"name": "b", "action": "drop", "reason": "redundant"}],
+    }
+    out = _apply_updates(starting, critique)
+    assert [c["name"] for c in out] == ["a", "c"]
+
+
+def test_apply_updates_rewrites_in_place_preserving_order():
+    starting = _criteria("a", "b", "c")
+    critique = {
+        "criteria_updates": [
+            {
+                "name": "b",
+                "action": "rewrite",
+                "new_name": "b_tightened",
+                "new_description": "1 if very b, 0 otherwise",
+                "reason": "was vague",
+            },
+        ],
+    }
+    out = _apply_updates(starting, critique)
+    assert [c["name"] for c in out] == ["a", "b_tightened", "c"]
+    assert out[1]["description"] == "1 if very b, 0 otherwise"
+
+
+def test_apply_updates_appends_new_criteria():
+    starting = _criteria("a")
+    critique = {
+        "new_criteria": [
+            {"name": "d", "description": "1 if d, 0 otherwise", "reason": "missing"},
+            {"name": "e", "description": "1 if e, 0 otherwise"},
+        ],
+    }
+    out = _apply_updates(starting, critique)
+    assert [c["name"] for c in out] == ["a", "d", "e"]
+
+
+def test_apply_updates_unknown_action_keeps_criterion():
+    starting = _criteria("a", "b")
+    critique = {
+        "criteria_updates": [{"name": "a", "action": "vandalize", "reason": "lol"}],
+    }
+    out = _apply_updates(starting, critique)
+    assert [c["name"] for c in out] == ["a", "b"]
+
+
+def test_apply_updates_rewrite_with_missing_fields_keeps_originals():
+    starting = _criteria("a")
+    critique = {
+        "criteria_updates": [{"name": "a", "action": "rewrite", "reason": "..."}],
+    }
+    out = _apply_updates(starting, critique)
+    # No new_name / new_description provided → fall back to the original.
+    assert out == starting
+
+
+def test_apply_updates_skips_malformed_new_criteria():
+    starting = _criteria("a")
+    critique = {
+        "new_criteria": [
+            {"name": "valid", "description": "1 if v, 0 otherwise"},
+            {"name": "missing_desc"},
+            {"description": "missing name"},
+        ],
+    }
+    out = _apply_updates(starting, critique)
+    assert [c["name"] for c in out] == ["a", "valid"]
+
+
+# ---------------------------------------------------------------------------
+# refine_criteria_loop — mocked Bedrock interactions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def starting_criteria():
+    return _criteria("alpha", "beta", "gamma")
+
+
+@pytest.fixture
+def qa_pairs():
+    return [
+        {"question": f"q{i}", "golden_answer": f"a{i}"} for i in range(20)
+    ]
+
+
+def test_loop_returns_input_when_max_iter_zero(starting_criteria, qa_pairs):
+    out = asyncio.run(
+        refine_criteria_loop(
+            bedrock=None,
+            criteria=starting_criteria,
+            qa_pairs=qa_pairs,
+            domain="t",
+            max_iter=0,
+        )
+    )
+    assert out == starting_criteria
+
+
+def test_loop_returns_input_when_no_criteria(qa_pairs):
+    out = asyncio.run(
+        refine_criteria_loop(
+            bedrock=None,
+            criteria=[],
+            qa_pairs=qa_pairs,
+            domain="t",
+        )
+    )
+    assert out == []
+
+
+def test_loop_returns_input_when_no_qa_pairs(starting_criteria):
+    out = asyncio.run(
+        refine_criteria_loop(
+            bedrock=None,
+            criteria=starting_criteria,
+            qa_pairs=[],
+            domain="t",
+        )
+    )
+    assert out == starting_criteria
+
+
+def test_loop_exits_on_no_changes_needed(starting_criteria, qa_pairs):
+    """When the critic returns no_changes_needed=True on round 1, we
+    return immediately with the input criteria."""
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}]),
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(return_value={"no_changes_needed": True}),
+    ) as mock_critic:
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert out == starting_criteria
+    assert mock_critic.await_count == 1
+
+
+def test_loop_applies_changes_and_continues(starting_criteria, qa_pairs):
+    """Iter 1: critic drops 'beta'. Iter 2: critic says converged.
+    Result should be the post-iter-1 criteria."""
+    critic_responses = [
+        {
+            "no_changes_needed": False,
+            "criteria_updates": [
+                {"name": "beta", "action": "drop", "reason": "redundant"}
+            ],
+        },
+        {"no_changes_needed": True},
+    ]
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}]),
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(side_effect=critic_responses),
+    ):
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert [c["name"] for c in out] == ["alpha", "gamma"]
+
+
+def test_loop_falls_back_on_critic_error(starting_criteria, qa_pairs):
+    """A raised exception inside an iteration must NOT propagate. The
+    loop returns the most recent good criteria — here, the original
+    input since iter 1 failed before any update applied."""
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}]),
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(side_effect=RuntimeError("bedrock blew up")),
+    ):
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert out == starting_criteria
+
+
+def test_loop_returns_last_good_when_second_iter_fails(starting_criteria, qa_pairs):
+    """Iter 1 applies changes successfully, iter 2 errors. Return the
+    post-iter-1 state, not the original."""
+    critic_responses = [
+        {
+            "no_changes_needed": False,
+            "criteria_updates": [{"name": "alpha", "action": "drop", "reason": "x"}],
+        },
+        RuntimeError("kaboom"),
+    ]
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}]),
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(side_effect=critic_responses),
+    ):
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert [c["name"] for c in out] == ["beta", "gamma"]
+
+
+def test_loop_respects_max_iter_when_critic_never_converges(starting_criteria, qa_pairs):
+    """Critic always proposes more changes; loop exits at max_iter with
+    whatever the latest state is. No 'didn't converge' surfacing per design."""
+    critic_response = {
+        "no_changes_needed": False,
+        "criteria_updates": [],
+        "new_criteria": [{"name": "extra", "description": "1 if extra, 0 otherwise"}],
+    }
+    score_mock = AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}])
+    critic_mock = AsyncMock(return_value=critic_response)
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=score_mock,
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=critic_mock,
+    ):
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=2,
+            )
+        )
+    # Started with 3, each iter adds 1, ran 2 iters → 5.
+    assert len(out) == 5
+    assert critic_mock.await_count == 2
+
+
+def test_loop_caps_at_max_criteria(qa_pairs):
+    """When the critic proposes additions that push past MAX_CRITERIA,
+    the loop truncates rather than letting the set grow unbounded."""
+    starting = _criteria(*[f"c{i}" for i in range(MAX_CRITERIA - 1)])
+    flood = {
+        "no_changes_needed": False,
+        "new_criteria": [
+            {"name": f"new_{i}", "description": "1 if x, 0 otherwise"}
+            for i in range(5)
+        ],
+    }
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[{"question": "q", "golden": "a", "scores": {}}]),
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(side_effect=[flood, {"no_changes_needed": True}]),
+    ):
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert len(out) == MAX_CRITERIA
+
+
+def test_loop_falls_back_when_all_scoring_fails(starting_criteria, qa_pairs):
+    """If every per-sample judge call fails, the loop bails to last-good
+    rather than calling the critic with no signal."""
+    with patch(
+        "eval_mcp.tools.generate_judge._score_samples",
+        new=AsyncMock(return_value=[]),  # all samples dropped
+    ), patch(
+        "eval_mcp.tools.generate_judge._critique_criteria",
+        new=AsyncMock(),
+    ) as mock_critic:
+        out = asyncio.run(
+            refine_criteria_loop(
+                bedrock=None,
+                criteria=starting_criteria,
+                qa_pairs=qa_pairs,
+                domain="t",
+                max_iter=3,
+            )
+        )
+    assert out == starting_criteria
+    mock_critic.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration test (gated on Bedrock reachability) — proves end-to-end that
+# the cap is actually lifted in practice, not just in code.
+# ---------------------------------------------------------------------------
+
+
+def _bedrock_reachable() -> bool:
+    try:
+        import boto3
+
+        session = boto3.Session(region_name=os.environ.get("AWS_REGION", "us-west-2"))
+        creds = session.get_credentials()
+        return creds is not None and creds.access_key is not None
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _bedrock_reachable(),
+    reason="Bedrock credentials not available — skipping live criteria-loop integration test.",
+)
+def test_integration_loop_produces_more_than_five_criteria():
+    """End-to-end: feed the loop a real dataset and confirm it returns
+    a set with >5 criteria (the old hard cap). Doesn't assert on
+    specific content — that's the job of human review. Just proves the
+    plumbing lets the cap exceed 5."""
+    from eval_mcp.core.bedrock_client import BedrockClient
+    from eval_mcp.tools.generate_judge import generate_judge
+
+    bedrock = BedrockClient()
+    qa_pairs = [
+        {
+            "question": "What's the capital of France?",
+            "golden_answer": "Paris is the capital of France. It has been the country's capital since 987 AD.",
+        },
+        {
+            "question": "Explain how photosynthesis works in plants.",
+            "golden_answer": "Plants convert sunlight, water, and carbon dioxide into glucose and oxygen via chlorophyll in their leaves. The light reactions produce ATP and NADPH; the Calvin cycle uses these to fix CO2 into sugars.",
+        },
+        {
+            "question": "What is the Pythagorean theorem?",
+            "golden_answer": "For a right triangle with legs a and b and hypotenuse c, a² + b² = c². It's used to compute distances and is named for the Greek mathematician Pythagoras.",
+        },
+        {
+            "question": "Who wrote Hamlet?",
+            "golden_answer": "William Shakespeare wrote Hamlet around 1600. It's one of his four major tragedies.",
+        },
+        {
+            "question": "What causes the seasons?",
+            "golden_answer": "Earth's axis is tilted ~23.5° relative to its orbital plane. As Earth orbits the Sun, different hemispheres receive more direct sunlight at different times of year, causing seasonal changes.",
+        },
+    ]
+
+    initial = asyncio.run(generate_judge(bedrock, qa_pairs, "general knowledge"))
+    initial_criteria = initial.get("criteria", [])
+    assert initial_criteria, "Initial generation returned nothing"
+
+    refined = asyncio.run(
+        refine_criteria_loop(
+            bedrock=bedrock,
+            criteria=initial_criteria,
+            qa_pairs=qa_pairs,
+            domain="general knowledge",
+            max_iter=2,  # cap iterations to keep CI cost bounded
+            sample_size=3,
+        )
+    )
+
+    assert len(refined) >= 3, f"Loop returned fewer criteria than minimum: {len(refined)}"
+    assert len(refined) <= MAX_CRITERIA, f"Loop exceeded MAX_CRITERIA: {len(refined)}"
+    # Headline assertion: the OLD schema cap was 5. We want to confirm the
+    # path is structurally capable of producing more, even if a particular
+    # run converges below 5 — so we check the cap was lifted, not that the
+    # specific result is large.
+    # (A run that converges to 4 doesn't disprove the cap was lifted; only
+    # a run that returns >5 does. We don't assert >5 because convergence
+    # is dataset-dependent and would make the test flaky.)
+    print(f"Refined criteria ({len(refined)}):")
+    for c in refined:
+        print(f"  - {c['name']}: {c['description']}")


### PR DESCRIPTION
## Summary

- Adds a critic-led refinement loop to `generate_judge`: after initial criteria proposal, the loop scores ~10 QA pairs against the criteria, then asks an LLM critic to drop redundant ones, rewrite vague ones, and add missing failure modes. Iterates up to 3 times, exits early when the critic returns `no_changes_needed`.
- Lifts the under-generation cap. `judge_config.py:MAX_CRITERIA` was already 10 but the generator schema silently capped at `maxItems: 5`. Now `MAX_CRITERIA = 15` and the schema matches.
- New `eval_mcp/tools/generate_judge.py` helpers: `_build_scoring_tool`, `_score_qa_pair`, `_score_samples`, `_critique_criteria`, `_apply_updates`, `refine_criteria_loop`. All inlined to avoid an `eval_mcp/ -> backend/` import direction (today the dependency runs the other way).
- `EVAL_MCP_CRITIC_MAX_ITERATIONS` env var overrides the iteration cap. No separate critic-model env var — `BedrockClient` is a singleton already configured via `BEDROCK_MODEL_ID`.

## Why

Inspired by the skill-creator "grader-also-critiques-the-evals" pattern. Two problems with the prior design:

1. **Under-generation**: schema cap (5) silently overrode the prompt's "up to 10" hint, so users got 3-5 criteria regardless of how rich the dataset was.
2. **No quality feedback**: a vague criterion, a redundant pair, or one that always-passes on the dataset went undetected until full evaluation — by which point users had already configured downstream tooling against the bad set.

We considered a pass-rate threshold for keeping/dropping criteria (the mechanical version) but rejected it: a discrimination metric can't tell *why* a criterion always-fails. On a mixed dataset, "explains the underlying mechanism" passes on how/why questions and fails on factual recall. A metric would drop it. The LLM critic reads the judge's reasons, sees the failures are appropriate, and rewrites with a question-type conditional — turning a flawed criterion into a load-bearing one. The integration test below shows this exact rewrite happening on real Bedrock output.

Asymmetry vs eval-time scoring is intentional. The jury uses 3 judges to smooth measurement noise across N samples. The design-time critic is a single judge call: it's a craft judgment, runs at most 3 times, and the user reviews the final criteria anyway.

The loop is crash-safe: any exception inside an iteration returns the last-good criteria, so a flaky round never wipes out a usable set. All-failures during sample scoring also bail to last-good rather than calling the critic with no signal.

## Test plan

- [x] Unit tests pass (17/17): \`uv run --extra dev pytest tests/test_generate_judge_iter.py -v -k 'not integration'\` — covers \`_apply_updates\` pure-function behavior (drop / rewrite / append / unknown-action / malformed-input) and loop semantics with mocked critic (exit-on-no-changes / fallback-on-error / max-iter cap / MAX_CRITERIA truncation / all-scoring-fails bail-out).
- [x] Full suite unaffected: \`uv run --extra dev pytest tests/ --ignore=tests/test_mcp_eval.py --ignore=tests/test_langchain_subprocess_e2e.py\` → 130 passed, 1 skipped. The 21 errors are pre-existing \`ModuleNotFoundError: asyncpg\` in \`test_data_api.py\`, unrelated to this branch.
- [x] Integration test against real Bedrock with 5 mixed QA pairs (gated on AWS creds): converged at 10 criteria in 68s. Produced conditional clauses (\`mechanistic_explanation_when_required\` with explicit "if not how/why question, score 1") and tolerance bands (\`numerical_precision\`: "within 10%") the single-pass generator doesn't produce. See test docstring for fixture and full output.
- [ ] Post-merge smoke test: from a real MCP client, run \`analyze_dataset\` + \`generate_judge\` on a production-ish dataset, eyeball the criteria for redundancy / missing failure modes.