### PR TITLE
docs(readme): clone to a fixed target so re-runs don't nest

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Share datasets, judges, configs, and eval results across your team via a shared 
 **First on the team — creating the bucket?** One person runs this once:
 
 ```bash
-git clone https://github.com/awslabs/llm-evaluation-system.git
-cd llm-evaluation-system/infra/eval-logs-bucket
+git clone https://github.com/awslabs/llm-evaluation-system.git /tmp/eval-mcp-infra
+cd /tmp/eval-mcp-infra/infra/eval-logs-bucket
 ./create-bucket.sh my-team-evals
 ```
 


### PR DESCRIPTION
## Summary

One-line change to `README.md:98` — clone to `/tmp/eval-mcp-infra` instead of the implicit current directory, matching what `INSTALL.md` and `eval_mcp/INSTALL.md` already do.

## Why

`git clone https://...` with no target creates `./llm-evaluation-system` in the user's current shell directory. If they retry the README block from inside the previous clone (common after the first attempt errored out), the new clone lands inside the previous one. A real user reported their cwd reaching this:

```
.../llm-evaluation-system/llm-evaluation-system/infra/.../llm-evaluation-system/infra/eval-logs-bucket/llm-evaluation-system/infra/eval-logs-bucket
```

— seven stacked clones, all from following the README block multiple times.

The two `INSTALL.md` copies (which agents read) already use `/tmp/eval-mcp-infra` and don't have this problem. This brings the human-facing README to parity.

## Effect

After this change, re-running the block either:
- succeeds (the temp dir was cleaned up), or
- fails loudly with git's `destination path '/tmp/eval-mcp-infra' already exists` — clear, recoverable.

No more silent nesting.

## Test plan

- [x] Diff is one block, two lines.
- [ ] Manual: from a fresh shell, follow README → bucket created at `/tmp/eval-mcp-infra/infra/eval-logs-bucket`. Re-run from inside that directory → git errors out instead of nesting.