### PR TITLE
feat(infra): add create-bucket.sh wrapper with AWS_PROFILE prompt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,13 +39,14 @@ If **yes, team already has a bucket**:
 uvx --from llm-evaluation-system eval-mcp init <bucket-name>
 ```
 
-If **yes, creating a new bucket** (first on the team). Prereq: AWS credentials configured — verify with `aws sts get-caller-identity` before running terraform.
+If **yes, creating a new bucket** (first on the team):
 ```bash
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/eval-logs-bucket
-terraform init
-terraform apply -var="bucket_name=<logical-name>" -var="region=us-west-2"
+./create-bucket.sh <logical-name>
 ```
+The script prompts for an AWS profile if one isn't set, validates credentials, then runs `terraform init` + `apply`. Mirrors the `deploy.sh` / `destroy.sh` pattern — no surprise credential errors from terraform itself.
+
 The Terraform module appends the caller's AWS account ID, so the actual bucket created is `<logical-name>-<account-id>` — globally unique, no name collisions with other teams using the same example. The full name is printed under the `bucket_name` Terraform output.
 
 Then `uvx --from llm-evaluation-system eval-mcp init <logical-name>` — `init` probes both the literal name and the account-suffixed name, persists whichever exists along with its region. Tell the user: teammates run `eval-mcp init <logical-name>` from the same AWS account — no Terraform needed.

--- a/README.md
+++ b/README.md
@@ -92,16 +92,15 @@ Share datasets, judges, configs, and eval results across your team via a shared 
 
 ### Setup
 
-**First on the team — creating the bucket?** One person runs this once.
-
-Prereq: AWS credentials configured (`aws configure`, `AWS_PROFILE`, or env vars — verify with `aws sts get-caller-identity`).
+**First on the team — creating the bucket?** One person runs this once:
 
 ```bash
 git clone https://github.com/awslabs/llm-evaluation-system.git
 cd llm-evaluation-system/infra/eval-logs-bucket
-terraform init
-terraform apply -var="bucket_name=my-team-evals" -var="region=us-west-2"
+./create-bucket.sh my-team-evals
 ```
+
+The script prompts for an AWS profile if one isn't already set (mirrors `deploy.sh` / `destroy.sh`), validates credentials with `sts get-caller-identity`, then runs `terraform init` + `apply`. Works with SSO profiles — it'll tell you to run `aws sso login --profile <name>` if your session expired.
 
 The Terraform module appends your AWS account ID so the actual bucket is `my-team-evals-<your-account-id>` — globally unique without you having to invent a unique name. Terraform prints the full name under the `bucket_name` output.
 

--- a/eval_mcp/INSTALL.md
+++ b/eval_mcp/INSTALL.md
@@ -39,13 +39,14 @@ If **yes, team already has a bucket**:
 uvx --from llm-evaluation-system eval-mcp init <bucket-name>
 ```
 
-If **yes, creating a new bucket** (first on the team). Prereq: AWS credentials configured — verify with `aws sts get-caller-identity` before running terraform.
+If **yes, creating a new bucket** (first on the team):
 ```bash
 git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
 cd /tmp/eval-mcp-infra/infra/eval-logs-bucket
-terraform init
-terraform apply -var="bucket_name=<logical-name>" -var="region=us-west-2"
+./create-bucket.sh <logical-name>
 ```
+The script prompts for an AWS profile if one isn't set, validates credentials, then runs `terraform init` + `apply`. Mirrors the `deploy.sh` / `destroy.sh` pattern — no surprise credential errors from terraform itself.
+
 The Terraform module appends the caller's AWS account ID, so the actual bucket created is `<logical-name>-<account-id>` — globally unique, no name collisions with other teams using the same example. The full name is printed under the `bucket_name` Terraform output.
 
 Then `uvx --from llm-evaluation-system eval-mcp init <logical-name>` — `init` probes both the literal name and the account-suffixed name, persists whichever exists along with its region. Tell the user: teammates run `eval-mcp init <logical-name>` from the same AWS account — no Terraform needed.

--- a/infra/eval-logs-bucket/create-bucket.sh
+++ b/infra/eval-logs-bucket/create-bucket.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Create the eval-mcp team-sharing S3 bucket.
+#
+# Wraps `terraform init` + `terraform apply` with the same AWS_PROFILE +
+# region prompts as deploy.sh / destroy.sh / manage-users.sh, so users
+# (especially SSO users) don't hit cryptic "No valid credential sources
+# found" errors from terraform itself.
+#
+# Usage:
+#   ./create-bucket.sh                    # prompts for everything missing
+#   ./create-bucket.sh my-team-evals      # uses given logical name
+#   AWS_PROFILE=foo ./create-bucket.sh    # skips profile prompt
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+#------------------------------------------------------------------------------
+# AWS credentials
+#------------------------------------------------------------------------------
+
+if [ -z "${AWS_PROFILE:-}" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  echo "No AWS_PROFILE set. Available profiles:"
+  aws configure list-profiles 2>/dev/null | sed 's/^/    /'
+  echo ""
+  printf "Enter AWS profile name: "
+  read -r PROFILE_INPUT
+  if [ -z "$PROFILE_INPUT" ]; then
+    echo "ERROR: No profile specified." >&2
+    exit 1
+  fi
+  export AWS_PROFILE="$PROFILE_INPUT"
+fi
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "ERROR: AWS credentials not usable for profile '${AWS_PROFILE:-(default)}'." >&2
+  if [ -n "${AWS_PROFILE:-}" ]; then
+    echo "If using SSO, refresh with: aws sso login --profile $AWS_PROFILE" >&2
+  fi
+  exit 1
+fi
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+IDENTITY_ARN="$(aws sts get-caller-identity --query Arn --output text)"
+
+#------------------------------------------------------------------------------
+# Region
+#------------------------------------------------------------------------------
+
+if [ -z "${AWS_REGION:-}" ]; then
+  AWS_REGION="$(aws configure get region 2>/dev/null || true)"
+fi
+if [ -z "$AWS_REGION" ]; then
+  printf "AWS region for the bucket (e.g. us-west-2): "
+  read -r AWS_REGION
+  if [ -z "$AWS_REGION" ]; then
+    echo "ERROR: No region specified." >&2
+    exit 1
+  fi
+fi
+export AWS_REGION
+
+#------------------------------------------------------------------------------
+# Bucket name
+#------------------------------------------------------------------------------
+
+BUCKET_NAME="${1:-}"
+if [ -z "$BUCKET_NAME" ]; then
+  printf "Logical bucket name (account-ID will be appended) [my-team-evals]: "
+  read -r BUCKET_NAME
+  BUCKET_NAME="${BUCKET_NAME:-my-team-evals}"
+fi
+
+#------------------------------------------------------------------------------
+# Plan + apply
+#------------------------------------------------------------------------------
+
+echo ""
+echo "Plan:"
+echo "  Profile:    ${AWS_PROFILE:-(env credentials)}"
+echo "  Identity:   $IDENTITY_ARN"
+echo "  Region:     $AWS_REGION"
+echo "  Bucket:     ${BUCKET_NAME}-${ACCOUNT_ID}"
+echo ""
+
+terraform init -upgrade
+terraform apply -var="bucket_name=$BUCKET_NAME" -var="region=$AWS_REGION"
+
+echo ""
+echo "Done. Next: uvx --from llm-evaluation-system eval-mcp init $BUCKET_NAME"


### PR DESCRIPTION
## Summary

- New `infra/eval-logs-bucket/create-bucket.sh` wrapper that prompts for `AWS_PROFILE` if one isn't set, validates credentials via `sts get-caller-identity`, and falls through to `terraform init` + `apply`.
- README + INSTALL.md (both) now point at the script. Raw terraform commands still work for anyone who prefers them.

## Why

Even after #82 fixed the missing provider block, users (especially SSO users) still hit:

```
Error: No valid credential sources found
  failed to refresh cached credentials, no EC2 IMDS role found
```

because `aws sso login --profile <name>` only refreshes a profile's cached token — it doesn't tell terraform to use that profile. Terraform falls back to the default credential chain, finds nothing, and errors out.

The repo already solves this for the web-app deployment in `deploy.sh` / `destroy.sh` / `manage-users.sh` — they prompt for a profile when none is set, list available ones via `aws configure list-profiles`, and validate. This PR applies the same pattern to the bucket-creation flow so the two paths feel consistent.

## What the script does

1. If `AWS_PROFILE` and `AWS_ACCESS_KEY_ID` are both empty → list profiles, prompt for one, export it.
2. `aws sts get-caller-identity` → on failure, suggest `aws sso login --profile <name>` if a profile is set.
3. If `AWS_REGION` and `aws configure get region` are both empty → prompt for one.
4. Logical bucket name from `$1` or prompt (default: `my-team-evals`).
5. Print a `Plan:` block (profile, identity, region, final bucket name) before applying.
6. `terraform init -upgrade && terraform apply -var=...`.

## Test plan

- [ ] Manual: no AWS_PROFILE set → prompts, picks profile, applies cleanly.
- [ ] Manual: stale SSO session → prints the `aws sso login --profile <name>` hint instead of terraform's cryptic error.
- [ ] Manual: AWS_PROFILE already set → skips prompt, goes straight to apply.

Follow-up to #82.