### PR TITLE
fix: surface prompt template in comparison view (frontend gate + backend emission)

### DIFF
--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -585,7 +585,7 @@ def _build_detail_from_logs(
         result["pipeline"] = pipeline_stages
     if agent_image:
         result["agentImage"] = agent_image
-    if is_prompt_comparison and config_data and config_data.get("prompts"):
+    if config_data and config_data.get("prompts"):
         result["prompts"] = config_data["prompts"]
     return result
 

--- a/frontend/components/results/ComparisonView.tsx
+++ b/frontend/components/results/ComparisonView.tsx
@@ -133,13 +133,15 @@ export default function ComparisonView({ groupId }: { groupId: string }) {
           pipeline={data.pipeline}
           prompts={data.prompts}
         />
-        {data.prompts && data.prompts.length > 1 && (
+        {data.prompts && data.prompts.length > 0 && (
           <details className="group mb-4 border border-rule bg-ink-elev">
             <summary className="flex cursor-pointer list-none select-none items-center gap-2 px-3 py-2 eyebrow">
               <span className="font-mono text-[10px] transition-transform group-open:rotate-90">
                 ▶
               </span>
-              Prompt templates ({data.prompts.length}) — click to expand
+              {data.prompts.length === 1
+                ? "Prompt template — click to expand"
+                : `Prompt templates (${data.prompts.length}) — click to expand`}
             </summary>
             <div className="space-y-2 border-t border-rule-soft px-3 pb-3 pt-2">
               {data.prompts.map((prompt, i) => (


### PR DESCRIPTION
## Summary
Two gates were hiding the prompt template in the comparison view:

1. **Frontend** — `ComparisonView.tsx` only rendered the "Prompt templates" panel when `prompts.length > 1`. Single-prompt evals (the common case) hid it entirely.
2. **Backend** — `eval_results.py` only emitted `result["prompts"]` when `is_prompt_comparison` was true. `is_prompt_comparison` is only true for runs with multiple distinct task names (the multi-prompt A/B case), so single-custom-prompt evals never had prompts in the API payload at all.

Either fix alone is insufficient: the frontend needed permission to render the panel for one prompt, AND the backend needed to actually send the prompt for non-comparison runs.

## Why
User reported "sometimes I can't see prompts in the prompt comparison." Single-custom-prompt evals were the case that hit both gates.

`config_data["prompts"]` is set only when the user picked a non-default template (see `create_config.py:374-380` — default `{question}` leaves it as `None`), so emitting `prompts` whenever the config has it is safe: we never surface the meaningless default.

## Test plan
- [ ] Run an eval with a single custom prompt template → confirm "Prompt template — click to expand" panel appears above the score grid and shows the prompt text under a `P1` chip.
- [ ] Run a 2+ prompt comparison → confirm the label reads "Prompt templates (N) — click to expand" and all prompts render.
- [ ] Run an eval with the default `{question}` template → confirm no panel appears (no meaningful prompt to surface).