### PR TITLE
fix(s3): auto-detect bucket region in eval-mcp init

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,12 +41,13 @@ uvx --from llm-evaluation-system eval-mcp init <bucket-name>
 
 If **yes, creating a new bucket** (first on the team):
 ```bash
+export AWS_REGION=us-west-2  # pick the region the bucket should live in
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/modules/eval-logs-bucket
 terraform init
 terraform apply -var="bucket_name=<bucket-name>"
 ```
-Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>`. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
+Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>` — `init` probes the bucket and persists its region, so cross-region uploads work without any extra setup. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
 
 Suggested bucket name if they don't have a preference: `eval-mcp-$(aws sts get-caller-identity --query Account --output text)` — globally unique, easy to remember.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ s3://my-team-evals/
 One person on the team runs this once:
 
 ```bash
+export AWS_REGION=us-west-2  # pick the region the bucket should live in
 git clone https://github.com/awslabs/llm-evaluation-system.git
 cd llm-evaluation-system/infra/modules/eval-logs-bucket
 terraform init

--- a/eval_mcp/INSTALL.md
+++ b/eval_mcp/INSTALL.md
@@ -41,12 +41,13 @@ uvx --from llm-evaluation-system eval-mcp init <bucket-name>
 
 If **yes, creating a new bucket** (first on the team):
 ```bash
+export AWS_REGION=us-west-2  # pick the region the bucket should live in
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/modules/eval-logs-bucket
 terraform init
 terraform apply -var="bucket_name=<bucket-name>"
 ```
-Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>`. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
+Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>` — `init` probes the bucket and persists its region, so cross-region uploads work without any extra setup. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
 
 Suggested bucket name if they don't have a preference: `eval-mcp-$(aws sts get-caller-identity --query Account --output text)` — globally unique, easy to remember.
 

--- a/eval_mcp/cli.py
+++ b/eval_mcp/cli.py
@@ -188,6 +188,27 @@ def _print_install_guide():
     click.echo(guide.read_text())
 
 
+def _detect_bucket_region(bucket: str):
+    """Probe S3 for the bucket's home region.
+
+    head_bucket returns `x-amz-bucket-region` even on a 301 redirect, so a
+    fixed probe region works regardless of where the bucket actually lives.
+    Returns None on NoSuchBucket / unreachable / missing credentials.
+    """
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    client = boto3.client("s3", region_name="us-east-1")
+    try:
+        response = client.head_bucket(Bucket=bucket)
+        return response["ResponseMetadata"]["HTTPHeaders"].get("x-amz-bucket-region")
+    except ClientError as e:
+        headers = e.response.get("ResponseMetadata", {}).get("HTTPHeaders", {})
+        return headers.get("x-amz-bucket-region")
+    except BotoCoreError:
+        return None
+
+
 @main.command()
 @click.argument("bucket")
 def init(bucket):
@@ -198,10 +219,22 @@ def init(bucket):
         eval-mcp init my-team-evals
     """
     from eval_mcp.config import set_config_value, get_user
+
+    region = _detect_bucket_region(bucket)
+    if not region:
+        click.echo(
+            f"Could not reach s3://{bucket} — check the bucket name and your "
+            "AWS credentials (aws sts get-caller-identity).",
+            err=True,
+        )
+        sys.exit(1)
+
     set_config_value("bucket", bucket)
+    set_config_value("region", region)
     user = get_user()
     click.echo(f"Configured S3 sharing:")
     click.echo(f"  bucket: {bucket}")
+    click.echo(f"  region: {region}")
     click.echo(f"  user:   {user} (auto-detected from AWS identity)")
     click.echo(f"\nLogs will sync to s3://{bucket}/users/{user}/")
     click.echo(f"Shared projects auto-discovered from s3://{bucket}/projects/*/")


### PR DESCRIPTION
## Summary

- `eval-mcp init <bucket>` now probes the bucket via `head_bucket` and persists its region into `~/.eval-mcp/config.json`, so cross-region uploads work without any extra config.
- If the bucket can't be reached, `init` fails loudly instead of silently saving a half-configured state that fails later inside an eval.
- README + INSTALL.md gain one `export AWS_REGION=…` line in the bucket-creation block so the terraform apply lands the bucket where the user expects. The user-facing `init` command stays a one-liner.

## Why

Bucket region wasn't captured anywhere — `eval-mcp init` stored only the name, terraform module inherits region from the caller's provider config, and `_get_s3_client()` defaults to `us-east-1` when `AWS_REGION` isn't in the shell. Cross-region uploads then fail with `EndpointConnectionError`, but `replicate_async` swallows it into a `logger.warning` and the eval completes anyway — so users never notice their evals aren't actually replicating to S3.

## Test plan

- [x] Unit-tested `_detect_bucket_region` against three head_bucket outcomes: 200 (same region), 301 redirect with `x-amz-bucket-region` header (cross-region), and 404 (no bucket).
- [ ] Manual: `eval-mcp init <bucket-in-us-east-2>` from a shell with no `AWS_REGION` — verify config.json gets `"region": "us-east-2"`.
- [ ] Manual: run a real eval after init — verify objects land in `s3://<bucket>/users/<you>/`.