### PR TITLE
fix(mcp): own the MCP connection from a dedicated task so eval cancels don't kill the pod

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -110,11 +110,60 @@ event_queues: Dict[str, asyncio.Queue] = {}
 # Sessions marked for cancellation
 cancelled_sessions: Dict[str, dict] = {}  # session_id -> cancel info (evalId, configName)
 
+# MCP connection ownership.
+#
+# A dedicated background task owns the MCP client's lifecycle (connect,
+# any reconnects, disconnect on shutdown). All operations that change
+# the underlying anyio cancel scopes — open + close of the streamable
+# HTTP exit stack — must happen in this task. If a reconnect runs in
+# any *other* task, anyio detects the cross-task scope close and
+# raises CancelledError on the task that originally opened the scope.
+# Under the previous design that task was the FastAPI lifespan task,
+# so eval cancels (which fired reconnect from a fire-and-forget cleanup
+# task) killed the whole pod. Routing reconnect requests through a
+# queue that this owner task drains keeps the scope cleanup in-task.
+_mcp_reconnect_queue: Optional[asyncio.Queue] = None
+_mcp_owner_task: Optional[asyncio.Task] = None
+
+
+async def _mcp_owner_loop(connect_done: asyncio.Event, queue: asyncio.Queue) -> None:
+    """Single long-lived task that owns the MCP client.
+
+    Opens the connection. Drains the reconnect queue, executing each
+    reconnect in this task's scope. Disconnects on shutdown signal
+    (a `None` sentinel on the queue).
+    """
+    try:
+        await mcp_client.connect()
+        # Tell the client which task owns the lifecycle. Internal
+        # auto-reconnect paths inside MultiMCPClient (e.g. list_tools
+        # retry-on-empty) check this and refuse to close the scope
+        # from any other task — that cross-task close is what used to
+        # kill the pod on every eval cancel.
+        mcp_client.claim_ownership()
+        connect_done.set()
+
+        while True:
+            signal = await queue.get()
+            if signal is None:
+                break
+            try:
+                await mcp_client.reconnect_server(signal, max_retries=3)
+            except Exception as e:
+                logger.warning(
+                    f"[MCP owner] Reconnect of {signal} failed: {e}"
+                )
+    finally:
+        try:
+            await mcp_client.disconnect()
+        except Exception as e:
+            logger.warning(f"[MCP owner] Disconnect failed: {e}")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifecycle: startup and shutdown."""
-    global mcp_client, bedrock_client, db
+    global mcp_client, bedrock_client, db, _mcp_reconnect_queue, _mcp_owner_task
 
     # Startup
     print("🚀 Initializing backend...")
@@ -128,9 +177,28 @@ async def lifespan(app: FastAPI):
         await db.initialize()
         print("  ✓ Database initialized")
 
-        # Initialize MCP client (connects to existing MCP servers)
+        # Spawn the MCP owner task and wait for its initial connect.
+        # The owner task — not the lifespan task — opens the anyio
+        # scopes, so reconnects later can close + reopen them in the
+        # same task without triggering cross-task scope errors.
         mcp_client = MultiMCPClient(region=region)
-        await mcp_client.connect()
+        _mcp_reconnect_queue = asyncio.Queue()
+        _connect_done = asyncio.Event()
+        _mcp_owner_task = asyncio.create_task(
+            _mcp_owner_loop(_connect_done, _mcp_reconnect_queue)
+        )
+        # Bound the wait so a misconfigured / unreachable MCP server
+        # fails the pod startup loudly instead of hanging forever.
+        try:
+            await asyncio.wait_for(_connect_done.wait(), timeout=60.0)
+        except asyncio.TimeoutError:
+            if _mcp_owner_task.done():
+                exc = _mcp_owner_task.exception()
+                raise (exc or ConnectionError("MCP owner died during connect"))
+            raise ConnectionError("MCP connect timed out after 60s")
+        if _mcp_owner_task.done():
+            exc = _mcp_owner_task.exception()
+            raise (exc or ConnectionError("MCP owner exited before serving"))
         print("  ✓ Connected to MCP servers")
 
         # Initialize Bedrock client
@@ -143,11 +211,8 @@ async def lifespan(app: FastAPI):
 
     except Exception as e:
         print(f"❌ ERROR during startup: {e}")
-        if mcp_client:
-            try:
-                await mcp_client.disconnect()
-            except Exception:
-                pass
+        if _mcp_owner_task and not _mcp_owner_task.done():
+            _mcp_owner_task.cancel()
         raise
 
     finally:
@@ -217,13 +282,22 @@ async def lifespan(app: FastAPI):
             print(f"  ⚠ Error handling running evaluations: {e}")
             logger.error(f"[SHUTDOWN] Eval shutdown error: {e}")
 
-        if mcp_client:
+        # Signal the MCP owner task to exit and wait for it to
+        # disconnect in its own scope. We never call mcp_client.disconnect()
+        # directly from this lifespan task: doing so would close the
+        # anyio scopes the owner opened, raising CancelledError on the
+        # owner task — the same cross-task close that bombs reconnect.
+        if _mcp_owner_task and not _mcp_owner_task.done():
             try:
-                await mcp_client.disconnect()
+                _mcp_reconnect_queue.put_nowait(None)
+                await asyncio.wait_for(_mcp_owner_task, timeout=10.0)
                 print("  ✓ Disconnected from MCP servers")
+            except asyncio.TimeoutError:
+                print("  ⚠ MCP owner did not exit within 10s, cancelling")
+                _mcp_owner_task.cancel()
             except Exception as e:
-                print(f"  ⚠ Error disconnecting MCP client: {e}")
-                logger.error(f"[SHUTDOWN] MCP disconnect error: {e}")
+                print(f"  ⚠ Error stopping MCP owner: {e}")
+                logger.error(f"[SHUTDOWN] MCP owner stop error: {e}")
 
         if db:
             try:
@@ -659,30 +733,27 @@ async def chat_status(session_id: str, user_id: str = Depends(get_current_user_i
 async def _cancel_eval_subprocess_and_reconnect(user_id: str) -> None:
     """Background cleanup after a chat cancel.
 
-    Always POSTs to the local MCP /cancel endpoint (idempotent — no-op
-    if nothing's registered). ONLY reconnects the MCP client when an
-    eval subprocess was actually killed.
+    POSTs to the local MCP /cancel endpoint (idempotent — no-op if
+    nothing's registered). If an eval subprocess was actually killed,
+    enqueues a reconnect signal for the MCP owner task to process.
 
-    Why the split (this was previously unified, then split again):
-    Reconnecting the MCP server from a background task closes anyio
-    cancel scopes that were opened by the FastAPI lifespan task.
-    anyio detects the cross-task scope exit, raises CancelledError,
-    and that CancelledError propagates UP through the lifespan's
-    `yield` — triggering the whole backend pod's shutdown. We saw
-    this in production:
+    Why the queue handoff: reconnecting the MCP server tears down and
+    re-opens anyio cancel scopes. anyio's structured concurrency
+    requires the close to happen in the same task that opened it.
+    Under the old design this function called `reconnect_server`
+    directly from the chat cancel's background task, so the close
+    crossed task boundaries — anyio raised CancelledError on the
+    lifespan task (the original opener), and it propagated through
+    `yield`, bringing the whole pod down on every eval cancel:
 
         POST /cancel/{user_id} → 200
         [SHUTDOWN] Backend shutdown initiated
         Shutdown caused by exception: CancelledError
-            ...at backend/api/main.py:681 (the reconnect call)
 
-    For plain-chat cancels there's nothing to reconnect anyway (no
-    MCP RPC was in flight, no subprocess was killed) — so the cost
-    of skipping reconnect is zero and the benefit is "doesn't kill
-    the pod." For eval cancels we still reconnect; the cross-task
-    scope issue can still bite there, but it's much rarer and is a
-    separate, larger fix (likely: drive reconnects from the lifespan
-    task via a queue rather than directly from background tasks).
+    Routing through `_mcp_reconnect_queue` makes the actual
+    open/close happen inside `_mcp_owner_loop`, which is the same
+    task that originally opened the scopes. The close is in-task and
+    safe.
     """
     try:
         mcp_url = os.environ["EVAL_MCP_URL"]
@@ -705,10 +776,22 @@ async def _cancel_eval_subprocess_and_reconnect(user_id: str) -> None:
             # described above).
             return
 
-        # Cap reconnect attempts to 3 so a transient MCP unavailability
-        # doesn't pile up retries (default is 10 → up to ~9 minutes of
-        # _reconnect_lock held → frontend cooldown can't compensate).
-        await mcp_client.reconnect_server("eval", max_retries=3)
+        # Hand the reconnect off to the MCP owner task via its queue.
+        # Doing the reconnect here would call exit_stack.aclose() from
+        # THIS background task, but the scope was opened by the owner
+        # task — anyio sees the cross-task close, raises CancelledError
+        # on the owner, and (under the previous architecture) the error
+        # propagated through the lifespan's `yield`, killing the pod
+        # on every eval cancel. The owner drains the queue in its own
+        # task scope, so the close is in-task and harmless.
+        if _mcp_reconnect_queue is not None:
+            try:
+                _mcp_reconnect_queue.put_nowait("eval")
+            except asyncio.QueueFull:
+                logger.warning(
+                    "[CANCEL bg] Reconnect queue full; dropping signal "
+                    "(owner will catch up on next signal)"
+                )
     except Exception as e:
         logger.warning(f"[CANCEL bg] Failed to clean up eval state for {user_id}: {e}")
 

--- a/backend/core/mcp_client.py
+++ b/backend/core/mcp_client.py
@@ -137,6 +137,17 @@ class MultiMCPClient:
 
         return False
 
+    def claim_ownership(self) -> None:
+        """Mark the current task as the sole owner of this client's
+        connection lifecycle. Future calls to `reconnect_server` from
+        any other task will refuse to close the anyio scope — closing
+        a scope from a foreign task raises CancelledError on the owner
+        and (under the previous architecture) brought the whole pod
+        down. Other tasks should signal the owner via a queue rather
+        than call reconnect_server directly.
+        """
+        self._owner_task = asyncio.current_task()
+
     async def reconnect_server(
         self, server_name: str, max_retries: int = 10
     ) -> bool:
@@ -151,8 +162,30 @@ class MultiMCPClient:
                 ~9 minutes of retry behind the reconnect_lock.
 
         Returns:
-            True if reconnection succeeded
+            True if reconnection succeeded.
+
+        Must run in the task that originally connected the client.
+        See `claim_ownership`. Calling from a foreign task is treated
+        as a bug and refused (returns False) — closing the exit stack
+        cross-task triggers anyio CancelledError on the owner and
+        previously killed the pod on every eval cancel.
         """
+        owner = getattr(self, "_owner_task", None)
+        if owner is not None:
+            current = asyncio.current_task()
+            if current is not None and current is not owner:
+                self.logger.warning(
+                    "reconnect_server(%s) refused: called from task %r, "
+                    "owner is %r. Internal auto-reconnect paths (list_tools, "
+                    "call_tool) hit this when run from the agent task; the "
+                    "tool call error will propagate instead of silently "
+                    "trying to recover (which would crash the pod).",
+                    server_name,
+                    current.get_name(),
+                    owner.get_name(),
+                )
+                return False
+
         async with self._reconnect_lock:
             # Clean up old connection if exists
             if server_name in self._exit_stacks:

--- a/tests/test_chat_cancel_eks.py
+++ b/tests/test_chat_cancel_eks.py
@@ -277,13 +277,12 @@ async def test_cancel_eval_skips_reconnect_when_nothing_was_killed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cancel_eval_does_reconnect_when_eval_was_killed(monkeypatch):
-    """Symmetric to the skip test: when an eval WAS killed, reconnect
-    is still called. We accept the cross-task anyio risk in that case
-    because (a) eval cancels are rarer than plain-chat cancels and
-    (b) reconnect is the documented way to flush MCP RPC state after
-    a SIGTERM. The deeper fix (drive reconnects from the lifespan
-    task) is a separate, larger change.
+async def test_cancel_eval_enqueues_reconnect_for_owner_task(monkeypatch):
+    """When an eval was actually killed, we need to refresh MCP state.
+    The cancel-cleanup task MUST hand that work off to the MCP owner
+    task via `_mcp_reconnect_queue` — NOT call `reconnect_server`
+    directly. Direct call closes the anyio scope from the wrong task
+    and crashes the pod (see test_mcp_reconnect_lifespan_owner.py).
     """
     from backend.api import main
 
@@ -303,20 +302,30 @@ async def test_cancel_eval_does_reconnect_when_eval_was_killed(monkeypatch):
 
     monkeypatch.setattr(main, "httpx", MagicMock(AsyncClient=lambda: _FakeClient()))
 
-    reconnect_called = asyncio.Event()
+    # Spy on mcp_client.reconnect_server. Direct call here = the bug.
+    direct_call = asyncio.Event()
     fake_mcp = MagicMock()
 
     async def fake_reconnect(*a, **k):
-        reconnect_called.set()
+        direct_call.set()
 
     fake_mcp.reconnect_server = fake_reconnect
     monkeypatch.setattr(main, "mcp_client", fake_mcp)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    monkeypatch.setattr(main, "_mcp_reconnect_queue", queue)
 
     monkeypatch.setenv("EVAL_MCP_URL", "http://localhost:8002/mcp")
 
     await main._cancel_eval_subprocess_and_reconnect(user_id)
 
-    assert reconnect_called.is_set(), (
-        "When an eval was actually killed, reconnect_server should "
-        "still be called to flush any in-flight MCP RPC state."
+    assert not direct_call.is_set(), (
+        "Cancel-cleanup called reconnect_server directly. That closes "
+        "the anyio scope from a foreign task and kills the pod. The "
+        "reconnect must be enqueued for the MCP owner task instead."
     )
+    assert not queue.empty(), (
+        "Cancel-cleanup didn't enqueue a reconnect signal for the "
+        "owner task. MCP state never gets refreshed after the SIGTERM."
+    )
+    assert queue.get_nowait() == "eval"

--- a/tests/test_mcp_reconnect_lifespan_owner.py
+++ b/tests/test_mcp_reconnect_lifespan_owner.py
@@ -1,0 +1,197 @@
+"""Pin the fix for the pod-shutdown-on-eval-cancel bug.
+
+Background: anyio cancel scopes (used internally by the MCP
+streamable-http client) are tied to the task that opened them.
+Closing such a scope from a *different* task raises CancelledError on
+the original opener. Under the previous design, the FastAPI lifespan
+task opened the MCP connection, then a chat-cancel background task
+(`_cancel_eval_subprocess_and_reconnect`) called `reconnect_server`
+directly — which closed and reopened the exit stack from the wrong
+task. anyio cancelled the lifespan, the cancel cascaded through the
+lifespan's `yield`, and the pod shut down. Every eval cancel.
+
+Fix: route reconnect signals through `_mcp_reconnect_queue`. A
+dedicated `_mcp_owner_loop` task drains the queue and performs the
+reconnect *in its own scope* — the same task that originally opened
+the scope, so the close stays in-task.
+
+This test asserts the wiring rather than the anyio scope mechanics
+themselves (which would require a real MCP server to reproduce).
+Specifically: after a successful eval cancel, the chat cancel cleanup
+must NOT call `reconnect_server` directly. It must put a signal on
+`_mcp_reconnect_queue` instead.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_eval_cancel_enqueues_reconnect_signal_not_direct_call(monkeypatch):
+    """Eval cancel must NOT call mcp_client.reconnect_server directly —
+    that's the cross-task scope close that bombs the pod. It must put
+    a signal on _mcp_reconnect_queue for the owner task to drain.
+    """
+    from backend.api import main
+
+    user_id = "test-user-eval-cancelled"
+    monkeypatch.setenv("EVAL_MCP_URL", "http://localhost:8002/mcp")
+
+    # Simulate "yes an eval was actually running" from the local MCP
+    # /cancel endpoint — body says cancelled: True.
+    class _CancelledResp:
+        def json(self):
+            return {"cancelled": True, "evalId": "e1", "configName": "c1"}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            return _CancelledResp()
+
+    monkeypatch.setattr(main, "httpx", MagicMock(AsyncClient=lambda: _FakeClient()))
+
+    # Spy on mcp_client.reconnect_server — if the code calls it
+    # directly the test fails, because that's the cross-task path
+    # that crashed pods.
+    direct_reconnect_called = asyncio.Event()
+    fake_mcp = MagicMock()
+
+    async def _direct_reconnect(*a, **k):
+        direct_reconnect_called.set()
+
+    fake_mcp.reconnect_server = _direct_reconnect
+    monkeypatch.setattr(main, "mcp_client", fake_mcp)
+
+    # Install a fresh queue and verify the function uses it.
+    queue: asyncio.Queue = asyncio.Queue()
+    monkeypatch.setattr(main, "_mcp_reconnect_queue", queue)
+
+    await main._cancel_eval_subprocess_and_reconnect(user_id)
+
+    # Direct call must NOT happen — that's the bug.
+    assert not direct_reconnect_called.is_set(), (
+        "_cancel_eval_subprocess_and_reconnect called "
+        "mcp_client.reconnect_server directly. That closes the anyio "
+        "scope from the wrong task and kills the pod. It should "
+        "enqueue on _mcp_reconnect_queue instead."
+    )
+
+    # The signal must be on the queue, ready for the owner task.
+    assert not queue.empty(), (
+        "Eval cancel did not enqueue a reconnect signal. The MCP "
+        "owner task will never know to refresh the session."
+    )
+    signal = queue.get_nowait()
+    assert signal == "eval", (
+        f"Expected 'eval' on the reconnect queue, got {signal!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_chat_cancel_does_not_enqueue_reconnect(monkeypatch):
+    """No eval was running → MCP /cancel returns cancelled: False →
+    we must NOT enqueue a reconnect. Reconnecting for nothing burns
+    the _reconnect_lock and slows the next message for no reason.
+    """
+    from backend.api import main
+
+    user_id = "test-user-plain-cancel"
+    monkeypatch.setenv("EVAL_MCP_URL", "http://localhost:8002/mcp")
+
+    class _NoEvalResp:
+        def json(self):
+            return {"cancelled": False, "reason": "no running eval"}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            return _NoEvalResp()
+
+    monkeypatch.setattr(main, "httpx", MagicMock(AsyncClient=lambda: _FakeClient()))
+    monkeypatch.setattr(main, "mcp_client", MagicMock())
+
+    queue: asyncio.Queue = asyncio.Queue()
+    monkeypatch.setattr(main, "_mcp_reconnect_queue", queue)
+
+    await main._cancel_eval_subprocess_and_reconnect(user_id)
+
+    assert queue.empty(), (
+        "Plain-chat cancel enqueued a reconnect signal. That holds the "
+        "_reconnect_lock and stalls the next user message for no reason."
+    )
+
+
+@pytest.mark.asyncio
+async def test_owner_loop_drains_signal_in_its_own_task(monkeypatch):
+    """The owner loop must execute reconnect_server in its own task
+    scope. We can't test the anyio scope ownership directly without a
+    real MCP server, but we can verify the call happens via the owner
+    task — proving the architecture is right.
+    """
+    from backend.api import main
+
+    seen_in_task: list[str] = []
+
+    fake_mcp = MagicMock()
+
+    async def _fake_connect():
+        seen_in_task.append(f"connect:{asyncio.current_task().get_name()}")
+
+    async def _fake_disconnect():
+        seen_in_task.append(f"disconnect:{asyncio.current_task().get_name()}")
+
+    async def _fake_reconnect(server_name, max_retries=10):
+        seen_in_task.append(
+            f"reconnect:{server_name}:{asyncio.current_task().get_name()}"
+        )
+
+    fake_mcp.connect = _fake_connect
+    fake_mcp.disconnect = _fake_disconnect
+    fake_mcp.reconnect_server = _fake_reconnect
+    monkeypatch.setattr(main, "mcp_client", fake_mcp)
+
+    connect_done = asyncio.Event()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    owner = asyncio.create_task(
+        main._mcp_owner_loop(connect_done, queue), name="mcp-owner"
+    )
+
+    await asyncio.wait_for(connect_done.wait(), timeout=2.0)
+
+    # Push a reconnect signal — it should be processed by the owner.
+    queue.put_nowait("eval")
+    # Tiny delay for the owner to drain it.
+    for _ in range(20):
+        if any("reconnect:eval" in line for line in seen_in_task):
+            break
+        await asyncio.sleep(0.05)
+
+    # Shut down the owner.
+    queue.put_nowait(None)
+    await asyncio.wait_for(owner, timeout=2.0)
+
+    # All three operations must have run inside the owner task — that's
+    # the structural invariant that prevents the cross-task scope bug.
+    connect_lines = [s for s in seen_in_task if s.startswith("connect:")]
+    reconnect_lines = [s for s in seen_in_task if s.startswith("reconnect:")]
+    disconnect_lines = [s for s in seen_in_task if s.startswith("disconnect:")]
+
+    assert connect_lines, f"Owner did not call connect. seen={seen_in_task}"
+    assert reconnect_lines, f"Owner did not drain reconnect signal. seen={seen_in_task}"
+    assert disconnect_lines, f"Owner did not disconnect on shutdown. seen={seen_in_task}"
+
+    owner_name = "mcp-owner"
+    assert all(owner_name in s for s in connect_lines + reconnect_lines + disconnect_lines), (
+        f"Some MCP operation ran outside the owner task. seen={seen_in_task}"
+    )


### PR DESCRIPTION
## What

Move MCP client connect / reconnect / disconnect into a dedicated long-lived task (`_mcp_owner_loop`). The lifespan task spawns it and waits for connect-done before yielding. Background callers (chat-cancel cleanup, internal auto-reconnect paths) signal the owner via `_mcp_reconnect_queue` instead of touching `mcp_client.reconnect_server` directly. A new `claim_ownership` / owner-check guard on `MultiMCPClient.reconnect_server` refuses cross-task calls.

## Why

User clicks Stop while an eval is running. Symptom: subsequent retries fail with "network error". Root cause (from pod logs, session `b2244725...`):

```
05:54:32.744  [AGENT CANCELLED] eval cancel triggered
05:54:32.854  POST localhost:8002/cancel/{user} → 200 (eval was killed)
05:54:32.856  [SHUTDOWN] Backend shutdown initiated
              Shutdown caused by exception: CancelledError
              ...at backend/api/main.py:705 (mcp_client.reconnect_server call)
```

`_cancel_eval_subprocess_and_reconnect` was calling `reconnect_server` from a fire-and-forget cleanup task. Inside `reconnect_server`, `exit_stack.aclose()` closes anyio cancel scopes that were opened by the lifespan task during startup. Anyio's structured-concurrency invariant: a scope must be closed by the same task that opened it. The cross-task close raises CancelledError on the *owner* task (lifespan), which propagates through `yield` and exits the lifespan → uvicorn shutdown → pod dies. Every eval cancel.

The user-visible "network error" is the load balancer routing to a pod that's mid-shutdown.

The prior fix `671562f` skipped reconnect when *no eval was killed* — that handled plain-chat cancels (the common case). For eval cancels the reconnect still fired and still killed the pod. The code comment acknowledged this was a half-fix: *"the cross-task scope issue can still bite there ... a separate, larger fix (likely: drive reconnects from the lifespan task via a queue rather than directly from background tasks)."* This PR is that fix.

## Architecture

```
                          ┌──────────────────────────┐
   FastAPI lifespan ────► │ _mcp_owner_loop (task)   │
   (just spawns and       │  - mcp_client.connect()  │
   waits for ready)       │  - claim_ownership()     │
                          │  - while: drain queue    │
                          │       → reconnect_server │
                          │  - mcp_client.disconnect │
                          └──────────────────────────┘
                                     ▲
                                     │ signal
                                     │
   ┌───────────────────────────┐     │
   │ _cancel_eval_subprocess_  │─────┘
   │ and_reconnect (bg task)   │   put "eval" on queue
   └───────────────────────────┘   (does NOT call reconnect_server)
```

Every `await mcp_client.connect()`, `reconnect_server()`, and `disconnect()` now runs in the same task. Anyio scopes never close cross-task.

The guard on `reconnect_server` plugs the same hole in the internal auto-reconnect paths inside `list_tools` and `call_tool`. Those run in the agent task (also not the owner). They haven't fired in recent prod logs but were a latent crash vector — now they log a warning and return False instead of bombing the pod.

## Tests

- New `tests/test_mcp_reconnect_lifespan_owner.py`:
  - `test_eval_cancel_enqueues_reconnect_signal_not_direct_call` — chat-cancel cleanup must enqueue, never direct-call
  - `test_plain_chat_cancel_does_not_enqueue_reconnect` — no signal when nothing was killed
  - `test_owner_loop_drains_signal_in_its_own_task` — connect/reconnect/disconnect all run inside the owner task
- `tests/test_chat_cancel_eks.py::test_cancel_eval_does_reconnect_when_eval_was_killed` rewritten as `test_cancel_eval_enqueues_reconnect_for_owner_task` — asserts the queue handoff instead of the direct call.
- Full unit suite: **264 passed, 1 skipped.**

## Risk

The lifespan now depends on a background task surviving startup. If `_mcp_owner_loop` dies between `connect_done.set()` and the queue drain, the lifespan yields without realising — the symptom is "all MCP calls fail until pod restart." Mitigation: the owner's `finally` runs `mcp_client.disconnect()`, so sessions get cleared and subsequent `list_tools`/`call_tool` raise clear errors instead of hanging. Worth keeping an eye on `[MCP owner]` warning lines in pod logs after deploy.