### PR TITLE
fix(frontend): stretch ComparisonGrid table to fill container with few columns

### DIFF
--- a/frontend/components/results/ComparisonGrid.tsx
+++ b/frontend/components/results/ComparisonGrid.tsx
@@ -99,7 +99,7 @@ export default function ComparisonGrid({
 
   return (
     <div className="w-full overflow-x-auto border border-rule bg-ink-elev">
-      <table className="border-collapse">
+      <table className="min-w-full border-collapse">
         <thead>
           <tr>
             <th


### PR DESCRIPTION
## Summary
- With only 2 model columns the comparison grid table sat flush-left in its wrapper, leaving a big empty stripe to the right.
- Cause: `<table class=\"border-collapse\">` had no width, so it shrank to its natural ~760px inside the `w-full overflow-x-auto` container.
- Fix: add `min-w-full` — the table fills the container when columns are narrow, and still allows horizontal overflow + sticky sample column when there are many.

Before / after (local repro with the exact Tailwind classes from the component):

| Before | After |
|---|---|
| Table ends ~halfway, empty band on the right | Score columns stretch evenly across the wrapper |

## Test plan
- [ ] Open Results with an eval that has only 2 model columns — confirm score cells stretch to fill width.
- [ ] Open Results with an eval that has 6+ model columns — confirm horizontal scroll still works and the sticky `Sample · expected` column stays anchored on scroll.