### PR TITLE
docs: ARCHITECTURE.md + CLAUDE.md rewrite + DEVELOPMENT.md cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,273 @@
+# Architecture
+
+Three diagrams covering the three distinct ways code in this repo runs:
+
+1. **[Eval execution](#1-eval-execution)** — what actually happens when a user says "evaluate this." End-to-end from MCP tool call through Inspect AI, Bedrock, the jury of judges, and back into the viewer.
+2. **[MCP server](#2-mcp-server)** — how the `eval-mcp` package is wired: transports, tool surface, storage, the local viewer, optional S3 team sharing.
+3. **[EKS deployment](#3-eks-deployment)** — the optional multi-user web app: CloudFront → ALB → backend pod (with the MCP as a K8s native sidecar) → S3/RDS.
+
+The MCP package (`eval_mcp/`) and the EKS web app (`backend/` + `frontend/` + `helm/` + `infra/`) are independently deployable. The web app embeds the MCP as a sidecar in the backend pod — that's the one place the two intersect.
+
+---
+
+## 1. Eval execution
+
+```mermaid
+flowchart TB
+    subgraph User["User session (IDE or web chat)"]
+        IDE["Coding agent<br/>(Claude Code, Cursor, Kiro, ...)"]
+    end
+
+    subgraph MCP["eval-mcp server (stdio or HTTP)"]
+        Tools["MCP tools<br/>list_bedrock_models<br/>generate_qa_pairs<br/>generate_judge<br/>create_eval_config<br/>run_evaluation"]
+    end
+
+    subgraph Storage["User dir ~/.eval-mcp/users/&lt;user&gt;/"]
+        Configs["configs/&lt;name&gt;.py<br/>configs/&lt;name&gt;.json"]
+        Datasets["datasets/"]
+        Judges["judges/"]
+        Logs["logs/&lt;eval_id&gt;.eval<br/>logs/raw_otel/*.jsonl"]
+    end
+
+    subgraph Inspect["Inspect AI subprocess<br/>(python -m inspect_ai eval)"]
+        Task["Task: samples × target models"]
+        Solver["Solver<br/>standard: call target model directly<br/>agent: spawn agent subprocess"]
+        Scorer["Jury scorer<br/>N judge models score each sample<br/>binary per-criterion, majority vote"]
+    end
+
+    subgraph Capture["Agent-eval capture path"]
+        AgentProc["Agent subprocess<br/>(user's agent_path)"]
+        OTLP["In-harness OTLP receiver<br/>(eval_mcp/otlp_receiver.py)"]
+    end
+
+    Bedrock[("AWS Bedrock<br/>(target + judge models)")]
+    Viewer["Local viewer :4001<br/>eval_mcp/viewer.py + viewer_static/"]
+    Report["PDF report<br/>generate_report"]
+
+    IDE -->|"tool call"| Tools
+    Tools -->|"writes"| Configs
+    Tools -->|"writes"| Datasets
+    Tools -->|"writes"| Judges
+
+    Tools -->|"spawn (asyncio.create_subprocess_exec)"| Inspect
+    Inspect --> Task
+    Task --> Solver
+    Solver -->|"standard eval"| Bedrock
+    Solver -->|"agent eval: spawn"| AgentProc
+    AgentProc -->|"OTEL_EXPORTER_OTLP_ENDPOINT"| OTLP
+    AgentProc -->|"instrumented Bedrock calls"| Bedrock
+    OTLP -->|"spans → ModelEvents"| Solver
+    Solver --> Scorer
+    Scorer -->|"each judge calls Bedrock<br/>per criterion"| Bedrock
+    Scorer -->|"writes .eval log"| Logs
+
+    Tools -->|"read .eval log"| Logs
+    Tools --> Report
+    Logs --> Viewer
+    IDE -->|"open browser"| Viewer
+```
+
+**Tool order in a typical session:** `list_bedrock_models` → `generate_qa_pairs` (from docs or context) → `save_dataset` → `generate_judge` → `create_eval_config` → `run_evaluation` → `generate_report`. The agent in the IDE picks the order; the MCP just exposes the tools.
+
+**Why subprocess isolation.** `run_evaluation` shells out to `python -m inspect_ai eval` rather than calling Inspect in-process. A cancelled or crashed eval can't take down the MCP, and the subprocess gets a fresh interpreter so OTel instrumentation can be installed cleanly per run.
+
+**How agent evals capture Bedrock calls.** For `agent_path` configs, the solver spawns the agent as a subprocess with `opentelemetry-instrument` autoloaded (via `opentelemetry-distro`) and `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at an in-process OTLP receiver inside the Inspect subprocess. The agent's Bedrock calls emit spans → receiver → ModelEvents in the `.eval` log. A pre-flight canary in `eval_mcp/canary.py` exercises this path once before the real eval, so a broken capture pipeline fails loudly instead of returning `success=true, scores=[]`. Raw spans are also appended to `logs/raw_otel/<eval_id>.jsonl` as cold storage in case the projection ever drops data.
+
+**Jury scoring.** Multiple judges from different model families (default in `eval_mcp/core/judge_config.py`) each score every sample binary-per-criterion. `backend/core/jury_scoring.py` aggregates: majority vote per criterion, then sample passes if all criteria pass. This is more reliable than single-judge numeric scales ([Mallinar et al., 2025](https://arxiv.org/abs/2503.23339v2)) and reduces self-preference bias ([Lifshitz et al., 2025](https://arxiv.org/abs/2502.20379)).
+
+---
+
+## 2. MCP server
+
+```mermaid
+flowchart TB
+    subgraph Clients["Clients"]
+        CC["Claude Code / Cursor / Kiro / VS Code / Codex<br/>(stdio)"]
+        Remote["Remote agent / EKS backend<br/>(streamable HTTP)"]
+    end
+
+    subgraph Process["eval-mcp process"]
+        CLI["eval_mcp/cli.py<br/>(click group)"]
+        Server["eval_mcp/server.py<br/>FastMCP('eval-server')"]
+
+        subgraph ToolMods["eval_mcp/tools/"]
+            T1["dataset: generate_qa, save_dataset, list_datasets"]
+            T2["judge: generate_judge, list_judges"]
+            T3["config: create_eval_config, create_agent_eval_config"]
+            T4["run: run_evaluation, retry_evaluation, optimize_prompt"]
+            T5["read: list_evaluations, get_evaluation_details, analyze_*"]
+            T6["report: generate_report"]
+        end
+
+        subgraph Core["eval_mcp/core/"]
+            Bed["bedrock_client.py<br/>cross-region + API-key auth"]
+            UStore["user_storage.py<br/>get_user_dir / get_user_log_dir"]
+            Pricing["pricing.py + provider_pricing.json"]
+            Jury["judge_config.py"]
+        end
+
+        Sub["subprocess_runner.py<br/>+ _agent_launcher.py<br/>(spawns inspect-ai)"]
+        OTLP2["otlp_receiver.py +<br/>bedrock_capture.py"]
+        S3Sync["s3_sync.py<br/>(replicate_async, auto_pull,<br/>sync_up/down/to_project)"]
+        Viewer2["viewer.py<br/>FastAPI on :4001<br/>serves viewer_static/"]
+
+        Installers["installers/<br/>claude_code, codex, cursor, kiro, vscode"]
+    end
+
+    UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs<br/>USER_STORAGE_BASE overrides")]
+    BedrockSvc[("AWS Bedrock")]
+    S3Bucket[("S3 team bucket<br/>(optional)<br/>users/&lt;you&gt;/, projects/&lt;name&gt;/")]
+    Browser["Browser"]
+
+    CC -->|"JSON-RPC over stdio"| Server
+    Remote -->|"streamable_http_app"| Server
+    CLI -->|"no subcommand → run server"| Server
+    CLI -->|"eval-mcp install"| Installers
+    CLI -->|"eval-mcp init &lt;bucket&gt;"| S3Sync
+    CLI -->|"eval-mcp view"| Viewer2
+    CLI -->|"eval-mcp sync / share"| S3Sync
+
+    Server --> ToolMods
+    ToolMods --> Core
+    ToolMods --> Sub
+    Sub -.->|"OTel spans"| OTLP2
+    Core --> BedrockSvc
+    ToolMods <--> UserDir
+    UserDir -.->|"auto-replicate on write"| S3Sync
+    S3Sync <--> S3Bucket
+    UserDir -.->|"auto-pull on list/read (debounced)"| S3Sync
+
+    Viewer2 --> UserDir
+    Browser --> Viewer2
+```
+
+**Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.
+
+**Tool registration.** Every tool is registered in `server.py` with a typed signature and an annotation preset (`READ_LOCAL`, `READ_REMOTE`, `CREATE_LOCAL`, `CREATE_REMOTE`, `RUN_REMOTE`). The docstring on the registered function is the description the LLM sees — keep it specific about ID formats, prerequisites, and failure modes.
+
+**Storage.** All persistent state lives under `~/.eval-mcp/users/<user>/` (overridable via `USER_STORAGE_BASE` — the EKS deployment sets this to `/data/users` on an emptyDir mount). Filesystem layout per user: `configs/`, `datasets/`, `judges/`, `logs/`. `EVAL_MCP_USER` (default `local`) selects the user namespace for standalone runs.
+
+**Team sharing.** `eval-mcp init <bucket>` writes the bucket to local config; from then on every write fires `replicate_async` into a thread pool, and every list/read calls `auto_pull` (debounced by TTL) so local state mirrors S3. Account-ID suffix is auto-resolved so teammates type the same short name. Bucket region is auto-detected via `head_bucket` even on cross-region 301 redirects.
+
+**Viewer.** `eval-mcp view` boots a FastAPI app that serves the pre-built Next.js export from `eval_mcp/viewer_static/`. The static bundle is package data per `pyproject.toml`, so rebuilding the frontend (`npm run build:viewer`) affects the published wheel.
+
+**Installers.** `eval_mcp/installers/` has one module per IDE. The dispatcher in `cli.py:install` auto-detects which IDEs are present, asks which to register, and writes the right config in each (JSON merge for Claude Code / Cursor / VS Code / Kiro, TOML round-trip for Codex via `tomlkit` so user comments survive).
+
+---
+
+## 3. EKS deployment
+
+The optional multi-user web app — Cognito-auth'd chat UI for non-technical users. Two Terraform layers with independent state; `deploy.sh` orchestrates both.
+
+```mermaid
+flowchart TB
+    User["User browser"]
+
+    subgraph Edge["AWS edge"]
+        CF["CloudFront (HTTPS)<br/>HTTP/2+3"]
+        WAF["WAF<br/>rate-limit 2000 req/5min<br/>AWS managed rules"]
+        VPCOrigin["VPC Origin<br/>(private AWS network)"]
+    end
+
+    Cognito["Cognito User Pool<br/>admin-signup + optional OIDC IdP"]
+
+    subgraph VPC["VPC (infra/data) — 10.0.0.0/16"]
+        ALB["Internal ALB<br/>(not internet-facing)"]
+        S3End["S3 VPC Endpoint"]
+
+        subgraph EKS["EKS cluster (infra/platform)"]
+            direction TB
+            OAuth["oauth2-proxy<br/>:4180"]
+
+            subgraph BackendPod["Pod: backend"]
+                BE["backend container<br/>FastAPI :8080"]
+                EvalSidecar["eval-mcp sidecar<br/>HTTP :8002<br/>(K8s 1.28+ native sidecar)"]
+                Eph["emptyDir /data<br/>USER_STORAGE_BASE=/data/users"]
+            end
+
+            subgraph FrontendPod["Pod: frontend"]
+                FE["Next.js :3000"]
+            end
+
+            Karp["Karpenter<br/>arm64 c/m/r/t medium-xl"]
+            ESO["External Secrets Operator<br/>+ Pod Identity"]
+        end
+    end
+
+    subgraph DataLayer["infra/data (persistent)"]
+        RDS[("RDS Postgres<br/>chat history<br/>IAM auth")]
+        S3Docs[("S3 documents bucket<br/>user uploads")]
+        S3Data[("S3 data bucket<br/>configs, datasets, judges,<br/>logs, periodic JSON backup")]
+    end
+
+    subgraph CICD["Image pipeline (infra/platform)"]
+        CB["CodeBuild<br/>(ARM64 build)"]
+        ECR[("ECR<br/>backend + frontend images")]
+        SrcS3[("S3 source bucket")]
+    end
+
+    SM[("Secrets Manager<br/>Cognito client + cookie + DB IAM")]
+    BedrockSvc2[("AWS Bedrock<br/>multi-region inference<br/>+ CloudWatch logging")]
+
+    User -->|"HTTPS"| CF
+    CF --> WAF
+    WAF --> VPCOrigin
+    VPCOrigin --> ALB
+
+    ALB -->|"/oauth2/*, protected routes"| OAuth
+    ALB -->|"/api/*"| BE
+    ALB -->|"/viewer/*"| BE
+    ALB -->|"/*"| FE
+    OAuth -.->|"login redirect"| Cognito
+    Cognito -.->|"OIDC"| OAuth
+
+    BE <-->|"http://localhost:8002/mcp"| EvalSidecar
+    BE --> Eph
+    EvalSidecar --> Eph
+    BE -->|"chat history"| RDS
+    BE -->|"user uploads"| S3Docs
+    EvalSidecar -->|"durable state +<br/>periodic backup"| S3Data
+    EvalSidecar -->|"target + judge calls"| BedrockSvc2
+
+    Eph -.->|"ephemeral; lost on pod restart"| Eph
+    S3Data -.->|"S3 VPC endpoint"| S3End
+
+    ESO --> SM
+    SM -.->|"injected as K8s secrets"| BE
+    SM -.->|"injected"| OAuth
+
+    SrcS3 --> CB
+    CB --> ECR
+    ECR -.->|"image pull"| BackendPod
+    ECR -.->|"image pull"| FrontendPod
+
+    Karp -.->|"provisions nodes"| BackendPod
+    Karp -.->|"provisions nodes"| FrontendPod
+```
+
+**Two Terraform layers, independent state.**
+
+- `infra/data/` — VPC (2 AZs, public/private/intra subnets, NAT, S3 VPC endpoint), RDS Postgres (db.t3.micro, 20→100GB, IAM auth), two S3 buckets (documents + data). Survives `./destroy.sh`.
+- `infra/platform/` — EKS 1.34 (2× t4g.medium managed node group), Karpenter for autoscaling, internal ALB, CloudFront + WAF, Cognito (with optional external OIDC IdP), CodeBuild + ECR, ESO + Pod Identity, multi-region Bedrock logging (`us-west-2`, `us-east-1`, `us-east-2`). Destroyed and recreated by deploy/destroy.
+
+Layers connect via `-var=` flags (not `terraform_remote_state`) so platform state never sees data-state secrets. `deploy.sh` reads ~13 data outputs and passes them in explicitly.
+
+**Why the ALB is internal.** Only CloudFront can reach it, via [VPC Origins](https://aws.amazon.com/cloudfront/vpc-origins/) over the AWS private network. The internet never sees the ALB directly — defense in depth on top of WAF.
+
+**Why backend is stateless.** `helm/eval/templates/pvc.yaml` is intentionally empty (see its comment). All durable state goes to S3; pod-local `/data` is `emptyDir`, lost on restart. Chat history is in RDS. This means a pod restart is harmless and HPA scaling Just Works — different from the old EBS-PVC design referenced in some older docs.
+
+**MCP as a sidecar.** The backend Deployment runs two containers in one Pod: `backend` (FastAPI) and `eval-mcp` (HTTP transport on :8002, declared as a K8s 1.28+ native sidecar via `initContainers` with `restartPolicy: Always`). Backend reaches the MCP at `http://localhost:8002/mcp` (the `EVAL_MCP_URL` env var). They share the `/data` emptyDir, so anything the MCP writes is visible to the backend in the same pod.
+
+**Ingress routes** (per `infra/platform/alb.tf` + Helm values):
+
+| Path                  | Service         | Auth                |
+|-----------------------|-----------------|---------------------|
+| `/`, `/_next/*`       | frontend        | public              |
+| `/api/auth/*`         | frontend        | public (NextAuth)   |
+| `/api/*`              | backend         | oauth2-proxy        |
+| `/viewer/*`           | backend         | oauth2-proxy        |
+| `/health`             | backend         | public              |
+| `/oauth2/*`           | oauth2-proxy    | public              |
+| everything else       | frontend        | oauth2-proxy        |
+
+**Secrets.** Everything sensitive is in Secrets Manager; External Secrets Operator syncs it into K8s Secrets via Pod Identity. Database auth uses RDS IAM tokens — no static passwords anywhere.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,53 +58,39 @@ flowchart TB
 
 ## 2. MCP server
 
-Two distinct user workflows live in the `eval-mcp` package:
-
-- **Running evals** — the IDE (or a remote agent) talks to the MCP server, which exposes tools that read/write the user dir, call Bedrock, and spawn Inspect AI for actual evaluation runs.
-- **Viewing results** — the user runs `eval-mcp view` to start a *separate* local FastAPI process that serves a results UI on `localhost:4001`; the user then opens a regular web browser to look at past eval results.
-
-Both processes are part of the same `eval-mcp` package and share the same local user dir on disk — that's how the viewer sees what the server wrote.
-
 ```mermaid
 flowchart TB
-    %% Callers — labeled by intent, not just "browser"
+    %% Callers
     IDE["IDE coding agent<br/>(Claude Code, Cursor, Kiro, ...)"]
     Remote["Remote agent /<br/>EKS backend"]
-    HumanUser["User reviewing results<br/>(in a web browser)"]
 
-    %% MCP server process — spawned by the IDE, or run as eval-mcp serve
+    %% Server process
     subgraph MCPProc["eval-mcp server process"]
         Server["FastMCP server<br/>(eval_mcp/server.py)"]
         Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
         Server --> Tools
     end
 
-    %% Viewer — separate process, only runs while the user wants the UI
-    subgraph ViewerProc["eval-mcp view process (separate)"]
-        Viewer["FastAPI on :4001<br/>+ static results frontend"]
-    end
-
-    %% Local storage + spawned subprocess
+    %% Local
     UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, eval logs")]
     Inspect["Inspect AI subprocess<br/>(spawned per eval)"]
 
-    %% External services
+    %% External
     Bedrock[("AWS Bedrock")]
     S3[("Team S3 bucket<br/>(optional)")]
 
     %% Flow
     IDE -->|"JSON-RPC over stdio"| Server
     Remote -->|"streamable HTTP"| Server
-    HumanUser -->|"opens http://localhost:4001"| Viewer
 
     Tools <-->|"read/write"| UserDir
     Tools -->|"generate_qa, generate_judge,<br/>analyze_*"| Bedrock
     Tools -->|"run_evaluation only"| Inspect
 
-    Viewer -->|"reads eval logs<br/>(viewer is read-only)"| UserDir
-
     UserDir <-.->|"auto-sync after<br/>eval-mcp init"| S3
 ```
+
+**Viewing results.** The viewer is a *separate* local process, not part of the MCP server. After running evals, the user opens a terminal and runs `eval-mcp view`, which starts a FastAPI app on `localhost:4001` that reads the same `~/.eval-mcp/users/<user>/logs/` directory the MCP server wrote into. The user then opens any web browser at `http://localhost:4001` to inspect past evals. No connection to the MCP server itself — they communicate only through the shared user dir on disk.
 
 **Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,17 +14,36 @@ The MCP package (`eval_mcp/`) and the EKS web app (`backend/` + `frontend/` + `h
 
 ```mermaid
 flowchart TB
-    IDE["IDE coding agent"] --> Tools["eval-mcp tools"]
-    Tools -->|"spawn"| Inspect["Inspect AI subprocess"]
-    Inspect --> Solver{"Solver:<br/>standard or agent?"}
-    Solver -->|"standard"| Bedrock[("AWS Bedrock<br/>target + judges")]
-    Solver -->|"agent"| Agent["Agent subprocess<br/>(OTel-instrumented)"]
-    Agent --> Bedrock
-    Agent -.->|"spans via OTLP receiver"| Solver
-    Solver --> Scorer["Jury scorer<br/>N judges, binary per criterion,<br/>majority vote"]
-    Scorer --> Bedrock
-    Scorer --> Log[(".eval log<br/>+ raw OTel JSONL")]
-    Log --> Viewer["Local viewer<br/>+ PDF report"]
+    %% Nodes
+    IDE["IDE coding agent"]
+    Tools["eval-mcp tools"]
+
+    subgraph Inspect["Inspect AI subprocess (per sample)"]
+        direction TB
+        Fork{"Eval type?"}
+        Standard["Standard:<br/>call target model"]
+        Agent["Agent:<br/>spawn subprocess,<br/>OTel-instrumented"]
+        Output["Model output"]
+        Jury["Jury scoring<br/>(N judges, binary per criterion,<br/>majority vote)"]
+    end
+
+    Bedrock[("AWS Bedrock<br/>target + judge models")]
+    Log[(".eval log<br/>+ raw OTel JSONL")]
+    Viewer["Local viewer<br/>+ PDF report"]
+
+    %% Flow
+    IDE --> Tools
+    Tools -->|"spawn"| Inspect
+
+    Fork -->|"standard"| Standard
+    Fork -->|"agent"| Agent
+    Standard --> Output
+    Agent --> Output
+    Output --> Jury
+
+    Inspect -->|"all model calls<br/>(target + judges)"| Bedrock
+    Inspect --> Log
+    Log --> Viewer
 ```
 
 **Tool order in a typical session:** `list_bedrock_models` → `generate_qa_pairs` (from docs or context) → `save_dataset` → `generate_judge` → `create_eval_config` → `run_evaluation` → `generate_report`. The agent in the IDE picks the order; the MCP just exposes the tools.
@@ -41,19 +60,37 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    IDE["IDE<br/>(Claude Code, Cursor, Kiro, ...)"] -->|"stdio"| Server
-    Remote["Remote agent /<br/>EKS backend"] -->|"HTTP"| Server
+    %% Clients
+    IDE["IDE<br/>(Claude Code, Cursor, Kiro, ...)"]
+    Remote["Remote agent /<br/>EKS backend"]
 
-    Server["eval-mcp server<br/>(FastMCP)"] --> Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
+    %% Process
+    Server["eval-mcp server<br/>(FastMCP)"]
+    Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
+    Inspect["Inspect AI subprocess"]
+    Viewer["Local viewer :4001"]
+    Browser["Browser"]
 
-    Tools <--> UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs")]
-    Tools -->|"spawn"| Inspect["Inspect AI subprocess"]
-    Tools --> Bedrock[("AWS Bedrock")]
+    %% Storage
+    UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs")]
 
-    UserDir <-.->|"auto-sync<br/>(optional, eval-mcp init)"| S3[("Team S3 bucket")]
+    %% External
+    Bedrock[("AWS Bedrock")]
+    S3[("Team S3 bucket<br/>(optional)")]
 
-    UserDir --> Viewer["Local viewer :4001"]
-    Browser["Browser"] --> Viewer
+    %% Flow
+    IDE -->|"stdio"| Server
+    Remote -->|"HTTP"| Server
+    Server --> Tools
+
+    Tools <-->|"read/write user state"| UserDir
+    Tools -->|"generate_qa, generate_judge,<br/>analyze_*"| Bedrock
+    Tools -->|"run_evaluation only"| Inspect
+
+    UserDir <-.->|"auto-sync after eval-mcp init"| S3
+
+    Browser --> Viewer
+    Viewer --> UserDir
 ```
 
 **Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.
@@ -76,24 +113,45 @@ The optional multi-user web app — Cognito-auth'd chat UI for non-technical use
 
 ```mermaid
 flowchart TB
-    User["User browser"] -->|"HTTPS"| CF["CloudFront + WAF"]
-    CF -->|"VPC Origin<br/>(private AWS network)"| ALB["Internal ALB"]
-    ALB --> OAuth["oauth2-proxy"]
-    OAuth -.->|"OIDC"| Cognito["Cognito User Pool"]
+    %% Ingress
+    User["User browser"]
+    CF["CloudFront + WAF"]
+    ALB["Internal ALB<br/>(private to VPC)"]
+    OAuth["oauth2-proxy"]
+    Cognito["Cognito User Pool"]
 
-    OAuth --> Frontend["Frontend Pod<br/>(Next.js)"]
-    OAuth --> BackendPod
-
-    subgraph BackendPod["Backend Pod (stateless)"]
-        BE["backend<br/>(FastAPI :8080)"]
-        MCP["eval-mcp sidecar<br/>(HTTP :8002)"]
-        BE <-->|"localhost"| MCP
+    %% Pods (stateless tier)
+    subgraph Pods["EKS pods (stateless)"]
+        Frontend["Frontend Pod<br/>(Next.js)"]
+        subgraph BackendPod["Backend Pod"]
+            BE["backend<br/>(FastAPI :8080)"]
+            MCP["eval-mcp sidecar<br/>(:8002)"]
+            BE <-->|"localhost"| MCP
+        end
     end
 
-    BE --> RDS[("RDS Postgres<br/>chat history")]
-    BE --> S3Docs[("S3 documents<br/>user uploads")]
-    MCP --> S3Data[("S3 data<br/>configs, datasets,<br/>judges, eval logs")]
-    MCP --> Bedrock[("AWS Bedrock")]
+    %% Durable tier
+    subgraph Durable["Durable state"]
+        RDS[("RDS Postgres<br/>chat history")]
+        S3Docs[("S3 documents<br/>user uploads")]
+        S3Data[("S3 data<br/>configs, datasets,<br/>judges, eval logs")]
+    end
+
+    Bedrock[("AWS Bedrock")]
+
+    %% Flow
+    User -->|"HTTPS"| CF
+    CF -->|"VPC Origin<br/>(private network)"| ALB
+    ALB -->|"public paths"| Frontend
+    ALB -->|"protected paths"| OAuth
+    OAuth -.->|"OIDC login"| Cognito
+    OAuth --> Frontend
+    OAuth --> BackendPod
+
+    BE --> RDS
+    BE --> S3Docs
+    MCP --> S3Data
+    MCP --> Bedrock
 ```
 
 **Two Terraform layers, independent state.**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,7 @@ flowchart TB
     %% Local
     UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, eval logs")]
     Inspect["Inspect AI subprocess<br/>(spawned per eval)"]
+    Viewer["Local viewer<br/>(run 'eval-mcp view',<br/>browse :4001)"]
 
     %% External
     Bedrock[("AWS Bedrock")]
@@ -87,10 +88,9 @@ flowchart TB
     Tools -->|"generate_qa, generate_judge,<br/>analyze_*"| Bedrock
     Tools -->|"run_evaluation only"| Inspect
 
+    UserDir --> Viewer
     UserDir <-.->|"auto-sync after<br/>eval-mcp init"| S3
 ```
-
-**Viewing results.** The viewer is a *separate* local process, not part of the MCP server. After running evals, the user opens a terminal and runs `eval-mcp view`, which starts a FastAPI app on `localhost:4001` that reads the same `~/.eval-mcp/users/<user>/logs/` directory the MCP server wrote into. The user then opens any web browser at `http://localhost:4001` to inspect past evals. No connection to the MCP server itself — they communicate only through the shared user dir on disk.
 
 **Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,57 +14,17 @@ The MCP package (`eval_mcp/`) and the EKS web app (`backend/` + `frontend/` + `h
 
 ```mermaid
 flowchart TB
-    subgraph User["User session (IDE or web chat)"]
-        IDE["Coding agent<br/>(Claude Code, Cursor, Kiro, ...)"]
-    end
-
-    subgraph MCP["eval-mcp server (stdio or HTTP)"]
-        Tools["MCP tools<br/>list_bedrock_models<br/>generate_qa_pairs<br/>generate_judge<br/>create_eval_config<br/>run_evaluation"]
-    end
-
-    subgraph Storage["User dir ~/.eval-mcp/users/&lt;user&gt;/"]
-        Configs["configs/&lt;name&gt;.py<br/>configs/&lt;name&gt;.json"]
-        Datasets["datasets/"]
-        Judges["judges/"]
-        Logs["logs/&lt;eval_id&gt;.eval<br/>logs/raw_otel/*.jsonl"]
-    end
-
-    subgraph Inspect["Inspect AI subprocess<br/>(python -m inspect_ai eval)"]
-        Task["Task: samples × target models"]
-        Solver["Solver<br/>standard: call target model directly<br/>agent: spawn agent subprocess"]
-        Scorer["Jury scorer<br/>N judge models score each sample<br/>binary per-criterion, majority vote"]
-    end
-
-    subgraph Capture["Agent-eval capture path"]
-        AgentProc["Agent subprocess<br/>(user's agent_path)"]
-        OTLP["In-harness OTLP receiver<br/>(eval_mcp/otlp_receiver.py)"]
-    end
-
-    Bedrock[("AWS Bedrock<br/>(target + judge models)")]
-    Viewer["Local viewer :4001<br/>eval_mcp/viewer.py + viewer_static/"]
-    Report["PDF report<br/>generate_report"]
-
-    IDE -->|"tool call"| Tools
-    Tools -->|"writes"| Configs
-    Tools -->|"writes"| Datasets
-    Tools -->|"writes"| Judges
-
-    Tools -->|"spawn (asyncio.create_subprocess_exec)"| Inspect
-    Inspect --> Task
-    Task --> Solver
-    Solver -->|"standard eval"| Bedrock
-    Solver -->|"agent eval: spawn"| AgentProc
-    AgentProc -->|"OTEL_EXPORTER_OTLP_ENDPOINT"| OTLP
-    AgentProc -->|"instrumented Bedrock calls"| Bedrock
-    OTLP -->|"spans → ModelEvents"| Solver
-    Solver --> Scorer
-    Scorer -->|"each judge calls Bedrock<br/>per criterion"| Bedrock
-    Scorer -->|"writes .eval log"| Logs
-
-    Tools -->|"read .eval log"| Logs
-    Tools --> Report
-    Logs --> Viewer
-    IDE -->|"open browser"| Viewer
+    IDE["IDE coding agent"] --> Tools["eval-mcp tools"]
+    Tools -->|"spawn"| Inspect["Inspect AI subprocess"]
+    Inspect --> Solver{"Solver:<br/>standard or agent?"}
+    Solver -->|"standard"| Bedrock[("AWS Bedrock<br/>target + judges")]
+    Solver -->|"agent"| Agent["Agent subprocess<br/>(OTel-instrumented)"]
+    Agent --> Bedrock
+    Agent -.->|"spans via OTLP receiver"| Solver
+    Solver --> Scorer["Jury scorer<br/>N judges, binary per criterion,<br/>majority vote"]
+    Scorer --> Bedrock
+    Scorer --> Log[(".eval log<br/>+ raw OTel JSONL")]
+    Log --> Viewer["Local viewer<br/>+ PDF report"]
 ```
 
 **Tool order in a typical session:** `list_bedrock_models` → `generate_qa_pairs` (from docs or context) → `save_dataset` → `generate_judge` → `create_eval_config` → `run_evaluation` → `generate_report`. The agent in the IDE picks the order; the MCP just exposes the tools.
@@ -81,64 +41,19 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    subgraph Clients["Clients"]
-        CC["Claude Code / Cursor / Kiro / VS Code / Codex<br/>(stdio)"]
-        Remote["Remote agent / EKS backend<br/>(streamable HTTP)"]
-    end
+    IDE["IDE<br/>(Claude Code, Cursor, Kiro, ...)"] -->|"stdio"| Server
+    Remote["Remote agent /<br/>EKS backend"] -->|"HTTP"| Server
 
-    subgraph Process["eval-mcp process"]
-        CLI["eval_mcp/cli.py<br/>(click group)"]
-        Server["eval_mcp/server.py<br/>FastMCP('eval-server')"]
+    Server["eval-mcp server<br/>(FastMCP)"] --> Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
 
-        subgraph ToolMods["eval_mcp/tools/"]
-            T1["dataset: generate_qa, save_dataset, list_datasets"]
-            T2["judge: generate_judge, list_judges"]
-            T3["config: create_eval_config, create_agent_eval_config"]
-            T4["run: run_evaluation, retry_evaluation, optimize_prompt"]
-            T5["read: list_evaluations, get_evaluation_details, analyze_*"]
-            T6["report: generate_report"]
-        end
+    Tools <--> UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs")]
+    Tools -->|"spawn"| Inspect["Inspect AI subprocess"]
+    Tools --> Bedrock[("AWS Bedrock")]
 
-        subgraph Core["eval_mcp/core/"]
-            Bed["bedrock_client.py<br/>cross-region + API-key auth"]
-            UStore["user_storage.py<br/>get_user_dir / get_user_log_dir"]
-            Pricing["pricing.py + provider_pricing.json"]
-            Jury["judge_config.py"]
-        end
+    UserDir <-.->|"auto-sync<br/>(optional, eval-mcp init)"| S3[("Team S3 bucket")]
 
-        Sub["subprocess_runner.py<br/>+ _agent_launcher.py<br/>(spawns inspect-ai)"]
-        OTLP2["otlp_receiver.py +<br/>bedrock_capture.py"]
-        S3Sync["s3_sync.py<br/>(replicate_async, auto_pull,<br/>sync_up/down/to_project)"]
-        Viewer2["viewer.py<br/>FastAPI on :4001<br/>serves viewer_static/"]
-
-        Installers["installers/<br/>claude_code, codex, cursor, kiro, vscode"]
-    end
-
-    UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs<br/>USER_STORAGE_BASE overrides")]
-    BedrockSvc[("AWS Bedrock")]
-    S3Bucket[("S3 team bucket<br/>(optional)<br/>users/&lt;you&gt;/, projects/&lt;name&gt;/")]
-    Browser["Browser"]
-
-    CC -->|"JSON-RPC over stdio"| Server
-    Remote -->|"streamable_http_app"| Server
-    CLI -->|"no subcommand → run server"| Server
-    CLI -->|"eval-mcp install"| Installers
-    CLI -->|"eval-mcp init &lt;bucket&gt;"| S3Sync
-    CLI -->|"eval-mcp view"| Viewer2
-    CLI -->|"eval-mcp sync / share"| S3Sync
-
-    Server --> ToolMods
-    ToolMods --> Core
-    ToolMods --> Sub
-    Sub -.->|"OTel spans"| OTLP2
-    Core --> BedrockSvc
-    ToolMods <--> UserDir
-    UserDir -.->|"auto-replicate on write"| S3Sync
-    S3Sync <--> S3Bucket
-    UserDir -.->|"auto-pull on list/read (debounced)"| S3Sync
-
-    Viewer2 --> UserDir
-    Browser --> Viewer2
+    UserDir --> Viewer["Local viewer :4001"]
+    Browser["Browser"] --> Viewer
 ```
 
 **Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.
@@ -161,88 +76,24 @@ The optional multi-user web app — Cognito-auth'd chat UI for non-technical use
 
 ```mermaid
 flowchart TB
-    User["User browser"]
+    User["User browser"] -->|"HTTPS"| CF["CloudFront + WAF"]
+    CF -->|"VPC Origin<br/>(private AWS network)"| ALB["Internal ALB"]
+    ALB --> OAuth["oauth2-proxy"]
+    OAuth -.->|"OIDC"| Cognito["Cognito User Pool"]
 
-    subgraph Edge["AWS edge"]
-        CF["CloudFront (HTTPS)<br/>HTTP/2+3"]
-        WAF["WAF<br/>rate-limit 2000 req/5min<br/>AWS managed rules"]
-        VPCOrigin["VPC Origin<br/>(private AWS network)"]
+    OAuth --> Frontend["Frontend Pod<br/>(Next.js)"]
+    OAuth --> BackendPod
+
+    subgraph BackendPod["Backend Pod (stateless)"]
+        BE["backend<br/>(FastAPI :8080)"]
+        MCP["eval-mcp sidecar<br/>(HTTP :8002)"]
+        BE <-->|"localhost"| MCP
     end
 
-    Cognito["Cognito User Pool<br/>admin-signup + optional OIDC IdP"]
-
-    subgraph VPC["VPC (infra/data) — 10.0.0.0/16"]
-        ALB["Internal ALB<br/>(not internet-facing)"]
-        S3End["S3 VPC Endpoint"]
-
-        subgraph EKS["EKS cluster (infra/platform)"]
-            direction TB
-            OAuth["oauth2-proxy<br/>:4180"]
-
-            subgraph BackendPod["Pod: backend"]
-                BE["backend container<br/>FastAPI :8080"]
-                EvalSidecar["eval-mcp sidecar<br/>HTTP :8002<br/>(K8s 1.28+ native sidecar)"]
-                Eph["emptyDir /data<br/>USER_STORAGE_BASE=/data/users"]
-            end
-
-            subgraph FrontendPod["Pod: frontend"]
-                FE["Next.js :3000"]
-            end
-
-            Karp["Karpenter<br/>arm64 c/m/r/t medium-xl"]
-            ESO["External Secrets Operator<br/>+ Pod Identity"]
-        end
-    end
-
-    subgraph DataLayer["infra/data (persistent)"]
-        RDS[("RDS Postgres<br/>chat history<br/>IAM auth")]
-        S3Docs[("S3 documents bucket<br/>user uploads")]
-        S3Data[("S3 data bucket<br/>configs, datasets, judges,<br/>logs, periodic JSON backup")]
-    end
-
-    subgraph CICD["Image pipeline (infra/platform)"]
-        CB["CodeBuild<br/>(ARM64 build)"]
-        ECR[("ECR<br/>backend + frontend images")]
-        SrcS3[("S3 source bucket")]
-    end
-
-    SM[("Secrets Manager<br/>Cognito client + cookie + DB IAM")]
-    BedrockSvc2[("AWS Bedrock<br/>multi-region inference<br/>+ CloudWatch logging")]
-
-    User -->|"HTTPS"| CF
-    CF --> WAF
-    WAF --> VPCOrigin
-    VPCOrigin --> ALB
-
-    ALB -->|"/oauth2/*, protected routes"| OAuth
-    ALB -->|"/api/*"| BE
-    ALB -->|"/viewer/*"| BE
-    ALB -->|"/*"| FE
-    OAuth -.->|"login redirect"| Cognito
-    Cognito -.->|"OIDC"| OAuth
-
-    BE <-->|"http://localhost:8002/mcp"| EvalSidecar
-    BE --> Eph
-    EvalSidecar --> Eph
-    BE -->|"chat history"| RDS
-    BE -->|"user uploads"| S3Docs
-    EvalSidecar -->|"durable state +<br/>periodic backup"| S3Data
-    EvalSidecar -->|"target + judge calls"| BedrockSvc2
-
-    Eph -.->|"ephemeral; lost on pod restart"| Eph
-    S3Data -.->|"S3 VPC endpoint"| S3End
-
-    ESO --> SM
-    SM -.->|"injected as K8s secrets"| BE
-    SM -.->|"injected"| OAuth
-
-    SrcS3 --> CB
-    CB --> ECR
-    ECR -.->|"image pull"| BackendPod
-    ECR -.->|"image pull"| FrontendPod
-
-    Karp -.->|"provisions nodes"| BackendPod
-    Karp -.->|"provisions nodes"| FrontendPod
+    BE --> RDS[("RDS Postgres<br/>chat history")]
+    BE --> S3Docs[("S3 documents<br/>user uploads")]
+    MCP --> S3Data[("S3 data<br/>configs, datasets,<br/>judges, eval logs")]
+    MCP --> Bedrock[("AWS Bedrock")]
 ```
 
 **Two Terraform layers, independent state.**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,27 +58,34 @@ flowchart TB
 
 ## 2. MCP server
 
+Two distinct user workflows live in the `eval-mcp` package:
+
+- **Running evals** — the IDE (or a remote agent) talks to the MCP server, which exposes tools that read/write the user dir, call Bedrock, and spawn Inspect AI for actual evaluation runs.
+- **Viewing results** — the user runs `eval-mcp view` to start a *separate* local FastAPI process that serves a results UI on `localhost:4001`; the user then opens a regular web browser to look at past eval results.
+
+Both processes are part of the same `eval-mcp` package and share the same local user dir on disk — that's how the viewer sees what the server wrote.
+
 ```mermaid
 flowchart TB
-    %% Callers (top)
-    IDE["IDE<br/>(Claude Code, Cursor,<br/>Kiro, ...)"]
+    %% Callers — labeled by intent, not just "browser"
+    IDE["IDE coding agent<br/>(Claude Code, Cursor, Kiro, ...)"]
     Remote["Remote agent /<br/>EKS backend"]
-    UserBrowser["User browser"]
+    HumanUser["User reviewing results<br/>(in a web browser)"]
 
-    %% MCP server process — spawned by IDE or run as eval-mcp serve
-    subgraph MCPProc["eval-mcp server process<br/>(stdio or HTTP)"]
+    %% MCP server process — spawned by the IDE, or run as eval-mcp serve
+    subgraph MCPProc["eval-mcp server process"]
         Server["FastMCP server<br/>(eval_mcp/server.py)"]
         Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
         Server --> Tools
     end
 
-    %% Viewer — separate process started by `eval-mcp view`
-    subgraph ViewerProc["eval-mcp view process<br/>(separate, started on demand)"]
-        Viewer["FastAPI viewer :4001<br/>+ static frontend"]
+    %% Viewer — separate process, only runs while the user wants the UI
+    subgraph ViewerProc["eval-mcp view process (separate)"]
+        Viewer["FastAPI on :4001<br/>+ static results frontend"]
     end
 
     %% Local storage + spawned subprocess
-    UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs")]
+    UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, eval logs")]
     Inspect["Inspect AI subprocess<br/>(spawned per eval)"]
 
     %% External services
@@ -88,13 +95,13 @@ flowchart TB
     %% Flow
     IDE -->|"JSON-RPC over stdio"| Server
     Remote -->|"streamable HTTP"| Server
-    UserBrowser -->|"HTTP :4001"| Viewer
+    HumanUser -->|"opens http://localhost:4001"| Viewer
 
     Tools <-->|"read/write"| UserDir
-    Tools -->|"generate_qa,<br/>generate_judge, analyze_*"| Bedrock
+    Tools -->|"generate_qa, generate_judge,<br/>analyze_*"| Bedrock
     Tools -->|"run_evaluation only"| Inspect
 
-    Viewer -->|"read eval logs"| UserDir
+    Viewer -->|"reads eval logs<br/>(viewer is read-only)"| UserDir
 
     UserDir <-.->|"auto-sync after<br/>eval-mcp init"| S3
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,46 +112,32 @@ The optional multi-user web app — Cognito-auth'd chat UI for non-technical use
 
 ```mermaid
 flowchart TB
-    %% Ingress
     User["User browser"]
-    CF["CloudFront + WAF"]
-    ALB["Internal ALB<br/>(private to VPC)"]
-    OAuth["oauth2-proxy"]
-    Cognito["Cognito User Pool"]
+    Edge["AWS edge<br/>(CloudFront + WAF +<br/>oauth2-proxy + Cognito)"]
 
-    %% Pods (stateless tier)
     subgraph Pods["EKS pods (stateless)"]
         Frontend["Frontend Pod<br/>(Next.js)"]
         subgraph BackendPod["Backend Pod"]
-            BE["backend<br/>(FastAPI :8080)"]
-            MCP["eval-mcp sidecar<br/>(:8002)"]
+            BE["backend<br/>(FastAPI)"]
+            MCP["eval-mcp sidecar"]
             BE <-->|"localhost"| MCP
         end
     end
 
-    %% Durable tier
     subgraph Durable["Durable state"]
         RDS[("RDS Postgres<br/>chat history")]
-        S3Docs[("S3 documents<br/>user uploads")]
-        S3Data[("S3 data<br/>configs, datasets,<br/>judges, eval logs")]
+        S3[("S3 buckets<br/>configs, eval logs,<br/>user uploads")]
     end
 
-    Bedrock[("AWS Bedrock")]
-
-    %% Flow
-    User -->|"HTTPS"| CF
-    CF -->|"VPC Origin<br/>(private network)"| ALB
-    ALB -->|"public paths"| Frontend
-    ALB -->|"protected paths"| OAuth
-    OAuth -.->|"OIDC login"| Cognito
-    OAuth --> Frontend
-    OAuth --> BackendPod
-
+    User -->|"HTTPS"| Edge
+    Edge --> Frontend
+    Edge --> BackendPod
     BE --> RDS
-    BE --> S3Docs
-    MCP --> S3Data
-    MCP --> Bedrock
+    BE --> S3
+    MCP --> S3
 ```
+
+The `Edge` box collapses several AWS services (CloudFront, WAF, an internal ALB, oauth2-proxy on EKS, Cognito as the IdP) into one logical boundary — they exist, but they're not architecturally interesting beyond "authenticated HTTPS gateway." Same for the two physical S3 buckets and three Bedrock regions, which collapse into single tiles. The depth lives in the prose below.
 
 **Two Terraform layers, independent state.**
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,37 +60,43 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    %% Clients
-    IDE["IDE<br/>(Claude Code, Cursor, Kiro, ...)"]
+    %% Callers (top)
+    IDE["IDE<br/>(Claude Code, Cursor,<br/>Kiro, ...)"]
     Remote["Remote agent /<br/>EKS backend"]
+    UserBrowser["User browser"]
 
-    %% Process
-    Server["eval-mcp server<br/>(FastMCP)"]
-    Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
-    Inspect["Inspect AI subprocess"]
-    Viewer["Local viewer :4001"]
-    Browser["Browser"]
+    %% MCP server process — spawned by IDE or run as eval-mcp serve
+    subgraph MCPProc["eval-mcp server process<br/>(stdio or HTTP)"]
+        Server["FastMCP server<br/>(eval_mcp/server.py)"]
+        Tools["Tool handlers<br/>(eval_mcp/tools/*)"]
+        Server --> Tools
+    end
 
-    %% Storage
+    %% Viewer — separate process started by `eval-mcp view`
+    subgraph ViewerProc["eval-mcp view process<br/>(separate, started on demand)"]
+        Viewer["FastAPI viewer :4001<br/>+ static frontend"]
+    end
+
+    %% Local storage + spawned subprocess
     UserDir[("~/.eval-mcp/users/&lt;user&gt;/<br/>configs, datasets, judges, logs")]
+    Inspect["Inspect AI subprocess<br/>(spawned per eval)"]
 
-    %% External
+    %% External services
     Bedrock[("AWS Bedrock")]
     S3[("Team S3 bucket<br/>(optional)")]
 
     %% Flow
-    IDE -->|"stdio"| Server
-    Remote -->|"HTTP"| Server
-    Server --> Tools
+    IDE -->|"JSON-RPC over stdio"| Server
+    Remote -->|"streamable HTTP"| Server
+    UserBrowser -->|"HTTP :4001"| Viewer
 
-    Tools <-->|"read/write user state"| UserDir
-    Tools -->|"generate_qa, generate_judge,<br/>analyze_*"| Bedrock
+    Tools <-->|"read/write"| UserDir
+    Tools -->|"generate_qa,<br/>generate_judge, analyze_*"| Bedrock
     Tools -->|"run_evaluation only"| Inspect
 
-    UserDir <-.->|"auto-sync after eval-mcp init"| S3
+    Viewer -->|"read eval logs"| UserDir
 
-    Browser --> Viewer
-    Viewer --> UserDir
+    UserDir <-.->|"auto-sync after<br/>eval-mcp init"| S3
 ```
 
 **Transport.** `eval_mcp/server.py:main()` reads `EVAL_MCP_TRANSPORT` — defaults to `stdio` (what IDEs use), set to `http` to serve `streamable_http_app` at `EVAL_MCP_PORT` (default 8002) for self-hosted / EKS-sidecar use. Same server, same tools, different mouth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,108 @@
 # CLAUDE.md
 
-Contributor and agent-facing instructions for this repo live in
-[AGENTS.md](./AGENTS.md). That file is the canonical source — read it
-first. Same convention is used by Codex, Cursor, and other agentic
-tools, so we keep a single file rather than splitting per-tool docs.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-On-demand workflows live as skills under [`.claude/skills/`](./.claude/skills/).
-Claude Code auto-loads each `SKILL.md`'s frontmatter at session start and
-loads the full body only when the skill triggers, so they don't bloat
-context. Today there's one: [`ship-it`](./.claude/skills/ship-it/SKILL.md)
-for the commit → PR → release workflow.
+Agent-facing conventions (worktree workflow, model-add checklist, key files) live in [AGENTS.md](./AGENTS.md) — read it first. This file adds the commands + architecture overview that aren't in AGENTS.md.
+
+## What's in this repo
+
+Two deployables that share some code:
+
+- **`eval_mcp/`** — the MCP package published to PyPI as `llm-evaluation-system` (entry point `eval-mcp`). Self-contained, no database, no web app. This is what 99% of users install.
+- **`backend/` + `frontend/`** — the optional EKS web app (FastAPI chat + Next.js UI + Cognito auth). `./deploy.sh` is its entry point; `make dev` runs it locally via Docker Compose.
+
+The same `frontend/` source builds two artifacts: the Next.js app for the web deployment (`next build`), and a static export bundled into `eval_mcp/viewer_static/` for the MCP's local results viewer (`npm run build:viewer`). Changing frontend code therefore affects the PyPI wheel — the viewer static is package data per `pyproject.toml`.
+
+## Commands
+
+### MCP development (the common path)
+
+```bash
+uv venv && uv pip install -e .             # editable install
+.venv/bin/eval-mcp                         # run as stdio MCP (what IDEs invoke)
+.venv/bin/eval-mcp view                    # results viewer on :4001
+.venv/bin/eval-mcp serve                   # HTTP MCP on :8002 (self-host path)
+```
+
+Point Claude Code at your editable install by setting `command` in `~/.claude.json`'s `eval` entry to `/abs/path/.venv/bin/eval-mcp`. Then `/mcp` → reconnect `eval` after each edit — no reinstall. Details in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#3-point-claude-code-at-your-local-build-permanent-dev-setup).
+
+### Tests
+
+```bash
+.venv/bin/pytest tests/                                # full suite
+.venv/bin/pytest tests/test_run_eval.py                # one file
+.venv/bin/pytest tests/test_run_eval.py::test_name     # one test
+.venv/bin/pytest -k "qa_allocation"                    # by keyword
+```
+
+Pytest is **only useful for narrow deterministic logic** (parsing, validation, regex). End-to-end coverage requires running the MCP from Claude Code — mocks of Bedrock/subprocesses/user-dirs produce false greens. See `docs/DEVELOPMENT.md` section 2.
+
+### Frontend / viewer
+
+```bash
+cd frontend
+npm install                  # first time only
+npm run build:viewer         # rebuild + copy to eval_mcp/viewer_static/
+npm run dev                  # standalone Next dev server on :3000
+npm run lint                 # next lint
+```
+
+`build:viewer` runs `BUILD_MODE=export next build` and replaces `eval_mcp/viewer_static/`. Run it whenever you change frontend source if you want the local MCP viewer to reflect it.
+
+### Local full-stack (web app)
+
+```bash
+AWS_PROFILE=my-profile make dev          # docker compose, all services, hot reload
+make logs s=backend                       # tail one service
+make restart s=backend                    # restart one with fresh creds
+make stop                                 # docker compose down
+make clean                                # also wipe volumes
+```
+
+Open http://127.0.0.1:4001. See [local/README.md](local/README.md).
+
+### Release
+
+`make release` (patch) / `make release-minor` / `make release-major` from a clean `main`. Tags `vX.Y.Z`, pushes, GitHub Actions builds the wheel (frontend rebuilt in CI) and publishes to PyPI via trusted publishing. Version is derived from the tag by `setuptools-scm` — **never** add a static `version` to `pyproject.toml`. Full ship workflow in the [ship-it skill](./.claude/skills/ship-it/SKILL.md).
+
+## Architecture
+
+### MCP server flow
+
+User chats with an IDE → IDE invokes MCP tools registered in `eval_mcp/server.py` → handlers in `eval_mcp/tools/*.py` call into:
+- `eval_mcp/core/bedrock_client.py` — Bedrock + cross-region inference + API-key auth.
+- `eval_mcp/subprocess_runner.py` + `eval_mcp/_agent_launcher.py` — Inspect AI runs spawn as isolated subprocesses (NOT in-process), so a cancelled eval can't take down the MCP.
+- `eval_mcp/otlp_receiver.py` + `eval_mcp/bedrock_capture.py` — in-harness OTLP receiver consumes spans from those subprocesses (env `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`) — this is how agent evals capture Bedrock calls without code modification.
+- `eval_mcp/storage.py` + `eval_mcp/core/user_storage.py` — JSON files under `~/.eval-mcp/users/<user>/` (overridable via `USER_STORAGE_BASE`).
+- `eval_mcp/s3_sync.py` — optional bidirectional sync with a team S3 bucket; enabled by `eval-mcp init <bucket>`.
+- `eval_mcp/viewer.py` — FastAPI viewer that serves `viewer_static/` for results.
+
+Tool order in a typical session: `list_bedrock_models` → `generate_qa_pairs` → `generate_judge` → `create_eval_config` → `run_evaluation` → `get_viewer_url`. The agent system prompt that orchestrates this lives in `backend/core/agent.py` (used by the EKS web app) — the MCP itself doesn't host an agent; the IDE's model is the driver.
+
+### EKS web app flow (separate from MCP)
+
+`./deploy.sh` runs two Terraform layers with independent state:
+- `infra/data/` — VPC, RDS Postgres, S3 buckets. Persistent across redeploys.
+- `infra/platform/` — EKS, Karpenter, ALB, CloudFront, WAF, Cognito. Recreated by destroy/deploy.
+
+Data-layer outputs flow into platform-layer via `-var=` flags (NOT `terraform_remote_state`, to avoid leaking secrets between states). Helm chart at `helm/eval/` deploys a stateless backend Pod (the backend FastAPI + `eval-mcp` as a K8s 1.28+ native sidecar over an emptyDir `/data`) and a frontend Pod; durable state lives in RDS + S3.
+
+`infra/eval-logs-bucket/` is a third, unrelated Terraform root — it's the optional S3 bucket for MCP team sharing, surfaced through `eval-mcp init`. Has its own provider block and account-ID-suffixed naming.
+
+### Adding a model
+
+Touch both: `eval_mcp/tools/bedrock_models.py` (or the relevant SUPPORTED_MODELS list — see [AGENTS.md](./AGENTS.md#adding-a-new-model)) AND `eval_mcp/provider_pricing.json`. Missing pricing entries silently break cost reporting downstream.
+
+### Adding a tool
+
+1. Async handler in `eval_mcp/tools/<name>.py`.
+2. Register in `eval_mcp/server.py` with typed signature + tool annotation preset (`READ_LOCAL` / `CREATE_REMOTE` / etc.) — the docstring becomes the LLM-visible description.
+3. Pytest for any narrow deterministic logic.
+4. Exercise via Claude Code pointed at the editable install before shipping.
+
+## Conventions worth knowing up front
+
+- **Worktrees by default** for non-trivial changes: `git worktree add .claude/worktrees/<name> -b <type>/<name>`. Keeps `viewer_static/`, `node_modules/`, build artifacts from colliding across parallel branches. `.claude/` is gitignored except `.claude/skills/`.
+- **Conventional Commits** for every commit and every PR title (`feat(mcp): ...`, `fix(release): ...`). Enforced by convention, not lint.
+- **Never push to `main`, never force-push, never auto-release on merge.** Releases are an explicit `make release` after the user says ship. See [ship-it skill](./.claude/skills/ship-it/SKILL.md) for the full flow + the supply-chain reasoning behind avoiding release-please-style bots.
+- **`uvx` caches resolved versions per user.** A fresh PyPI release won't reach existing users until they run `uv cache clean llm-evaluation-system`. When verifying a release locally use `uvx --refresh --from 'llm-evaluation-system==X.Y.Z' eval-mcp --help`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ The script auto-installs Terraform, kubectl, and Helm, then deploys the complete
 ./destroy.sh
 ```
 
-Architecture details, OIDC config, Helm values, and manual deployment steps: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+Architecture diagrams: [ARCHITECTURE.md](ARCHITECTURE.md). OIDC config, Helm values, terraform variables, and manual deployment steps: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+
+## Architecture
+
+Three diagrams covering the three distinct ways code in this repo runs — eval execution, the MCP server, and the EKS deployment: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Roadmap
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -164,30 +164,26 @@ Opens http://localhost:4001. Each service hot-reloads independently; see [`local
               ┌──────────────────────────────┼──────────────────────────────┐
               │                              │                              │
               ▼                              ▼                              ▼
-     ┌─────────────────┐          ┌─────────────────┐          ┌─────────────────┐
-     │    Frontend     │          │     Backend     │          │   MCP Servers   │
-     │    (Next.js)    │          │    (FastAPI)    │          │  - synthetic    │
-     │                 │          │  - Chat/Agent   │          │  - providers    │
-     └─────────────────┘          │  - Viewer Proxy │          │  - dataset      │
-                                  └────────┬────────┘          └─────────────────┘
-                                           │
-                    ┌──────────────────────┼──────────────────────┐
-                    │                      │                      │
-                    ▼                      ▼                      ▼
-           ┌──────────────┐       ┌──────────────┐       ┌──────────────┐
-           │   User A     │       │   User B     │       │   User C     │
-           │ /data/users/ │       │ /data/users/ │       │ /data/users/ │
-           │  - configs   │       │  - configs   │       │  - configs   │
-           │  - datasets  │       │  - datasets  │       │  - datasets  │
-           │  - viewer    │       │  - viewer    │       │  - viewer    │
-           └──────────────┘       └──────────────┘       └──────────────┘
-                    │                      │                      │
-                    └──────────────────────┼──────────────────────┘
-                                           │
-                              ┌────────────▼────────────┐
-                              │   JSON + EBS Storage   │
-                              │  Periodic S3 backup      │
-                              └─────────────────────────┘
+     ┌─────────────────┐     ┌──────────────────────────────────────┐
+     │    Frontend     │     │   Backend Pod (stateless)            │
+     │    (Next.js)    │     │  ┌──────────────┐  ┌──────────────┐  │
+     │                 │     │  │   backend    │↔│   eval-mcp   │  │
+     └─────────────────┘     │  │  (FastAPI)   │  │  (sidecar,   │  │
+                             │  │   :8080      │  │   HTTP :8002)│  │
+                             │  └──────┬───────┘  └───────┬──────┘  │
+                             │         └──────┬───────────┘         │
+                             │                ▼                     │
+                             │     emptyDir /data (ephemeral)       │
+                             └────────────────┬─────────────────────┘
+                                              │
+                       ┌──────────────────────┼──────────────────────┐
+                       ▼                      ▼                      ▼
+              ┌──────────────┐       ┌──────────────┐       ┌──────────────┐
+              │ RDS Postgres │       │  S3 data     │       │ S3 documents │
+              │ chat history │       │  configs,    │       │ user uploads │
+              │  (IAM auth)  │       │  datasets,   │       │              │
+              │              │       │  judges,logs │       │              │
+              └──────────────┘       └──────────────┘       └──────────────┘
 ```
 
 ## Security Architecture
@@ -297,9 +293,9 @@ helm/eval/
 ├── values.yaml           # Shared defaults (multi-environment)
 ├── values-aws.yaml       # AWS EKS overrides
 └── templates/
-    ├── deployment.yaml   # Backend + Frontend + 3 MCP sidecars + s3-backup
+    ├── deployment.yaml   # Backend Pod (backend + eval-mcp sidecar) + Frontend
     ├── service.yaml      # Backend, Frontend services
-    ├── pvc.yaml          # Backend EBS gp3 storage (200Gi)
+    ├── pvc.yaml          # Intentionally empty — backend is stateless (data in S3)
     ├── hpa.yaml          # Horizontal Pod Autoscaling
     ├── pdb.yaml          # Pod Disruption Budgets
     └── rbac.yaml         # RBAC configuration
@@ -448,18 +444,23 @@ helm template eval ./helm/eval -f ./helm/eval/values-aws.yaml \
 
 ### Storage Management
 
-Backend uses single-pod architecture with EBS gp3 storage (200Gi). Sidecar backs up JSON databases to S3 every 15 minutes. Brief downtime (~30s) occurs during deploys.
+Backend is **stateless** — `/data` is an `emptyDir` volume (lost on pod restart). All durable state lives in S3:
+
+- **S3 data bucket** (`infra/data/storage.tf` → `data_bucket`) — configs, datasets, judges, eval logs, PDF reports. Written directly by `eval-mcp` via `USER_STORAGE_BASE=/data/users` plus the S3 sync layer.
+- **S3 documents bucket** — user-uploaded PDFs and knowledge bases.
+- **RDS Postgres** — chat history.
+
+Pod restarts and rolling deploys are therefore non-disruptive to durable state. HPA scaling works without volume coordination. There is no PVC and no `s3-backup` sidecar; `helm/eval/templates/pvc.yaml` is intentionally empty (see its comment).
 
 ```bash
-# Check disk usage
-kubectl exec -n eval-managed deployment/backend -- df -h /data
+# Inspect the ephemeral working dir (resets on pod restart)
+kubectl exec -n eval-managed deployment/backend -c backend -- df -h /data
 
-# Expand storage (no downtime, applies automatically)
-kubectl patch pvc backend-data -n eval-managed \
-  -p '{"spec":{"resources":{"requests":{"storage":"400Gi"}}}}'
+# Verify durable state is in S3
+aws s3 ls s3://$(cd infra/data && terraform output -raw data_bucket)/users/
 
-# Check backup status
-kubectl logs -n eval-managed -l app=backend -c s3-backup
+# Tail MCP sidecar logs (where the S3 writes happen)
+kubectl logs -n eval-managed -l app=backend -c eval-mcp
 ```
 
 ### Terraform State

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -156,48 +156,11 @@ Opens http://localhost:4001. Each service hot-reloads independently; see [`local
 
 ## Architecture
 
-```
-                         ┌─────────────────────────────────────────┐
-                         │      CloudFront + WAF → Internal ALB    │
-                         └───────────────────┬─────────────────────┘
-                                             │
-              ┌──────────────────────────────┼──────────────────────────────┐
-              │                              │                              │
-              ▼                              ▼                              ▼
-     ┌─────────────────┐     ┌──────────────────────────────────────┐
-     │    Frontend     │     │   Backend Pod (stateless)            │
-     │    (Next.js)    │     │  ┌──────────────┐  ┌──────────────┐  │
-     │                 │     │  │   backend    │↔│   eval-mcp   │  │
-     └─────────────────┘     │  │  (FastAPI)   │  │  (sidecar,   │  │
-                             │  │   :8080      │  │   HTTP :8002)│  │
-                             │  └──────┬───────┘  └───────┬──────┘  │
-                             │         └──────┬───────────┘         │
-                             │                ▼                     │
-                             │     emptyDir /data (ephemeral)       │
-                             └────────────────┬─────────────────────┘
-                                              │
-                       ┌──────────────────────┼──────────────────────┐
-                       ▼                      ▼                      ▼
-              ┌──────────────┐       ┌──────────────┐       ┌──────────────┐
-              │ RDS Postgres │       │  S3 data     │       │ S3 documents │
-              │ chat history │       │  configs,    │       │ user uploads │
-              │  (IAM auth)  │       │  datasets,   │       │              │
-              │              │       │  judges,logs │       │              │
-              └──────────────┘       └──────────────┘       └──────────────┘
-```
-
-## Security Architecture
-
-```
-Internet → CloudFront (HTTPS + WAF) → VPC Origin → Internal ALB → Pods
-```
-
-- **Internal ALB**: Not internet-facing. Only reachable via CloudFront VPC Origins.
-- **VPC Origins**: CloudFront connects to ALB via AWS private network.
-- **WAF**: Rate limiting (2000 req/5min per IP), AWS managed rules.
-- **Authentication**: Cognito (native or external OIDC IdP) via oauth2-proxy.
-- **Secrets**: Stored in AWS Secrets Manager, synced to K8s via External Secrets Operator.
-- **Database auth**: IAM token authentication (no static passwords).
+System architecture, request flow, and security boundaries are in
+[ARCHITECTURE.md](../ARCHITECTURE.md) — three mermaid diagrams covering
+eval execution, the MCP server, and the EKS deployment. This file
+focuses on operational procedures (commands, terraform variables,
+troubleshooting) rather than what the system is.
 
 ## Project Structure
 
@@ -234,37 +197,11 @@ llm-evaluation-system/
 
 The EKS/web-app content below is the heavyweight deployment path. For the MCP, the section above ("Working on the MCP locally") is what you want.
 
-## Infrastructure Layout
+## How the Terraform layers connect
 
-Infrastructure is split into two Terraform layers with separate state:
+Infrastructure is split into `infra/data/` (persistent: VPC, RDS, S3 — survives `./destroy.sh`) and `infra/platform/` (compute: EKS, ALB, CloudFront, Cognito — recreated by deploy/destroy). Resource breakdowns are in [ARCHITECTURE.md](../ARCHITECTURE.md#3-eks-deployment).
 
-### Data Layer (`infra/data/`)
-
-Persistent resources that survive `./destroy.sh`:
-
-- **VPC** — 10.0.0.0/16 CIDR, 2 AZs, public/private/intra subnets, NAT gateway, S3 VPC endpoint
-- **RDS PostgreSQL** — db.t3.micro, 20GB (auto-scales to 100GB), IAM auth enabled
-- **S3 Documents Bucket** — User uploads, versioned
-- **S3 Backup Bucket** — Periodic JSON backups, versioned
-
-### Platform Layer (`infra/platform/`)
-
-Compute and networking resources destroyed/recreated by scripts:
-
-- **EKS** — Kubernetes 1.34, 2x t4g.medium managed node group (ARM64/Graviton)
-- **Karpenter** — Auto-scaling with c/m/r/t instance types (arm64, medium-xlarge)
-- **ALB** — Internal (non-internet-facing), targets: backend (8080), frontend (3000), oauth2-proxy (4180)
-- **CloudFront** — HTTPS CDN with VPC Origin to internal ALB, HTTP/2+3
-- **WAF** — Rate limiting (2000 req/5min per IP), AWS managed rules
-- **Cognito** — User Pool with admin-only signup, optional external OIDC IdP
-- **CodeBuild** — ARM64 image builds, source from S3
-- **ECR** — Private container registry
-- **Bedrock Logging** — Multi-region (us-west-2, us-east-1, us-east-2) CloudWatch logs
-- **Kubernetes resources** — Namespace, ConfigMap, StorageClass, External Secrets, Pod Identity, TGBs
-
-### How Layers Connect
-
-The deploy script reads data-layer outputs and passes them as `-var` flags to the platform layer. This avoids `terraform_remote_state` (which exposes entire state including secrets).
+`deploy.sh` reads data-layer outputs and passes them to the platform layer as `-var` flags rather than using `terraform_remote_state` (which would expose the entire data-state including secrets):
 
 ```bash
 # deploy.sh internally does:
@@ -332,19 +269,6 @@ Inherits `region` and `project_name`, plus:
 | `vpc_id` | (required) | From data layer output |
 | `private_subnets` | (required) | From data layer output |
 | ... | | (13 data-layer variables total, passed by deploy.sh) |
-
-## Ingress Routes
-
-| Path | Service | Description |
-|------|---------|-------------|
-| `/api/auth/*` | frontend | NextAuth authentication |
-| `/api/*` | backend | FastAPI endpoints |
-| `/viewer/*` | backend | Per-user viewer proxy |
-| `/health` | backend | Health check |
-| `/*` | frontend | Next.js app |
-
-Public routes (no auth): `/`, `/_next/*`, `/favicon.ico` — bypassed at ALB level.
-Protected routes: `/chat`, `/api/*`, `/viewer/*` — through oauth2-proxy.
 
 ## Manual Deployment Steps
 


### PR DESCRIPTION
## Summary

Doc overhaul that splits the project's documentation into a clearer three-way structure:

- **ARCHITECTURE.md** (new) — what the system IS. Three mermaid diagrams covering eval execution, the MCP server, and the EKS deployment.
- **CLAUDE.md** (rewrite) — quick reference for Claude Code sessions: the two-deployable split, common commands (editable install, single-test patterns, build:viewer, make targets, release flow), MCP + EKS architecture overviews, and the conventions that are easy to get wrong (worktrees, conventional commits, no-push-to-main, uvx cache nuance).
- **docs/DEVELOPMENT.md** — keeps the procedural content (dev loop, manual deploy, terraform variables, troubleshooting) but drops four sections now duplicated in ARCHITECTURE.md, plus fixes a stale storage section that still described an EBS gp3 PVC + s3-backup sidecar that no longer exists.
- **README.md** — adds an \`## Architecture\` section linking to ARCHITECTURE.md so the diagrams are discoverable from the front door.

## Why

Two motivations stacked up while writing the architecture diagrams:

1. **Doc drift.** \`helm/eval/templates/pvc.yaml\` is now a comment-only file and \`values-aws.yaml\` declares \"Stateless backend — all persistent data in S3,\" but DEVELOPMENT.md still walked users through resizing a PVC that no longer exists and tailing an \`-c s3-backup\` container that's not there. New contributors following those instructions would get confused.
2. **Single-purpose docs.** DEVELOPMENT.md was trying to be both \"architectural reference\" and \"developer handbook\" — splitting them out makes each easier to maintain and to find content in.

## Commits

- \`199a768\` — fix the stateless-backend storage description in DEVELOPMENT.md (the original scope of this branch)
- \`3ca79f1\` — add ARCHITECTURE.md with the three mermaid diagrams
- \`a26c63a\` — rewrite CLAUDE.md so future Claude Code sessions land with commands + architecture in context, not just a pointer to AGENTS.md
- \`4165cf2\` — link ARCHITECTURE.md from README and prune the four duplicated sections from DEVELOPMENT.md

## Test plan

- [x] \`grep -i \"ebs\\|gp3\\|200gi\\|s3-backup\\|backend-data\\|single-pod\"\` in DEVELOPMENT.md returns only the one new sentence explicitly noting their absence.
- [x] Verified \`data_bucket\` (not \`data_bucket_name\`) is the real terraform output in \`infra/data/outputs.tf\`.
- [x] Verified \`eval-mcp\` (not \`s3-backup\`) is the sidecar container name in \`helm/eval/templates/deployment.yaml\`.
- [x] Mermaid diagrams render on GitHub — please confirm in the file preview.
- [x] No code or behavior changes — docs only.