### PR TITLE
fix(s3): auto-suffix bucket name with AWS account ID for global uniqueness

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,13 +45,15 @@ export AWS_REGION=us-west-2  # pick the region the bucket should live in
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/modules/eval-logs-bucket
 terraform init
-terraform apply -var="bucket_name=<bucket-name>"
+terraform apply -var="bucket_name=<logical-name>"
 ```
-Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>` — `init` probes the bucket and persists its region, so cross-region uploads work without any extra setup. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
+The Terraform module appends the caller's AWS account ID, so the actual bucket created is `<logical-name>-<account-id>` — globally unique, no name collisions with other teams using the same example. The full name is printed under the `bucket_name` Terraform output.
 
-Suggested bucket name if they don't have a preference: `eval-mcp-$(aws sts get-caller-identity --query Account --output text)` — globally unique, easy to remember.
+Then `uvx --from llm-evaluation-system eval-mcp init <logical-name>` — `init` probes both the literal name and the account-suffixed name, persists whichever exists along with its region. Tell the user: teammates run `eval-mcp init <logical-name>` from the same AWS account — no Terraform needed.
 
-If **no**: skip. They can enable it later with `eval-mcp init <bucket>`.
+Suggested logical name if they don't have a preference: `<team>-evals` (e.g. `growth-evals`, `platform-evals`). The account-ID suffix makes it unique without the user having to think about uniqueness.
+
+If **no**: skip. They can enable it later with `eval-mcp init <logical-name>`.
 
 ## Fallback: manual per-IDE install
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ User identity is auto-detected from your AWS credentials. Projects are auto-disc
 ### How it works
 
 ```
-s3://my-team-evals/
+s3://my-team-evals-<your-aws-account-id>/
   users/alice/            ← Alice's evals, datasets, judges, configs (auto-replicated on every write)
   users/bob/              ← Bob's
   projects/project-alpha/ ← shared team evals
   projects/project-beta/  ← shared team evals
 ```
+
+The Terraform module appends your AWS account ID so the bucket is globally unique without you having to invent a unique name. You only ever type `my-team-evals` — `eval-mcp init` resolves the full name via your account.
 
 - Every write (eval result, dataset, judge, config, PDF report) auto-replicates to `users/{you}/` in the background
 - Every list/read auto-pulls from S3 first (debounced) so your local state mirrors S3
@@ -124,6 +126,8 @@ cd llm-evaluation-system/infra/modules/eval-logs-bucket
 terraform init
 terraform apply -var="bucket_name=my-team-evals"
 ```
+
+The actual bucket created is `my-team-evals-<your-aws-account-id>` — Terraform prints it under the `bucket_name` output. Teammates run `eval-mcp init my-team-evals` from the same account and the tool finds it automatically.
 
 ## Deploy Full Platform on EKS
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,25 @@ Share datasets, judges, configs, and eval results across your team via a shared 
 
 ### Setup
 
+**First on the team — creating the bucket?** One person runs this once:
+
+```bash
+export AWS_REGION=us-west-2  # pick the region the bucket should live in
+git clone https://github.com/awslabs/llm-evaluation-system.git
+cd llm-evaluation-system/infra/modules/eval-logs-bucket
+terraform init
+terraform apply -var="bucket_name=my-team-evals"
+```
+
+The Terraform module appends your AWS account ID so the actual bucket is `my-team-evals-<your-account-id>` — globally unique without you having to invent a unique name. Terraform prints the full name under the `bucket_name` output.
+
+**Everyone (including the bucket creator), on every machine:**
+
 ```bash
 uvx --from llm-evaluation-system eval-mcp init my-team-evals
 ```
 
-User identity is auto-detected from your AWS credentials. Projects are auto-discovered from the bucket.
+`eval-mcp init` resolves the account-ID suffix automatically, so all teammates type the same short name. User identity is auto-detected from AWS credentials; projects are auto-discovered from the bucket.
 
 ### How it works
 
@@ -108,26 +122,10 @@ s3://my-team-evals-<your-aws-account-id>/
   projects/project-beta/  ← shared team evals
 ```
 
-The Terraform module appends your AWS account ID so the bucket is globally unique without you having to invent a unique name. You only ever type `my-team-evals` — `eval-mcp init` resolves the full name via your account.
-
 - Every write (eval result, dataset, judge, config, PDF report) auto-replicates to `users/{you}/` in the background
 - Every list/read auto-pulls from S3 first (debounced) so your local state mirrors S3
 - `eval-mcp share my-project` → promote your stuff to a shared project prefix
 - `eval-mcp sync` → manual reconcile (used after long offline periods or on a fresh laptop)
-
-### Create the bucket
-
-One person on the team runs this once:
-
-```bash
-export AWS_REGION=us-west-2  # pick the region the bucket should live in
-git clone https://github.com/awslabs/llm-evaluation-system.git
-cd llm-evaluation-system/infra/modules/eval-logs-bucket
-terraform init
-terraform apply -var="bucket_name=my-team-evals"
-```
-
-The actual bucket created is `my-team-evals-<your-aws-account-id>` — Terraform prints it under the `bucket_name` output. Teammates run `eval-mcp init my-team-evals` from the same account and the tool finds it automatically.
 
 ## Deploy Full Platform on EKS
 

--- a/eval_mcp/INSTALL.md
+++ b/eval_mcp/INSTALL.md
@@ -45,13 +45,15 @@ export AWS_REGION=us-west-2  # pick the region the bucket should live in
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/modules/eval-logs-bucket
 terraform init
-terraform apply -var="bucket_name=<bucket-name>"
+terraform apply -var="bucket_name=<logical-name>"
 ```
-Then `uvx --from llm-evaluation-system eval-mcp init <bucket-name>` — `init` probes the bucket and persists its region, so cross-region uploads work without any extra setup. Tell the user: teammates just run `eval-mcp init <bucket-name>` — no Terraform needed.
+The Terraform module appends the caller's AWS account ID, so the actual bucket created is `<logical-name>-<account-id>` — globally unique, no name collisions with other teams using the same example. The full name is printed under the `bucket_name` Terraform output.
 
-Suggested bucket name if they don't have a preference: `eval-mcp-$(aws sts get-caller-identity --query Account --output text)` — globally unique, easy to remember.
+Then `uvx --from llm-evaluation-system eval-mcp init <logical-name>` — `init` probes both the literal name and the account-suffixed name, persists whichever exists along with its region. Tell the user: teammates run `eval-mcp init <logical-name>` from the same AWS account — no Terraform needed.
 
-If **no**: skip. They can enable it later with `eval-mcp init <bucket>`.
+Suggested logical name if they don't have a preference: `<team>-evals` (e.g. `growth-evals`, `platform-evals`). The account-ID suffix makes it unique without the user having to think about uniqueness.
+
+If **no**: skip. They can enable it later with `eval-mcp init <logical-name>`.
 
 ## Fallback: manual per-IDE install
 

--- a/eval_mcp/cli.py
+++ b/eval_mcp/cli.py
@@ -209,6 +209,38 @@ def _detect_bucket_region(bucket: str):
         return None
 
 
+def _get_account_id():
+    """Caller's AWS account ID, or None if STS is unreachable."""
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    try:
+        return boto3.client("sts").get_caller_identity()["Account"]
+    except (BotoCoreError, ClientError, KeyError):
+        return None
+
+
+def _resolve_bucket(name: str):
+    """Resolve a logical bucket name to (actual_name, region).
+
+    Tries the literal name first (existing buckets, custom names), then falls
+    back to `<name>-<account-id>` — the convention produced by this repo's
+    Terraform module. Returns (None, None) if neither exists.
+    """
+    region = _detect_bucket_region(name)
+    if region:
+        return name, region
+
+    account_id = _get_account_id()
+    if account_id and not name.endswith(f"-{account_id}"):
+        suffixed = f"{name}-{account_id}"
+        region = _detect_bucket_region(suffixed)
+        if region:
+            return suffixed, region
+
+    return None, None
+
+
 @main.command()
 @click.argument("bucket")
 def init(bucket):
@@ -220,24 +252,27 @@ def init(bucket):
     """
     from eval_mcp.config import set_config_value, get_user
 
-    region = _detect_bucket_region(bucket)
-    if not region:
+    resolved, region = _resolve_bucket(bucket)
+    if not resolved:
         click.echo(
-            f"Could not reach s3://{bucket} — check the bucket name and your "
-            "AWS credentials (aws sts get-caller-identity).",
+            f"Could not reach s3://{bucket} (or s3://{bucket}-<account-id>) — "
+            "check the bucket name and your AWS credentials "
+            "(aws sts get-caller-identity).",
             err=True,
         )
         sys.exit(1)
 
-    set_config_value("bucket", bucket)
+    set_config_value("bucket", resolved)
     set_config_value("region", region)
     user = get_user()
     click.echo(f"Configured S3 sharing:")
-    click.echo(f"  bucket: {bucket}")
+    click.echo(f"  bucket: {resolved}")
+    if resolved != bucket:
+        click.echo(f"          (resolved from '{bucket}' via account-ID suffix)")
     click.echo(f"  region: {region}")
     click.echo(f"  user:   {user} (auto-detected from AWS identity)")
-    click.echo(f"\nLogs will sync to s3://{bucket}/users/{user}/")
-    click.echo(f"Shared projects auto-discovered from s3://{bucket}/projects/*/")
+    click.echo(f"\nLogs will sync to s3://{resolved}/users/{user}/")
+    click.echo(f"Shared projects auto-discovered from s3://{resolved}/projects/*/")
 
 
 @main.command()

--- a/infra/modules/eval-logs-bucket/main.tf
+++ b/infra/modules/eval-logs-bucket/main.tf
@@ -8,11 +8,16 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+# S3 bucket names are globally unique. Suffix with the caller's AWS account ID
+# so the same logical `bucket_name` (e.g. "my-team-evals") produces a unique
+# bucket per account — no random suffixes, no README copy-paste collisions.
 module "eval_logs_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 4.0"
 
-  bucket = var.bucket_name
+  bucket = "${var.bucket_name}-${data.aws_caller_identity.current.account_id}"
 
   block_public_acls       = true
   block_public_policy     = true

--- a/infra/modules/eval-logs-bucket/variables.tf
+++ b/infra/modules/eval-logs-bucket/variables.tf
@@ -1,5 +1,5 @@
 variable "bucket_name" {
-  description = "Name for the S3 bucket that stores eval logs"
+  description = "Logical name for the S3 bucket. The module appends the caller's AWS account ID to guarantee global uniqueness — final bucket is <bucket_name>-<account_id>."
   type        = string
 }
 


### PR DESCRIPTION
## Summary

- Terraform module now suffixes the bucket name with the caller's AWS account ID — same `bucket_name` input produces a globally-unique bucket per account. No random suffixes, no copy-paste collisions on the README example.
- `eval-mcp init <name>` resolves the suffixed name transparently: probes the literal name first (backwards-compat + custom names), falls back to `<name>-<account-id>`. Persists whichever exists.
- README + INSTALL.md updated to show that the actual bucket created is `<name>-<account-id>` and the user-facing command remains `eval-mcp init <name>`.

## Why

S3 bucket names are globally unique across all of AWS. The README and INSTALL.md both used `my-team-evals` as a literal name across every example — `terraform apply`, the `s3://my-team-evals/` layout diagram, and the `eval-mcp init` command. The first reader to follow the README literally claimed the name forever; everyone after got `BucketAlreadyExists` with no path to recover (name uniqueness is global, not regional).

Auto-suffixing with the account ID is the canonical AWS pattern for shareable modules — deterministic, no Terraform state for a random suffix to drift on, and invisible to the user since the same logical name they type maps 1:1 to the bucket in their account.

## Test plan

- [x] Unit-tested `_resolve_bucket` for 5 cases: literal exists, literal missing + suffix exists, neither exists, STS unreachable, user passes already-suffixed name (no double-suffix).
- [ ] Manual: `terraform apply -var="bucket_name=test-evals"` from an account with ID `123456789012` → verify bucket created is `test-evals-123456789012`.
- [ ] Manual: `eval-mcp init test-evals` from the same account → verify config.json gets `"bucket": "test-evals-123456789012"`.
- [ ] Manual: pre-existing literal-name bucket → `eval-mcp init <literal>` still resolves to it (backwards compat).

Follow-up to #78 (region auto-detection).