### PR TITLE
fix(optimizer): drop undefined _auto_push call

### DIFF
--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -885,7 +885,6 @@ async def optimize_prompt(
         "test_holdout": test_holdout,
     }
     result = await handle_optimize_prompt(bedrock, args)
-    _auto_push(user_id)
     return result[0].text
 
 


### PR DESCRIPTION
## Summary

- `eval_mcp/server.py:888` called `_auto_push(user_id)` after `handle_optimize_prompt`, but no such function exists — only `_auto_pull` is defined.
- Every `optimize_prompt` MCP invocation raised `NameError: name '_auto_push' is not defined` before the tool result was returned to the agent.
- `save_optimization_to_db` already replicates to S3 internally, so there's no work for a push-back to do. Drop the stray call.

## Why

User report: local MCP errored with the NameError on every `optimize_prompt` invocation. v0.7.0 was unusable through the agent for this tool. Scaffolding from an earlier draft that didn't get cleaned up before PR #68 merged.

## Test plan

- [x] `from eval_mcp.server import optimize_prompt` imports cleanly
- [x] Other optimizer tests still pass (no change to behavior)
- [ ] Post-merge: cut **v0.7.2** so the local MCP install picks it up after `uv tool upgrade`