### PR TITLE
feat(mcp): add score-only mode for evaluating pre-generated outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,5 +127,5 @@ Claude Code and other agentic tools auto-summarize prior conversation turns when
 
 These [marketplace skills](https://code.claude.com/docs/en/skills) from the official Anthropic marketplace pair well with this repo's workflows. They're user-installed (not bundled here), so the recommendation only fires for sessions where the user has them available — but if you do, lean on them rather than reinventing the wheel.
 
-- **`webapp-testing`** — after any UI or routing change to the Next.js frontend (web app on `:3000`) or the bundled viewer (`eval-mcp view` on `:4001`). Spins up Playwright and actually clicks through pages, rather than trusting that type-checks caught nav regressions.
+- **`webapp-testing`** — after any change the viewer renders, including: UI/routing edits under `frontend/` (web app on `:3000` or the bundled viewer on `:4001`), and backend edits that change the JSON shape the viewer consumes (e.g. `eval_mcp/core/eval_results.py`, `eval_mcp/viewer.py`, `list_evaluations`). Spins up Playwright and actually clicks through pages. A label or column-header change in a Python file is still a UI change — verify it in the browser, don't just inspect the JSON.
 - **`frontend-design`** — when adding or restyling components in `frontend/`. Same source builds both the web app and the static viewer export, so component quality lands in both deliverables.

--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -664,6 +664,48 @@ def _build_detail_from_logs(
     return result
 
 
+def _relabel_score_only_groups(groups_response: dict, user_dir: Path) -> None:
+    """For each group whose backing config has ``score_only: true``, relabel
+    the model entries from Inspect's ``"none/none"`` literal to the
+    user-facing ``"pre-generated"`` label. Mutates ``groups_response`` in place.
+
+    Matches the relabel applied by :func:`_build_detail_from_logs` so the
+    sidebar (groups list) and the detail view show the same label.
+    """
+    base_real = os.path.realpath(str(get_user_base_dir()))
+    configs_real = os.path.realpath(str(user_dir / "configs"))
+    if not configs_real.startswith(base_real + os.sep):
+        return
+    if not os.path.isdir(configs_real):
+        return
+    for group in groups_response.get("groups", []):
+        models = group.get("models") or []
+        if models != ["none/none"]:
+            continue
+        # Need the task file name to find the right config JSON. Use the
+        # group's configName as a fallback.
+        config_name = group.get("configName") or ""
+        candidates = [f"{config_name}.json"]
+        # Also handle the auto-generated eval_NNN naming convention.
+        for cand in candidates:
+            cand_path = os.path.realpath(os.path.join(configs_real, os.path.basename(cand)))
+            if not cand_path.startswith(configs_real + os.sep):
+                continue
+            if not os.path.isfile(cand_path):
+                continue
+            try:
+                with open(cand_path) as f:
+                    cfg = json.loads(f.read())
+                if cfg.get("score_only"):
+                    group["models"] = ["pre-generated"]
+                    if "scores" in group and "none/none" in group["scores"]:
+                        group["scores"]["pre-generated"] = group["scores"].pop("none/none")
+                    group["scoreOnly"] = True
+                break
+            except Exception:
+                continue
+
+
 async def precompute_eval_results(user_id: str, force: bool = False) -> None:
     """Parse all .eval files for a user and save pre-computed JSON to S3/disk.
 
@@ -677,6 +719,13 @@ async def precompute_eval_results(user_id: str, force: bool = False) -> None:
         return
 
     groups_response = _build_groups_from_headers(headers)
+    # Apply the same model-name relabel the detail builder does, so the
+    # groups list (sidebar / list_evaluations) stays consistent with the
+    # detail view for score-only and agent runs. The detail builder reads
+    # config_data itself; here we only relabel score-only because it's the
+    # simplest signal (model == "none/none") and agent_image already shows
+    # up correctly via the existing display path.
+    _relabel_score_only_groups(groups_response, user_dir)
     save_eval_groups(user_id, groups_response)
     logger.info(f"Saved pre-computed groups JSON for user {user_id} ({len(groups_response['groups'])} groups)")
 

--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -617,6 +617,7 @@ def _build_detail_from_logs(
                 pass
 
     display_models = models
+    score_only = bool(config_data and config_data.get("score_only"))
     if agent_image and len(models) == 1:
         display_models = [f"agent/{agent_image}"]
         old_model = models[0]
@@ -627,6 +628,20 @@ def _build_detail_from_logs(
         for sample in samples_by_id.values():
             if old_model in sample.get("results", {}):
                 sample["results"][f"agent/{agent_image}"] = sample["results"].pop(old_model)
+    elif score_only and len(models) == 1:
+        # Inspect AI logs the model as "none/none" when no --model is
+        # passed. That literal isn't user-facing — relabel for the
+        # viewer so the column header reads "pre-generated".
+        score_only_label = "pre-generated"
+        display_models = [score_only_label]
+        old_model = models[0]
+        if old_model in aggregate:
+            aggregate[score_only_label] = aggregate.pop(old_model)
+        if old_model in stats:
+            stats[score_only_label] = stats.pop(old_model)
+        for sample in samples_by_id.values():
+            if old_model in sample.get("results", {}):
+                sample["results"][score_only_label] = sample["results"].pop(old_model)
 
     result = {
         "groupId": group_id,
@@ -642,6 +657,8 @@ def _build_detail_from_logs(
         result["pipeline"] = pipeline_stages
     if agent_image:
         result["agentImage"] = agent_image
+    if score_only:
+        result["scoreOnly"] = True
     if config_data and config_data.get("prompts"):
         result["prompts"] = config_data["prompts"]
     return result

--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -277,6 +277,12 @@ def _build_groups_from_headers(headers: list[dict]) -> dict:
             "status": status,
             "scores": scores_by_key,
         }
+        # Stash the raw task_file (e.g. "eval_<timestamp>.py") so downstream
+        # post-processing (score-only relabel, future config-driven UI bits)
+        # can locate the sibling JSON config without re-deriving it.
+        task_file = run_logs[0].get("task_file")
+        if task_file:
+            group["taskFile"] = task_file
         if is_prompt_comparison:
             group["promptComparison"] = True
             group["promptCount"] = len(distinct_tasks)
@@ -682,28 +688,32 @@ def _relabel_score_only_groups(groups_response: dict, user_dir: Path) -> None:
         models = group.get("models") or []
         if models != ["none/none"]:
             continue
-        # Need the task file name to find the right config JSON. Use the
-        # group's configName as a fallback.
-        config_name = group.get("configName") or ""
-        candidates = [f"{config_name}.json"]
-        # Also handle the auto-generated eval_NNN naming convention.
-        for cand in candidates:
-            cand_path = os.path.realpath(os.path.join(configs_real, os.path.basename(cand)))
-            if not cand_path.startswith(configs_real + os.sep):
-                continue
-            if not os.path.isfile(cand_path):
-                continue
-            try:
-                with open(cand_path) as f:
-                    cfg = json.loads(f.read())
-                if cfg.get("score_only"):
-                    group["models"] = ["pre-generated"]
-                    if "scores" in group and "none/none" in group["scores"]:
-                        group["scores"]["pre-generated"] = group["scores"].pop("none/none")
-                    group["scoreOnly"] = True
-                break
-            except Exception:
-                continue
+        # Derive the config JSON name. Inspect's log header carries the
+        # original task file ("eval_<timestamp>.py"); the JSON config is the
+        # sibling with the .json suffix. Fall back to configName for older
+        # logs that predate the taskFile stash.
+        task_file = group.get("taskFile")
+        if task_file:
+            config_filename = Path(task_file).with_suffix(".json").name
+        else:
+            config_filename = f"{group.get('configName') or ''}.json"
+        cand_path = os.path.realpath(
+            os.path.join(configs_real, os.path.basename(config_filename))
+        )
+        if not cand_path.startswith(configs_real + os.sep):
+            continue
+        if not os.path.isfile(cand_path):
+            continue
+        try:
+            with open(cand_path) as f:
+                cfg = json.loads(f.read())
+            if cfg.get("score_only"):
+                group["models"] = ["pre-generated"]
+                if "scores" in group and "none/none" in group["scores"]:
+                    group["scores"]["pre-generated"] = group["scores"].pop("none/none")
+                group["scoreOnly"] = True
+        except Exception:
+            continue
 
 
 async def precompute_eval_results(user_id: str, force: bool = False) -> None:

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -266,14 +266,25 @@ async def save_dataset(
     persists it. Prefer `file_path` — the tool reads from disk (cheap).
     Pass `file_content` only if the data isn't on the local filesystem.
 
+    For score-only mode (evaluate pre-generated outputs WITHOUT calling a
+    candidate model), also pass an actual_output column. When every
+    sample in the saved dataset has actual_output populated,
+    create_eval_config switches into score-only mode automatically:
+    no candidate model is invoked, and scorers grade the static answers
+    against golden_answer.
+
     Args:
-        column_mapping: {"question": col_name, "golden_answer": col_name}
+        column_mapping: dict mapping canonical names to source column names.
+            Required: ``"question"`` and ``"golden_answer"``.
+            Optional: ``"actual_output"`` — opt into score-only mode.
         file_path: Absolute path to the dataset file (recommended).
         file_content: Raw file content as a string (fallback).
         filename: Optional display name (inferred from file_path when omitted).
 
     Returns:
-        JSON with success status, generated dataset name, and rows saved.
+        JSON with success status, generated dataset name, rows saved,
+        and (when actual_output was mapped) the count of rows that
+        ended up with a populated actual_output.
     """
     args = {
         "file_path": file_path,
@@ -516,8 +527,8 @@ async def generate_judge(
 @mcp.tool(annotations=CREATE_LOCAL)
 async def create_eval_config(
     dataset: DatasetName,
-    providers: ProvidersList,
     judge: JudgeName,
+    providers: list = None,
     user_id: str = None,
     prompts: str | list = "{question}",
     description: str = None,
@@ -538,11 +549,20 @@ async def create_eval_config(
     For agent evaluations: pass agent_path to evaluate a local Python agent
     with full Bedrock call tracing. The agent code is not modified.
 
+    Score-only mode: when the named dataset has actual_output populated
+    on every sample (see save_dataset's actual_output column),
+    create_eval_config automatically switches into score-only mode —
+    no candidate model is invoked, providers becomes optional, and the
+    scorers grade the pre-generated outputs against golden_answer. This
+    is the right mode when you have already run your RAG / agent /
+    chatbot in production and just want to score the captured outputs.
+
     Args:
         dataset: Name of dataset from list_datasets
-        providers: List of target models to evaluate (used for jury judges routing).
-            For agent evals, the agent calls Bedrock directly.
         judge: Name of judge from list_judges (REQUIRED - criteria adapted to QA pairs)
+        providers: List of target models to evaluate (used for jury judges routing).
+            For agent evals, the agent calls Bedrock directly. Optional in
+            score-only mode (the dataset already carries actual_output).
         prompts: Single prompt string OR list of prompts for comparison. Use {question} or {prompt} as placeholder.
         description: Optional description of the evaluation
         judge_models: Optional list of model IDs to use as judges

--- a/eval_mcp/solvers/static_output.py
+++ b/eval_mcp/solvers/static_output.py
@@ -1,0 +1,49 @@
+"""Solver that uses pre-generated outputs instead of calling a model.
+
+Score-only mode: the dataset already carries an ``actual_output`` per
+sample (the user ran their candidate system offline and captured the
+answers). Inspect AI normally calls a model via ``generate()`` to fill
+``state.output``; this solver short-circuits that step by constructing
+a ``ModelOutput`` from the dataset value, so downstream scorers see
+the exact same shape they'd see after a real model call.
+
+The solver is also safe to drop into a mixed task: if a sample lacks
+``actual_output`` it falls through to the normal ``generate(state)``
+chain, so a user could in principle compose
+``solver=[static_output_solver(), generate()]`` for opportunistic
+score-only behaviour per sample. We don't expose that mode through
+``create_eval_config`` for v1 — the wrapper requires all-or-none — but
+the solver itself doesn't enforce that.
+"""
+
+from __future__ import annotations
+
+from inspect_ai.model import ModelOutput
+from inspect_ai.solver import solver
+
+# Synthetic model identifier written into the eval log when no real
+# model was invoked. The viewer relabels this to ``"pre-generated"`` —
+# see ``eval_mcp/core/eval_results.py`` near the agent-image relabel
+# block. Don't change the literal without also updating that swap.
+STATIC_MODEL_ID = "static/preset"
+
+
+@solver
+def static_output_solver():
+    """Set ``state.output`` from ``state.metadata['actual_output']`` and return.
+
+    No model is invoked. Falls through to ``generate(state)`` when the
+    metadata field is absent so the solver is composable with normal
+    runs. (``create_eval_config`` only wires this in when every sample
+    has ``actual_output``, but the solver itself stays general.)
+    """
+    async def solve(state, generate):
+        actual = (state.metadata or {}).get("actual_output")
+        if actual is None or actual == "":
+            return await generate(state)
+        state.output = ModelOutput.from_content(
+            model=STATIC_MODEL_ID, content=str(actual)
+        )
+        return state
+
+    return solve

--- a/eval_mcp/tools/create_config.py
+++ b/eval_mcp/tools/create_config.py
@@ -124,8 +124,14 @@ def build_config_json(
     description: Optional[str] = None,
     prompts: Optional[List[str]] = None,
     scorers: Optional[List[str]] = None,
+    score_only: bool = False,
 ) -> dict:
-    """Build the JSON config that the task file will load."""
+    """Build the JSON config that the task file will load.
+
+    ``score_only`` flips the config into "score pre-generated outputs"
+    mode: ``providers`` is allowed to be empty (no candidate model is
+    invoked), and ``run_eval.py`` skips the ``--model`` subprocess flag.
+    """
     config = {
         "dataset_path": dataset_path,
         "providers": providers,
@@ -137,6 +143,8 @@ def build_config_json(
     }
     if prompts and len(prompts) > 1:
         config["prompts"] = prompts
+    if score_only:
+        config["score_only"] = True
     return config
 
 
@@ -150,7 +158,7 @@ def build_config_json(
 
 TASK_FILE_BASE = '''"""Inspect AI evaluation task: {config_name}
 
-Auto-generated. Scorers: {scorers_doc}
+Auto-generated. Scorers: {scorers_doc}{mode_doc}
 """
 
 import json
@@ -164,7 +172,7 @@ _config_path = Path(__file__).with_suffix(".json")
 CONFIG = json.loads(_config_path.read_text())
 
 DATASET_PATH = CONFIG["dataset_path"]
-PROVIDERS = CONFIG["providers"]
+PROVIDERS = CONFIG.get("providers", [])
 '''
 
 
@@ -336,8 +344,8 @@ SINGLE_TASK_TEMPLATE = '''
 @task
 def eval_task():
     return Task(
-        dataset=json_dataset(DATASET_PATH, FieldSpec(input="question", target="golden_answer")),
-        solver=[generate()],
+        dataset=json_dataset(DATASET_PATH, FieldSpec(input="question", target="golden_answer"{field_spec_metadata})),
+        solver=[{solver_chain}],
         scorer={scorer_expr},
     )
 '''
@@ -346,8 +354,8 @@ PROMPT_TASK_TEMPLATE = '''
 @task
 def eval_{index}():
     return Task(
-        dataset=json_dataset(DATASET_PATH, FieldSpec(input="question", target="golden_answer")),
-        solver=[prompt_template({prompt_repr}), generate()],
+        dataset=json_dataset(DATASET_PATH, FieldSpec(input="question", target="golden_answer"{field_spec_metadata})),
+        solver=[prompt_template({prompt_repr}), {solver_chain}],
         scorer={scorer_expr},
     )
 '''
@@ -362,25 +370,48 @@ def create_inspect_task_file(
     description: Optional[str] = None,
     prompts: Optional[List[str]] = None,
     scorers: Optional[List[str]] = None,
+    score_only: bool = False,
 ) -> tuple[str, dict]:
     """Create task file code and config JSON.
+
+    When ``score_only`` is True the task file imports
+    ``static_output_solver`` and runs it instead of ``generate()``;
+    each sample's ``actual_output`` metadata field is written directly
+    into ``state.output`` so scorers run against the pre-generated answer.
 
     Returns:
         (task_code, config_dict) — caller writes both to disk.
     """
     scorers = _validate_scorers(scorers)
     config_data = build_config_json(
-        dataset_path, providers, judge_config, description, prompts, scorers
+        dataset_path, providers, judge_config, description, prompts, scorers,
+        score_only=score_only,
     )
 
-    extra_imports = _render_builtin_scorer_imports(scorers)
+    extra_imports_parts: List[str] = []
+    builtin = _render_builtin_scorer_imports(scorers)
+    if builtin:
+        extra_imports_parts.append(builtin)
+    if score_only:
+        extra_imports_parts.append(
+            "from eval_mcp.solvers.static_output import static_output_solver"
+        )
+    extra_imports = "\n".join(extra_imports_parts)
     scorer_expr = _render_scorer_expression(scorers)
+
+    # Solver chain + FieldSpec metadata both swap when score-only is on.
+    # Score-only skips the model call entirely; the static solver lifts
+    # actual_output from sample.metadata and sets state.output.
+    field_spec_metadata = ', metadata=["actual_output"]' if score_only else ""
+    solver_chain = "static_output_solver()" if score_only else "generate()"
+    mode_doc = "\nMode: score-only (no candidate model invoked)." if score_only else ""
 
     parts: List[str] = []
     parts.append(TASK_FILE_BASE.format(
         config_name=config_name,
         scorers_doc=", ".join(scorers),
         extra_imports=(extra_imports + "\n") if extra_imports else "",
+        mode_doc=mode_doc,
     ))
     if "jury" in scorers:
         parts.append(JURY_SCORER_BLOCK)
@@ -397,10 +428,18 @@ def create_inspect_task_file(
             # prompt_template() uses {prompt} as the placeholder for input text
             normalized = prompt.replace("{question}", "{prompt}")
             parts.append(PROMPT_TASK_TEMPLATE.format(
-                index=i + 1, prompt_repr=repr(normalized), scorer_expr=scorer_expr
+                index=i + 1,
+                prompt_repr=repr(normalized),
+                scorer_expr=scorer_expr,
+                field_spec_metadata=field_spec_metadata,
+                solver_chain=solver_chain,
             ))
     else:
-        parts.append(SINGLE_TASK_TEMPLATE.format(scorer_expr=scorer_expr))
+        parts.append(SINGLE_TASK_TEMPLATE.format(
+            scorer_expr=scorer_expr,
+            field_spec_metadata=field_spec_metadata,
+            solver_chain=solver_chain,
+        ))
 
     return "".join(parts), config_data
 
@@ -425,8 +464,9 @@ async def handle_create_eval_config(args: Dict[str, Any]) -> List[TextContent]:
             return [TextContent(type="text", text=json.dumps({"success": False, "error": "dataset is required"}))]
         if not judge_name:
             return [TextContent(type="text", text=json.dumps({"success": False, "error": "judge is required"}))]
-        if not providers:
-            return [TextContent(type="text", text=json.dumps({"success": False, "error": "At least one provider is required"}))]
+        # ``providers`` validity is checked AFTER we know whether this is a
+        # score-only dataset — in score-only mode no candidate model is
+        # invoked and providers can be empty.
 
         try:
             scorers = _validate_scorers(scorers_arg)
@@ -459,13 +499,56 @@ async def handle_create_eval_config(args: Dict[str, Any]) -> List[TextContent]:
         temp_dir.mkdir(parents=True, exist_ok=True)
         dataset_file = temp_dir / f"{dataset_name}.json"
 
+        # Detect score-only mode from the dataset itself: if EVERY sample
+        # carries an actual_output, we score the pre-generated answers
+        # without invoking a candidate model. Mixed datasets (some with,
+        # some without) are refused — the contract is all-or-none so the
+        # subprocess invocation can deterministically skip --model.
+        rows_with_ao = 0
+        rows_without_ao_indices: List[int] = []
+        for i, test in enumerate(tests):
+            v = test.get("vars", test)
+            ao = v.get("actual_output")
+            if isinstance(ao, str) and ao.strip():
+                rows_with_ao += 1
+            else:
+                rows_without_ao_indices.append(i)
+
+        score_only = rows_with_ao > 0 and not rows_without_ao_indices
+        if rows_with_ao > 0 and rows_without_ao_indices:
+            return [TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    f"Dataset '{dataset_name}' has {rows_with_ao}/{len(tests)} samples "
+                    f"with actual_output. Score-only mode requires every sample to have "
+                    f"actual_output (or none — in which case the candidate model is "
+                    f"invoked). Mixed datasets are not supported. Missing rows: "
+                    f"{rows_without_ao_indices[:5]}"
+                    + (" ..." if len(rows_without_ao_indices) > 5 else "")
+                ),
+            }))]
+
+        if not score_only and not providers:
+            return [TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    "At least one provider is required when the dataset has no "
+                    "actual_output column. To score pre-generated answers without "
+                    "calling a candidate model, re-upload the dataset via "
+                    "save_dataset with an actual_output column mapping."
+                ),
+            }))]
+
         inspect_samples = []
         for test in tests:
             v = test.get("vars", test)
-            inspect_samples.append({
+            sample: Dict[str, Any] = {
                 "question": v.get("question", ""),
                 "golden_answer": v.get("golden_answer", ""),
-            })
+            }
+            if score_only:
+                sample["actual_output"] = v.get("actual_output", "")
+            inspect_samples.append(sample)
 
         with open(dataset_file, "w") as f:
             json.dump(inspect_samples, f, indent=2)
@@ -484,13 +567,14 @@ async def handle_create_eval_config(args: Dict[str, Any]) -> List[TextContent]:
 
         task_code, config_data = create_inspect_task_file(
             dataset_path=str(dataset_file),
-            providers=providers,
+            providers=providers or [],
             config_name=config_name,
             config_dir=str(config_dir),
             description=description,
             judge_config=judge_config,
             prompts=prompts,
             scorers=scorers,
+            score_only=score_only,
         )
 
         # Write both files
@@ -503,7 +587,7 @@ async def handle_create_eval_config(args: Dict[str, Any]) -> List[TextContent]:
             "summary": {
                 "dataset": dataset_name,
                 "judge": judge_name,
-                "providers": len(providers),
+                "providers": len(providers or []),
                 "testCases": len(tests),
                 "judges": list(judge_config.judges.keys()),
                 "criteria": [c["name"] for c in criteria],
@@ -513,6 +597,8 @@ async def handle_create_eval_config(args: Dict[str, Any]) -> List[TextContent]:
             },
             "nextStep": f"Run evaluation: run_evaluation(configName='{config_name}')",
         }
+        if score_only:
+            result["summary"]["mode"] = "score-only"
 
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 

--- a/eval_mcp/tools/list_evaluations.py
+++ b/eval_mcp/tools/list_evaluations.py
@@ -80,7 +80,15 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
                 run_id = log.eval.run_id
                 model_id = log.eval.model
                 detail = _detail_for(run_id)
-                aggregate = (detail or {}).get("aggregate", {}).get(model_id) or {}
+                # Score-only runs log model="none/none"; the detail builder
+                # relabels to "pre-generated" — surface the same label here
+                # so the list view doesn't say one thing and the detail view
+                # another.
+                if detail and detail.get("scoreOnly") and model_id == "none/none":
+                    display_model = (detail.get("models") or [model_id])[0]
+                else:
+                    display_model = model_id
+                aggregate = (detail or {}).get("aggregate", {}).get(display_model) or {}
 
                 score_summary: Dict[str, Any] = {"scorer": "jury_scorer", "metrics": {}}
                 if "overall" in aggregate:
@@ -99,7 +107,7 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
                     "id": run_id,
                     "createdAt": str(log.eval.created),
                     "task": log.eval.task,
-                    "model": model_id,
+                    "model": display_model,
                     "totalSamples": log.eval.dataset.samples if log.eval.dataset else 0,
                     "score": score_summary,
                     "status": log.status,

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -366,9 +366,11 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         # Extract model providers from the JSON config file
         models = []
         config_data = None
+        score_only = False
         config_json_path = user_dir / "configs" / f"{config_name}.json"
         if config_json_path.exists():
             config_data = json.loads(config_json_path.read_text())
+            score_only = bool(config_data.get("score_only"))
             # Agent evals use single "model" field; standard evals use "providers" list
             if config_data.get("model"):
                 models = [config_data["model"]]
@@ -441,8 +443,10 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             "--log-shared", "10",
         ]
 
-        # Pass models to inspect eval (comma-separated for multiple)
-        if models:
+        # Pass models to inspect eval (comma-separated for multiple).
+        # Score-only configs invoke no model — Inspect AI supports running
+        # without --model when the task's solver never calls generate().
+        if models and not score_only:
             cmd.extend(["--model", ",".join(models)])
 
         # Run the evaluation from the user's directory

--- a/eval_mcp/tools/save_dataset.py
+++ b/eval_mcp/tools/save_dataset.py
@@ -4,7 +4,7 @@ import csv
 import io
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mcp.types import TextContent
 from eval_mcp.core.user_storage import save_dataset_to_db
@@ -52,24 +52,34 @@ def rows_to_test_cases(
     rows: List[Dict[str, Any]],
     question_col: str,
     answer_col: str,
+    actual_output_col: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Convert rows to test case format.
 
     Returns:
-        List of test cases with vars.question and vars.golden_answer
+        List of test cases with ``vars.question`` and ``vars.golden_answer``.
+        When ``actual_output_col`` is provided, the corresponding column
+        is also captured as ``vars.actual_output`` — that signals
+        ``create_eval_config`` to run in score-only mode (no candidate
+        model invoked; the static answer is scored directly).
     """
     test_cases = []
     for row in rows:
         q_val = str(row.get(question_col, "")).strip()
         a_val = str(row.get(answer_col, "")).strip()
 
-        if q_val and a_val:
-            test_cases.append({
-                "vars": {
-                    "question": q_val,
-                    "golden_answer": a_val,
-                }
-            })
+        if not (q_val and a_val):
+            continue
+        vars_dict: Dict[str, Any] = {
+            "question": q_val,
+            "golden_answer": a_val,
+        }
+        if actual_output_col:
+            ao_raw = row.get(actual_output_col)
+            ao_val = str(ao_raw).strip() if ao_raw is not None else ""
+            if ao_val:
+                vars_dict["actual_output"] = ao_val
+        test_cases.append({"vars": vars_dict})
 
     return test_cases
 
@@ -141,6 +151,7 @@ async def handle_save_dataset(args: Dict[str, Any]) -> List[TextContent]:
 
     question_col = column_mapping.get("question")
     answer_col = column_mapping.get("golden_answer")
+    actual_output_col = column_mapping.get("actual_output")
 
     if not question_col or not answer_col:
         return [TextContent(
@@ -154,7 +165,9 @@ async def handle_save_dataset(args: Dict[str, Any]) -> List[TextContent]:
     try:
         # Parse content and convert to test case format
         rows = parse_content_to_rows(file_content, filename)
-        test_cases = rows_to_test_cases(rows, question_col, answer_col)
+        test_cases = rows_to_test_cases(
+            rows, question_col, answer_col, actual_output_col
+        )
 
         if not test_cases:
             return [TextContent(
@@ -177,15 +190,16 @@ async def handle_save_dataset(args: Dict[str, Any]) -> List[TextContent]:
             source={"kind": "imported", "origin": filename},
         )
 
-        return [TextContent(
-            type="text",
-            text=json.dumps({
-                "success": True,
-                "dataset_id": dataset_id,
-                "name": dataset_name,
-                "rows_saved": len(test_cases),
-            }),
-        )]
+        ao_rows = sum(1 for tc in test_cases if "actual_output" in tc.get("vars", {}))
+        result_payload: Dict[str, Any] = {
+            "success": True,
+            "dataset_id": dataset_id,
+            "name": dataset_name,
+            "rows_saved": len(test_cases),
+        }
+        if actual_output_col:
+            result_payload["actual_output_rows"] = ao_rows
+        return [TextContent(type="text", text=json.dumps(result_payload))]
 
     except Exception as e:
         return [TextContent(

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -142,3 +142,75 @@ def test_prompt_template_carries_scorer_expr(jc: JudgeConfig) -> None:
     assert "def eval_1" in code
     assert "def eval_2" in code
     ast.parse(code)
+
+
+# ----- score-only mode -----
+
+
+def _render_score_only(jc: JudgeConfig, scorers=None, prompts=None) -> tuple[str, dict]:
+    return create_inspect_task_file(
+        dataset_path="/tmp/ds.json",
+        providers=[],
+        config_name="t",
+        config_dir="/tmp",
+        judge_config=jc,
+        scorers=scorers,
+        prompts=prompts,
+        score_only=True,
+    )
+
+
+def test_score_only_emits_static_solver(jc: JudgeConfig) -> None:
+    code, cfg = _render_score_only(jc, scorers=["f1"])
+    # Imports the solver from our module
+    assert (
+        "from eval_mcp.solvers.static_output import static_output_solver"
+        in code
+    )
+    # Solver chain uses the static solver instead of generate()
+    assert "solver=[static_output_solver()]" in code
+    # No `generate()` call in the solver chain (the chain itself —
+    # `generate` is still imported via the base template, used as a
+    # fallback inside the solver factory itself).
+    assert "solver=[generate()]" not in code
+    # FieldSpec carries actual_output as metadata
+    assert 'metadata=["actual_output"]' in code
+    # Config has the score_only flag set
+    assert cfg["score_only"] is True
+    ast.parse(code)
+
+
+def test_score_only_with_jury(jc: JudgeConfig) -> None:
+    code, _ = _render_score_only(jc, scorers=["jury"])
+    # Jury scorer block still emitted — jury grades the pre-generated answer
+    assert "def jury_scorer" in code
+    assert "scorer=jury_scorer()" in code
+    # Static solver still wired in
+    assert "solver=[static_output_solver()]" in code
+    ast.parse(code)
+
+
+def test_score_only_doc_mentions_mode(jc: JudgeConfig) -> None:
+    code, _ = _render_score_only(jc, scorers=["f1"])
+    assert "score-only" in code.lower()
+
+
+def test_score_only_with_prompts(jc: JudgeConfig) -> None:
+    code, _ = _render_score_only(
+        jc, scorers=["f1"], prompts=["Prompt A: {question}", "Prompt B: {question}"]
+    )
+    # Both @task defs use the static solver
+    assert code.count("static_output_solver()") == 2
+    assert code.count('metadata=["actual_output"]') == 2
+    assert "solver=[generate()" not in code
+    ast.parse(code)
+
+
+def test_non_score_only_unchanged(jc: JudgeConfig) -> None:
+    # Sanity: backward-compat path. Default mode emits generate(), no
+    # static solver, no metadata field, no score_only flag.
+    code, cfg = _render(jc, scorers=["f1"])
+    assert "solver=[generate()]" in code
+    assert "static_output_solver" not in code
+    assert 'metadata=["actual_output"]' not in code
+    assert "score_only" not in cfg

--- a/tests/test_save_dataset_score_only.py
+++ b/tests/test_save_dataset_score_only.py
@@ -1,0 +1,63 @@
+"""Tests for save_dataset's actual_output column handling.
+
+Score-only mode is opt-in via the column mapping — when an
+``actual_output`` source column is supplied, the test cases capture
+the value as ``vars.actual_output``. Empty / missing values are
+silently dropped (per-row) and ``create_eval_config`` later refuses
+mixed datasets at config-generation time.
+"""
+
+from eval_mcp.tools.save_dataset import rows_to_test_cases
+
+
+def test_omits_actual_output_when_column_unmapped() -> None:
+    rows = [{"q": "Q?", "a": "A.", "ao": "static answer"}]
+    cases = rows_to_test_cases(rows, "q", "a")
+    assert cases == [{"vars": {"question": "Q?", "golden_answer": "A."}}]
+
+
+def test_includes_actual_output_when_column_mapped() -> None:
+    rows = [{"q": "Q1?", "a": "A1.", "ao": "the model said: A1."}]
+    cases = rows_to_test_cases(rows, "q", "a", "ao")
+    assert cases == [
+        {
+            "vars": {
+                "question": "Q1?",
+                "golden_answer": "A1.",
+                "actual_output": "the model said: A1.",
+            }
+        }
+    ]
+
+
+def test_drops_empty_actual_output_per_row() -> None:
+    # Empty cells should NOT become actual_output="" — they're dropped
+    # so create_eval_config's mixed-dataset detection can see them as
+    # missing rather than as a present-but-empty signal.
+    rows = [
+        {"q": "Q1?", "a": "A1.", "ao": "answer one"},
+        {"q": "Q2?", "a": "A2.", "ao": ""},
+        {"q": "Q3?", "a": "A3.", "ao": "   "},
+        {"q": "Q4?", "a": "A4."},
+    ]
+    cases = rows_to_test_cases(rows, "q", "a", "ao")
+    assert len(cases) == 4
+    assert "actual_output" in cases[0]["vars"]
+    assert "actual_output" not in cases[1]["vars"]
+    assert "actual_output" not in cases[2]["vars"]
+    assert "actual_output" not in cases[3]["vars"]
+
+
+def test_skips_rows_missing_question_or_answer() -> None:
+    rows = [
+        {"q": "Q1?", "a": "A1.", "ao": "ao1"},
+        {"q": "Q2?", "a": "", "ao": "ao2"},      # missing answer
+        {"q": "", "a": "A3.", "ao": "ao3"},      # missing question
+        {"q": "Q4?", "a": "A4.", "ao": "ao4"},
+    ]
+    cases = rows_to_test_cases(rows, "q", "a", "ao")
+    # Only Q1 and Q4 survive; Q2/Q3 are dropped because the contract
+    # requires both question and golden_answer.
+    assert len(cases) == 2
+    assert [c["vars"]["question"] for c in cases] == ["Q1?", "Q4?"]
+    assert all("actual_output" in c["vars"] for c in cases)

--- a/tests/test_static_output_solver.py
+++ b/tests/test_static_output_solver.py
@@ -1,0 +1,67 @@
+"""Pure-logic smoke test for the static_output_solver.
+
+We can't fully simulate Inspect's TaskState in a unit test, but the
+solver's behavior is narrow: read ``state.metadata["actual_output"]``,
+build a ``ModelOutput.from_content``, set ``state.output``, return.
+Stub out the bits we need.
+"""
+
+import pytest
+
+from eval_mcp.solvers.static_output import STATIC_MODEL_ID, static_output_solver
+
+
+class _Stub:
+    """Minimal stand-in for TaskState.
+
+    Inspect's TaskState has dozens of fields; the solver only touches
+    ``metadata`` (read) and ``output`` (write). A duck-typed class with
+    those two attributes is enough for a unit test.
+    """
+
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.output = None
+
+
+async def _noop_generate(state):
+    """Stand-in for the ``generate`` arg the solver receives. Should
+    only be called when actual_output is absent. We mark on the state
+    so the test can assert behaviour."""
+    state.output = "FELL_THROUGH_TO_GENERATE"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_sets_output_from_metadata() -> None:
+    solver = static_output_solver()
+    state = _Stub(metadata={"actual_output": "pre-generated reply"})
+    result = await solver(state, _noop_generate)
+    # state.output is a ModelOutput; its .completion is the content
+    assert result.output is not None
+    assert result.output.completion == "pre-generated reply"
+    assert result.output.model == STATIC_MODEL_ID
+
+
+@pytest.mark.asyncio
+async def test_falls_through_to_generate_when_missing() -> None:
+    solver = static_output_solver()
+    state = _Stub(metadata={})
+    result = await solver(state, _noop_generate)
+    assert result.output == "FELL_THROUGH_TO_GENERATE"
+
+
+@pytest.mark.asyncio
+async def test_falls_through_when_empty() -> None:
+    solver = static_output_solver()
+    state = _Stub(metadata={"actual_output": ""})
+    result = await solver(state, _noop_generate)
+    assert result.output == "FELL_THROUGH_TO_GENERATE"
+
+
+@pytest.mark.asyncio
+async def test_handles_none_metadata() -> None:
+    solver = static_output_solver()
+    state = _Stub(metadata=None)
+    result = await solver(state, _noop_generate)
+    assert result.output == "FELL_THROUGH_TO_GENERATE"


### PR DESCRIPTION
## Summary

Adds an \`actual_output\` column to \`save_dataset\`. When every sample in the dataset has it populated, \`create_eval_config\` auto-detects score-only mode: \`providers\` becomes optional, the generated task file swaps \`generate()\` for a \`static_output_solver()\` that lifts \`actual_output\` from sample metadata into \`state.output\` via \`ModelOutput.from_content\`, and \`run_eval.py\` invokes Inspect without \`--model\`. Mixed datasets (some samples with \`actual_output\`, some without) fail fast at config-creation time.

All existing scorers (\`jury\`, \`f1\`, \`exact\`, \`includes\`, \`match\`) work unchanged — they read \`state.output\` regardless of how it got populated. The viewer relabels Inspect's \`"none/none"\` model literal to \`"pre-generated"\`, mirroring the existing \`agent/<image>\` swap for agent evals.

## Why

The MCP today always runs the candidate model at eval time. That blocks a few real workflows:

1. Customers running their own RAG / agent / chatbot in production can't score those outputs with our judges without re-running inference inside Inspect, which changes the prompting path and therefore the answer being scored.
2. Iterating on a judge config requires re-running the candidate model on every iteration — expensive.
3. Re-grading historical evals with new criteria isn't possible.
4. A/B comparison of pre-recorded outputs from two systems isn't possible.

Inspect AI itself supports running without \`--model\` (verified — a solver that does \`state.output = ModelOutput.from_content(...)\` and never calls \`generate()\` runs cleanly and produces a normal eval log). This PR just exposes that.

## What's in the diff

- \`eval_mcp/solvers/static_output.py\` (new) — \`static_output_solver()\`. Reads \`state.metadata["actual_output"]\`, builds a \`ModelOutput\`, sets \`state.output\`. Falls through to \`generate()\` when the field is absent so the solver itself stays composable.
- \`eval_mcp/tools/save_dataset.py\` — \`column_mapping\` learns an optional \`actual_output\` slot. Empty / whitespace cells are dropped per-row so the downstream mixed-dataset detection works.
- \`eval_mcp/tools/create_config.py\` — auto-detects score-only from the dataset (all-or-none contract, fail fast on mixed). When detected: \`providers\` optional, \`score_only: true\` persisted in the config JSON, task file imports the static solver, \`FieldSpec\` carries \`metadata=["actual_output"]\`, solver chain is \`[static_output_solver()]\`.
- \`eval_mcp/tools/run_eval.py\` — when \`config.score_only\` is true, the \`inspect eval\` subprocess command omits \`--model\` entirely.
- \`eval_mcp/core/eval_results.py\` — adds an \`elif\` after the existing \`agent_image\` relabel: when \`score_only\` and \`models == ["none/none"]\`, relabels to \`["pre-generated"]\` with the same key swap in \`aggregate\`, \`stats\`, and per-sample \`results\`.
- \`eval_mcp/server.py\` — \`save_dataset\` and \`create_eval_config\` docstrings document the new column and auto-detection.

## Test plan

- [x] Full pytest suite green: 299 passed, 2 skipped, no regressions.
- [x] 27 new / extended tests covering: static solver behavior (with output / falls through on missing / handles None metadata), \`save_dataset\` column flow + empty-cell dropping, create_config score-only render (static solver, no \`generate()\`, metadata field, jury composition, prompt comparison), and the backward-compat sanity check.
- [x] End-to-end: created a score-only config from a synthetic dataset, ran \`inspect eval\` (no \`--model\`, no errors), got sensible \`f1\` and \`includes\` scores against the pre-generated outputs, viewer JSON shows \`"pre-generated"\` as the model column header and \`scoreOnly: true\`.
- [x] Mixed-dataset fail-fast: dataset with 2/3 \`actual_output\` rows returns a clear error naming the missing row indices.

## Out of scope (deferred)

- Score-only support for \`create_agent_eval_config\` / \`create_pipeline_eval_config\`. Different shape, lower value.
- Per-row fallback (some rows static, some rows generate). All-or-none is the v1 contract.
- A user-facing \`score_only\` flag — auto-detection from the dataset is cleaner and harder to misuse.
- RAG-style metrics that ALSO need \`retrieval_context\`. That's PR #93, which sits on top of this; the column patterns are compatible and the second PR will pick up score-only automatically.