### PR TITLE
docs(agents): don't fret about context budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,25 @@ cd .claude/worktrees/<name>
 Skip the worktree only for trivial single-file edits you'll merge in the
 next minute.
 
+## Don't fret about context budget
+
+Claude Code (and other agentic tools) auto-summarize prior conversation
+turns when the context window fills up — the conversation isn't capped
+by the window. So don't stop work mid-task, "save context" by being
+terser than the task requires, commit half-done changes prematurely, or
+suggest the user open a fresh session just because the chat has gotten
+long. Those impulses are anti-patterns:
+
+- Stopping mid-implementation loses momentum and forces awkward resume.
+- Compressing your writing to "save tokens" sacrifices the clarity the
+  user actually needs from you.
+- Splitting one logical PR into two because "context might run out"
+  fractures a coherent change set that the user has to stitch back
+  together later.
+
+If the limit is genuinely reached, the platform handles it. Focus on
+finishing what was asked.
+
 ## Shipping changes (commit → PR → release)
 
 Use the **[`ship-it` skill](./.claude/skills/ship-it/SKILL.md)** — it


### PR DESCRIPTION
## Summary

Adds a short section to AGENTS.md telling agentic tools (Claude Code, Codex, Cursor, etc.) not to self-impose context limits.

## Why

The platform auto-summarizes older conversation turns when the context window fills — long sessions don't hit a hard wall. But agents have a pattern of getting cautious about session length anyway: stopping mid-task, compressing writing to "save tokens", or splitting one logical PR into two because the chat got long. All of those are anti-patterns:

- Stopping mid-implementation loses momentum and forces awkward resume.
- Compressing writing sacrifices clarity the user actually needs.
- Splitting a coherent change into two PRs makes the user stitch it back together.

Caught myself doing exactly this mid-implementation today; encoded the lesson so future sessions don't repeat it.

## Test plan

- [x] Doc-only change, no code paths to test.