### PR TITLE
fix(chat): rebuild agent per turn so chat history survives multi-pod traffic

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -8,7 +8,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import Depends, FastAPI, File, HTTPException, Request, UploadFile
@@ -91,11 +91,17 @@ async def get_current_user_id(request: Request) -> str:
     return user_id
 
 
-# Session-based agents (one agent per chat session)
-session_agents: Dict[str, Agent] = {}
-
 # Active background tasks for agent processing (keyed by session_id)
-# These run to completion even if client disconnects
+# These run to completion even if client disconnects.
+#
+# Note: there is intentionally no process-local cache of Agent instances
+# here. Backend runs as multiple replicas with no sticky routing, so
+# turn N can hit pod A and turn N+1 can hit pod B. A per-pod agent
+# cache silently diverges from the DB (the only cross-pod store) the
+# first time a session's turns split across pods — its history loses
+# every turn that happened on a different pod, and the model starts
+# answering as if those turns never occurred. We build the Agent fresh
+# per turn from the DB-backed conversation history instead.
 active_tasks: Dict[str, asyncio.Task] = {}
 
 # Event queues for streaming to clients (keyed by session_id)
@@ -779,9 +785,37 @@ async def cancel_chat(session_id: str, user_id: str = Depends(get_current_user_i
     return {"success": True, "message": "Cancellation requested", **eval_info}
 
 
+def _cancel_suffix(cancel_info: Dict[str, Any]) -> str:
+    """Build the suffix appended to a partial assistant response when the
+    user clicks Stop. For plain-chat cancels it's a short marker. For
+    eval cancels we embed the eval ID and a hint about how to resume,
+    so that on the NEXT turn the model — which now reads conversation
+    history from the DB rather than from in-memory agent state — has
+    enough context to offer the user a clean way to retry.
+
+    Previously this hint was injected via `Agent.cancel_info` and
+    `_orphan_tool_result_blocks` on the next turn. That path only fired
+    when the next turn happened on the SAME pod as the cancel (because
+    `cancel_info` lived on a process-local Agent instance), so it
+    silently failed under multi-pod traffic. Embedding the hint in the
+    DB-persisted response text makes it work the same way every time.
+    """
+    eval_id = cancel_info.get("evalId")
+    if not eval_id:
+        return "\n\n*[Response cancelled by user]*"
+    config_name = cancel_info.get("configName", "unknown")
+    return (
+        f"\n\n*[Evaluation cancelled by user. Eval ID: {eval_id}, "
+        f"Config: {config_name}. Partial results are saved. "
+        f"To resume, call retry_evaluation — it picks up incomplete evals "
+        f"by status.]*"
+    )
+
+
 async def run_agent_background(
     session_id: str,
     user_id: str,
+    agent: Agent,
     final_message: str,
     user_message_for_db: str,
     queue: asyncio.Queue,
@@ -791,21 +825,18 @@ async def run_agent_background(
     Background worker that runs agent to completion, regardless of client connection.
 
     Puts events into queue for SSE streaming. Saves response to DB when complete.
+
+    The agent is passed in from the request handler, freshly built and
+    hydrated from DB-backed history. We deliberately don't share it
+    across requests — see the module-level comment near `active_tasks`.
     """
-    global session_agents, active_tasks, cancelled_sessions
+    global active_tasks, cancelled_sessions
 
     full_response = ""
     event_count = 0
     was_cancelled = False
 
     try:
-        # Get agent for this session
-        agent = session_agents.get(session_id)
-        if not agent:
-            await queue.put({"type": "error", "data": {"error": "Agent not found"}})
-            await queue.put(None)  # Signal completion
-            return
-
         # Save user message to DB
         user_msg_id = str(uuid.uuid4())
         await db.save_message(user_msg_id, session_id, "user", user_message_for_db)
@@ -898,13 +929,7 @@ async def run_agent_background(
         # CancelledError handler below for why.
         if full_response:
             if was_cancelled:
-                full_response += "\n\n*[Response cancelled by user]*"
-                cancel_info = cancelled_sessions.get(session_id, {})
-                eval_id = cancel_info.get("evalId")
-                if eval_id:
-                    agent = session_agents.get(session_id)
-                    if agent:
-                        agent.cancel_info = cancel_info
+                full_response += _cancel_suffix(cancelled_sessions.get(session_id, {}))
             assistant_msg_id = str(uuid.uuid4())
             try:
                 await asyncio.wait_for(
@@ -940,11 +965,6 @@ async def run_agent_background(
         was_cancelled = True
         await queue.put({"type": "cancelled", "data": {"message": "Request cancelled", **cancel_info}})
 
-        # Store cancel info on agent so _fix_orphaned_tool_uses includes it in the tool result
-        agent = session_agents.get(session_id)
-        if agent and eval_id:
-            agent.cancel_info = cancel_info
-
         # Save partial response to DB — but bounded by a timeout. The
         # SSE stream can't close until this except handler returns
         # (finally puts None on queue), so a slow DB save would leave
@@ -954,7 +974,7 @@ async def run_agent_background(
         # unblocks the user. 5s is generous; the DB save normally takes
         # <50ms.
         if full_response:
-            full_response += "\n\n*[Response cancelled by user]*"
+            full_response += _cancel_suffix(cancel_info)
             assistant_msg_id = str(uuid.uuid4())
             try:
                 await asyncio.wait_for(
@@ -993,7 +1013,7 @@ async def run_agent_background(
 
 async def chat_stream(request: ChatRequest, user_id: str):
     """Stream chat responses with progress updates via SSE."""
-    global session_agents, active_tasks, event_queues
+    global active_tasks, event_queues
 
     logger = logging.getLogger(__name__)
 
@@ -1035,19 +1055,16 @@ async def chat_stream(request: ChatRequest, user_id: str):
     # Create session if it doesn't exist
     await db.create_session(session_id, user_id)
 
-    # Get or create agent for this session
-    if session_id not in session_agents:
-        agent = Agent(bedrock_client, mcp_client, debug=False)
-
-        # Load existing conversation history from database
-        existing_messages = await db.get_session_messages(session_id)
-        if existing_messages:
-            agent.conversation_history = [
-                {"role": msg["role"], "content": msg["content"]}
-                for msg in existing_messages
-            ]
-
-        session_agents[session_id] = agent
+    # Build a fresh Agent for this turn, hydrated from DB-backed history.
+    # The DB is the only cross-pod-coherent store in a multi-replica
+    # backend, so each turn re-reads it rather than relying on a
+    # process-local cache that would silently diverge.
+    existing_messages = await db.get_session_messages(session_id)
+    agent = Agent(bedrock_client, mcp_client, debug=False)
+    agent.conversation_history = [
+        {"role": msg["role"], "content": msg["content"]}
+        for msg in existing_messages
+    ]
 
     # Process file upload directly via Dataset MCP if present
     file_result_message = ""
@@ -1094,6 +1111,7 @@ async def chat_stream(request: ChatRequest, user_id: str):
         run_agent_background(
             session_id=session_id,
             user_id=user_id,
+            agent=agent,
             final_message=final_message,
             user_message_for_db=request.message,
             queue=queue,
@@ -1125,8 +1143,6 @@ async def chat_stream(request: ChatRequest, user_id: str):
 
 async def chat_non_stream(request: ChatRequest, user_id: str) -> ChatResponse:
     """Handle non-streaming chat requests (legacy mode)."""
-    global session_agents
-
     if not bedrock_client or not mcp_client or not db:
         raise HTTPException(status_code=500, detail="Backend not initialized")
 
@@ -1143,22 +1159,14 @@ async def chat_non_stream(request: ChatRequest, user_id: str) -> ChatResponse:
         # Create session if it doesn't exist
         await db.create_session(session_id, user_id)
 
-        # Get or create agent for this session
-        if session_id not in session_agents:
-            agent = Agent(bedrock_client, mcp_client, debug=False)
-
-            # Load existing conversation history from database
-            existing_messages = await db.get_session_messages(session_id)
-            if existing_messages:
-                # Convert DB format to agent format (only role and content needed)
-                agent.conversation_history = [
-                    {"role": msg["role"], "content": msg["content"]}
-                    for msg in existing_messages
-                ]
-
-            session_agents[session_id] = agent
-
-        agent = session_agents[session_id]
+        # Build a fresh Agent for this turn from DB-backed history —
+        # see the streaming-path comment above for why we don't cache.
+        existing_messages = await db.get_session_messages(session_id)
+        agent = Agent(bedrock_client, mcp_client, debug=False)
+        agent.conversation_history = [
+            {"role": msg["role"], "content": msg["content"]}
+            for msg in existing_messages
+        ]
 
         # Save user message
         user_msg_id = str(uuid.uuid4())

--- a/tests/test_chat_cancel_eks.py
+++ b/tests/test_chat_cancel_eks.py
@@ -53,11 +53,9 @@ async def test_cross_pod_cancel_fires_local_mcp_cancel(monkeypatch):
     fake_agent = MagicMock()
     fake_agent.run_conversation_turn_streaming = fake_stream
 
-    main.session_agents[session_id] = fake_agent
-
-    # Empty in-memory dict → forces the DB-poll branch (the cross-pod
-    # detection path). This is what would happen on Pod-A when cancel
-    # landed on Pod-B and only the DB row exists.
+    # Empty cancelled_sessions → forces the DB-poll branch (the
+    # cross-pod detection path). This is what would happen on Pod-A
+    # when cancel landed on Pod-B and only the DB row exists.
     main.cancelled_sessions.pop(session_id, None)
 
     fake_db = MagicMock()
@@ -87,6 +85,7 @@ async def test_cross_pod_cancel_fires_local_mcp_cancel(monkeypatch):
         main.run_agent_background(
             session_id=session_id,
             user_id=user_id,
+            agent=fake_agent,
             final_message="run a long eval",
             user_message_for_db="run a long eval",
             queue=queue,
@@ -116,7 +115,6 @@ async def test_cross_pod_cancel_fires_local_mcp_cancel(monkeypatch):
             await task
         except (asyncio.CancelledError, Exception):
             pass
-        main.session_agents.pop(session_id, None)
         main.cancelled_sessions.pop(session_id, None)
         main.active_tasks.pop(session_id, None)
         main.event_queues.pop(session_id, None)

--- a/tests/test_chat_history_xpod.py
+++ b/tests/test_chat_history_xpod.py
@@ -1,0 +1,207 @@
+"""Multi-pod chat-history persistence — stateless agent build.
+
+In a multi-replica backend with no sticky routing, turn N can land on
+Pod-A and turn N+1 on Pod-B. The previous design cached `Agent`
+instances in a per-pod dict (`session_agents`) and only loaded history
+from the DB the first time the pod saw a session. The result was
+silent divergence: each pod's cached agent only knew about the turns
+that had landed on it, and the model started answering as if the
+other pod's turns never happened.
+
+User-visible symptom: "my favorite number is 15" on one pod, then
+"what is my favorite number?" on the next pod returns "I don't know
+yet." Confirmed in prod (session `a34b2ee3...`) before the fix.
+
+Fix: drop the in-memory agent cache entirely. Build a fresh `Agent`
+per turn, hydrated from DB-backed conversation history. The DB is the
+only cross-pod-coherent store, so reading it on every turn keeps
+every pod's view identical.
+
+This test drives `run_agent_background` directly with a fake DB and a
+fake Bedrock so we can inspect exactly what the third turn sends to
+the model. If a future change reintroduces an in-memory history cache
+that shadows the DB, this test fails.
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _SharedDB:
+    """In-memory stand-in for Postgres. One DB shared across all simulated
+    pods so writes from any pod are visible to subsequent reads — same
+    coherence guarantee real Postgres gives us."""
+
+    def __init__(self):
+        self._messages: dict[str, list[dict]] = {}
+        self.create_user = AsyncMock(return_value=None)
+        self.create_session = AsyncMock(return_value=None)
+        self.clear_session_cancellation = AsyncMock(return_value=None)
+        self.get_session_cancellation = AsyncMock(return_value=None)
+        self.update_session_title = AsyncMock(return_value=None)
+
+    async def save_message(self, msg_id, session_id, role, content):
+        self._messages.setdefault(session_id, []).append(
+            {"id": msg_id, "role": role, "content": content,
+             "timestamp": datetime.datetime.now()}
+        )
+
+    async def get_session_messages(self, session_id):
+        return [
+            {"id": m["id"], "role": m["role"], "content": m["content"],
+             "timestamp": m["timestamp"].isoformat()}
+            for m in self._messages.get(session_id, [])
+        ]
+
+
+class _FakeBedrock:
+    """Captures the `messages` list it was called with on each turn so
+    the test can assert exactly what the model saw."""
+
+    def __init__(self):
+        self.calls: list[list[dict]] = []
+        self.responses: list[str] = []
+
+    def convert_mcp_tools_to_claude(self, tools):
+        return []
+
+    def extract_text_from_response(self, resp):
+        if isinstance(resp, dict):
+            for b in resp.get("content", []) or []:
+                if isinstance(b, dict) and b.get("type") == "text":
+                    return b.get("text", "")
+        return ""
+
+    def extract_tool_uses(self, resp):
+        return []
+
+    def create_tool_result_content(self, tu_id, r):
+        return {"type": "tool_result", "tool_use_id": tu_id, "content": str(r)}
+
+    async def create_message_streaming(self, messages, tools, system):
+        self.calls.append(copy.deepcopy(messages))
+        reply = self.responses.pop(0) if self.responses else "ok"
+        yield {"type": "text", "text": reply}
+        yield {
+            "type": "end",
+            "stop_reason": "end_turn",
+            "response": {"content": [{"type": "text", "text": reply}]},
+        }
+
+    def create_message(self, *a, **k):
+        raise NotImplementedError
+
+
+class _FakeMCP:
+    def set_user_id(self, _u):
+        pass
+
+    async def list_tools(self):
+        return []
+
+    async def read_resource(self, _name):
+        class _R:
+            contents = [type("X", (), {"text": '{"tools": []}'})()]
+        return _R()
+
+
+@pytest.mark.asyncio
+async def test_history_survives_three_turns_via_db_reload():
+    """Three turns on the same session, each driving the production
+    chat_stream path (fresh Agent, DB-hydrated history). Turn 3 must
+    see turns 1 AND 2 in its conversation history. With the old
+    cached-agent design, turn 3 on a pod that hadn't seen turn 2
+    would miss it — this test catches any regression to that pattern.
+    """
+    from backend.api import main
+    from backend.core.agent import Agent
+
+    shared_db = _SharedDB()
+
+    bed = _FakeBedrock()
+    main.bedrock_client = bed
+    main.mcp_client = _FakeMCP()
+    main.db = shared_db
+    main.cancelled_sessions.clear()
+    main.active_tasks.clear()
+    main.event_queues.clear()
+
+    bed.responses = [
+        "I don't know your favorite number yet.",
+        "Got it — 15.",
+        "Your favorite number is 15.",
+    ]
+
+    session_id = "session-xpod-bug"
+    user_id = "user-xpod"
+
+    async def drive_turn(user_msg):
+        # Mirror chat_stream: build a fresh Agent, hydrate from DB, hand
+        # it to run_agent_background. There's intentionally no per-pod
+        # state — that's the whole point of the stateless model.
+        existing = await main.db.get_session_messages(session_id)
+        agent = Agent(main.bedrock_client, main.mcp_client, debug=False)
+        agent.conversation_history = [
+            {"role": m["role"], "content": m["content"]} for m in existing
+        ]
+
+        queue: asyncio.Queue = asyncio.Queue()
+        main.event_queues[session_id] = queue
+        task = asyncio.create_task(
+            main.run_agent_background(
+                session_id=session_id,
+                user_id=user_id,
+                agent=agent,
+                final_message=user_msg,
+                user_message_for_db=user_msg,
+                queue=queue,
+                logger=MagicMock(),
+            )
+        )
+        while True:
+            ev = await queue.get()
+            if ev is None:
+                break
+        await task
+
+    # Three turns. In the buggy prod code, the second and third turns
+    # would have alternated pods (each pod with its own cached agent
+    # diverging from the shared DB). In the stateless code, the "pod"
+    # is irrelevant — every turn rebuilds the agent from DB.
+    await drive_turn("what is my favorite number?")
+    await drive_turn("its 15")
+    await drive_turn("what is my favorite number?")
+
+    assert len(bed.calls) == 3, f"expected 3 Bedrock calls, got {len(bed.calls)}"
+
+    turn3_msgs = bed.calls[2]
+    sent_flat = " | ".join(
+        f"{m['role']}: {m['content'] if isinstance(m['content'], str) else '<blocks>'}"
+        for m in turn3_msgs
+    )
+
+    # Turn 2's "its 15" must be present in what turn 3 sends to the model.
+    user_contents = [
+        m["content"] for m in turn3_msgs
+        if m["role"] == "user" and isinstance(m["content"], str)
+    ]
+    assert "its 15" in user_contents, (
+        f"Turn 3 (on Pod-A) lost turn 2's 'its 15' user message that "
+        f"happened on Pod-B. This means session_agents caching is "
+        f"shadowing the DB-backed history. Sent to Bedrock: {sent_flat}"
+    )
+
+    # Turn 2's assistant reply must be present too.
+    assistant_contents = [
+        m["content"] for m in turn3_msgs
+        if m["role"] == "assistant" and isinstance(m["content"], str)
+    ]
+    assert any("15" in c or "Got it" in c for c in assistant_contents), (
+        f"Turn 3 lost turn 2's assistant reply about '15'. "
+        f"Sent to Bedrock: {sent_flat}"
+    )


### PR DESCRIPTION
## What

Drop the process-local `session_agents` cache in `backend/api/main.py`. Build a fresh `Agent` for every turn, hydrated from DB-backed conversation history. Pass the agent into `run_agent_background` as a parameter.

## Why

Backend runs as 2+ replicas with no sticky routing. The old code only loaded history from the DB the first time a pod saw a session — after that it reused its in-memory cache. When alternate turns hit different pods, each pod's cached agent silently lost the turns that had landed on the other pod, and the model answered as if those turns never happened.

**Confirmed in prod** (session `a34b2ee3-468c-4458-b078-35efb31749d6`):

| Turn | Pod | Message |
|------|-----|---------|
| 1 | `j8ngq` | "what is my favorite number?" |
| 2 | `zg7l6` | "its 15" |
| 3 | `j8ngq` | "what is my favorite number?" |

Turn 3 was routed back to `j8ngq`, which still had its turn-1 agent in `session_agents`. That agent's history was missing turn 2 (which had happened on `zg7l6`), so the model truthfully replied "I still don't know your favorite number! You haven't told me yet." User-visible symptom: chat appears to lose memory mid-conversation.

## Why not "just always reload from DB"

Was the first patch I had ready — works, but leaves a now-vestigial dict caching Agents for nothing material (`tool_descriptions` could be module-level, `cancel_info` was load-bearing for the cross-turn eval resume hint but only on same-pod traffic anyway). The cache also leaked (no eviction). Going fully stateless is ~10 fewer lines and removes a class of bugs.

## Stop button

Cancel mechanics are independent of `session_agents` and continue to work:

- Same-pod cancel: `cancelled_sessions` in-memory flag → agent loop breaks.
- Cross-pod cancel: `session_cancellations` DB row → agent loop polls and breaks.
- Partial response saved with the cancel suffix.

The one feature affected is the cross-turn eval-cancel resume hint, which previously rode on `Agent.cancel_info`. That now goes into the DB-persisted cancelled response text via `_cancel_suffix`, so the next turn (any pod) sees it.

## Tests

- New: `tests/test_chat_history_xpod.py` — `test_history_survives_three_turns_via_db_reload` drives `run_agent_background` three times on the same session with a fake DB + fake Bedrock and asserts turn 3 sees turns 1 + 2 in its `messages` payload. Without the fix this would have failed (the old test scaffolding inlined the buggy logic and reproduced "model only sees turns 1 + 3").
- Updated: `tests/test_chat_cancel_eks.py` — passes `agent` as a parameter to `run_agent_background` instead of stuffing it into `session_agents`.
- Full unit suite: **261 passed, 1 skipped, 0 failures.**

## Trade-off worth flagging

We re-issue one MCP `read_resource` call per turn to load tool descriptions (it's local: `localhost:8002`, ~5 ms). Module-level caching is a follow-up if it ever shows up in flamegraphs.