### PR TITLE
fix(init): pick an AWS profile automatically so SSO just works

### DIFF
--- a/eval_mcp/cli.py
+++ b/eval_mcp/cli.py
@@ -317,6 +317,58 @@ def _init_error_message(bucket: str, error: str) -> str:
     )
 
 
+def _list_aws_profiles():
+    """Available AWS profiles, or [] if `aws` CLI isn't installed."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["aws", "configure", "list-profiles"],
+            capture_output=True, text=True, check=True,
+        )
+        return [p for p in result.stdout.splitlines() if p.strip()]
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+
+def _ensure_aws_profile():
+    """Pick an AWS profile if none is set. Mirrors deploy.sh / create-bucket.sh.
+
+    boto3's credential chain only reads SSO config from the profile named
+    by AWS_PROFILE (or the `default` profile) — it won't scan ~/.aws/config
+    for SSO-configured profiles. So if the user has SSO set up but no
+    AWS_PROFILE exported, boto3 finds nothing even though their SSO token
+    is cached and valid.
+
+    Detect that case, list profiles, auto-pick if there's one, prompt if
+    many. Sets os.environ["AWS_PROFILE"] so subsequent boto3 clients
+    inherit it.
+    """
+    import os
+    if os.environ.get("AWS_PROFILE") or os.environ.get("AWS_ACCESS_KEY_ID"):
+        return
+
+    profiles = _list_aws_profiles()
+    if not profiles:
+        click.echo(
+            "No AWS credentials in this shell and no profiles configured.\n"
+            "  • SSO: aws configure sso\n"
+            "  • Access keys: aws configure",
+            err=True,
+        )
+        sys.exit(1)
+
+    if len(profiles) == 1:
+        os.environ["AWS_PROFILE"] = profiles[0]
+        click.echo(f"Using AWS profile: {profiles[0]}")
+        return
+
+    click.echo("AWS profiles available:")
+    for p in profiles:
+        click.echo(f"  {p}")
+    picked = click.prompt("Pick a profile", type=click.Choice(profiles), show_choices=False)
+    os.environ["AWS_PROFILE"] = picked
+
+
 @main.command()
 @click.argument("bucket")
 def init(bucket):
@@ -327,6 +379,8 @@ def init(bucket):
         eval-mcp init my-team-evals
     """
     from eval_mcp.config import set_config_value, get_user
+
+    _ensure_aws_profile()
 
     resolved, region, error = _resolve_bucket(bucket)
     if not resolved:


### PR DESCRIPTION
## Summary

`eval-mcp init` now ports the AWS-profile-picking flow that already exists in `deploy.sh` / `destroy.sh` / `create-bucket.sh` into the Python CLI. If `AWS_PROFILE` and `AWS_ACCESS_KEY_ID` are both unset, it lists configured profiles, auto-picks if there's exactly one, prompts otherwise. SSO users no longer need to remember `export AWS_PROFILE` in every shell.

## Why

Root cause of SSO failures: boto3's credential chain has an `sso` provider, but it only reads from the *one* profile named by `AWS_PROFILE` (or `default`). It does **not** scan `~/.aws/config` for any profile that has SSO configured.

So a user who has done `aws sso login --profile terraform-datagomes` (cached SSO token in `~/.aws/sso/cache/`) still gets `NoCredentialsError` from `eval-mcp init` if `AWS_PROFILE` isn't exported in that shell — even though the SSO session is perfectly valid and `aws s3 ls --profile terraform-datagomes` works fine from the same shell.

Our shell scripts (`deploy.sh`, `destroy.sh`, `manage-users.sh`, `create-bucket.sh`) all handle this by prompting for a profile when none is set. This PR brings the Python CLI to parity.

## What it does

```
$ eval-mcp init my-team-evals
AWS profiles available:
  default
  terraform-datagomes
  staging
Pick a profile: terraform-datagomes
Configured S3 sharing:
  bucket: my-team-evals-406969672799
  region: us-west-2
  user:   andregomes (auto-detected from AWS identity)
```

If exactly one profile exists → auto-uses it (`Using AWS profile: <name>`).
If zero profiles → exits with a hint pointing at `aws configure sso` or `aws configure`.
If the picked profile's SSO token is stale → the existing PR #84 routing surfaces `expired` with `aws sso login --profile $AWS_PROFILE`.

## Test plan

- [x] Unit-tested 6 cases: AWS_PROFILE already set (no-op), AWS_ACCESS_KEY_ID set (no-op), zero profiles (exit), one profile (auto-pick), `aws` not installed (graceful), `aws` exits non-zero (graceful).
- [ ] Manual SSO: `unset AWS_PROFILE && aws sso login --profile X && eval-mcp init my-team-evals` from a fresh shell → succeeds without exporting AWS_PROFILE.
- [ ] Manual env-creds path: `AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... eval-mcp init ...` → skips profile prompt, uses env creds.

Follow-up to #84. Closes the loop on the SSO failure mode the user kept hitting.