### PR TITLE
feat(mcp): synthetic-RAG mode for QA generation (attachSourceContext)

### DIFF
--- a/backend/core/agent.py
+++ b/backend/core/agent.py
@@ -68,6 +68,8 @@ Available Tools:
 - generate_qa_pairs: Create test dataset with questions and golden answers
   * Persona mode: generate_qa_pairs(prompt="topic description", numSamples=10)
   * Document mode: generate_qa_pairs(documents=["path/to/doc.pdf"], numSamples=10)
+  * Synthetic-RAG mode: generate_qa_pairs(documents=[...], attachSourceContext=True)
+    adds a retrieval_context column so RAG scorers can run (see RAG EVALUATION below)
   * Large documents are automatically chunked - can generate many QA pairs (20 per chunk)
   * When user uploads documents, use the provided document paths with this tool
   * When user asks to use existing documents, first call list_documents to get paths
@@ -135,6 +137,38 @@ User: "Create QA pairs from my uploaded documents" or "Use my existing docs"
 1. list_documents() → get list of available document paths
 2. generate_qa_pairs(documents=[...paths from step 1...], numSamples=10) → get dataset name
 Then continue with generate_judge(dataset=...), create_eval_config(dataset=..., judge=...), etc.
+
+RAG EVALUATION:
+RAG scorers (faithfulness, answer_relevancy, contextual_precision, contextual_recall,
+contextual_relevancy) score answers against a retrieval_context column - the chunks a
+retriever pulled per question. A dataset needs that column before any RAG scorer can run.
+There are two honest ways to get it; pick based on what the user has:
+
+1. The user has a real retriever (their RAG pipeline):
+   They must upload their retriever's actual output - rows of
+   {question, golden_answer, retrieval_context: [chunk1, chunk2, ...]} - via save_dataset.
+   This is the only path that meaningfully scores RETRIEVAL quality
+   (contextual_precision/recall/relevancy).
+
+2. The user only has documents, no retriever (e.g. "run a RAG eval on this PDF"):
+   Use synthetic-RAG mode: generate_qa_pairs(documents=[...], attachSourceContext=True).
+   Each pair's retrieval_context is set to the source chunk it was generated from.
+   This validly scores the GENERATOR (faithfulness, answer_relevancy) but NOT the
+   retriever - the source chunk IS the context, so contextual_* would be trivially
+   perfect. Select ONLY faithfulness and answer_relevancy for synthetic datasets.
+
+NEVER claim you can produce retrieval_context from a document without attachSourceContext -
+plain document/persona mode produces only question + golden_answer, and a RAG scorer on
+such a dataset will fail fast asking for the missing column. Don't promise it, then loop.
+
+Example - "run a RAG eval on this PDF" (user has no retriever):
+User: [Uploaded 1 document. Document paths for generate_qa_pairs: ["paper.pdf"]]
+1. generate_qa_pairs(documents=["paper.pdf"], numSamples=5, attachSourceContext=True)
+   → dataset with retrieval_context attached
+2. create_eval_config(dataset=..., providers=[...], scorers=["faithfulness", "answer_relevancy"])
+3. run_evaluation(configName=...) → viewerUrl
+Tell the user this scored answer faithfulness/relevancy against the source passages, and
+that scoring retrieval quality would require uploading their own retriever's chunks.
 """
 
     async def _load_tool_descriptions(self) -> None:

--- a/eval_mcp/core/document_chunking.py
+++ b/eval_mcp/core/document_chunking.py
@@ -212,6 +212,40 @@ def extract_pdf_pages(pdf_bytes: bytes, start_page: int, end_page: int) -> bytes
     return output.getvalue()
 
 
+def pdf_to_text(pdf_bytes: bytes, skip_pages: int = 0) -> str:
+    """Extract plain text from a PDF, skipping the first ``skip_pages``.
+
+    ``skip_pages`` is used to drop a chunk's leading context-overlap pages so
+    only the *content* pages contribute. Best-effort: PDF text extraction is
+    lossy for tables/figures/multi-column layouts, which is acceptable for the
+    synthetic ``retrieval_context`` it feeds (faithfulness/answer_relevancy
+    judge against this text, not a pixel-perfect rendering).
+
+    Returns page texts joined by blank lines; empty string if nothing extracts.
+    """
+    from pypdf import PdfReader
+
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    parts: List[str] = []
+    for page in reader.pages[skip_pages:]:
+        try:
+            text = page.extract_text() or ""
+        except Exception:
+            text = ""
+        if text.strip():
+            parts.append(text.strip())
+    return "\n\n".join(parts)
+
+
+def pdf_chunk_to_text(chunk: PDFChunk) -> str:
+    """Plain text of a PDF chunk's *content* pages (excludes leading overlap).
+
+    Used to synthesise ``retrieval_context`` for RAG-style QA datasets: the
+    chunk a QA pair was generated from IS that pair's retrieved context.
+    """
+    return pdf_to_text(chunk.pdf_bytes, skip_pages=chunk.context_page_count)
+
+
 def chunk_pdf(pdf_bytes: bytes) -> List[PDFChunk]:
     """Chunk PDF into smaller PDFs with overlap for context continuity.
 

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -414,6 +414,7 @@ async def generate_qa_pairs(
     instructions: str = None,
     numSamples: NumSamples = 10,
     numPersonas: NumPersonas = 5,
+    attachSourceContext: bool = False,
 ) -> str:
     """
     Generate question-answer pairs with golden answers for LLM-as-judge evaluation.
@@ -429,6 +430,15 @@ async def generate_qa_pairs(
         instructions: Additional instructions for QA generation
         numSamples: Number of QA pairs to generate (default: 10)
         numPersonas: Number of personas for synthetic generation (default: 5, persona mode only)
+        attachSourceContext: Synthetic-RAG mode (document mode only). When True, each
+            QA pair gets a 'retrieval_context' column set to the source chunk it was
+            generated from — enough to run the RAG scorers 'faithfulness' and
+            'answer_relevancy' in create_eval_config WITHOUT a real retriever. The
+            source chunk IS the retrieved context, so the retriever-side scorers
+            (contextual_precision/recall/relevancy) are NOT meaningful here — don't
+            select them. For a true RAG eval, instead upload your retriever's actual
+            chunks via save_dataset's retrieval_context column. Ignored in persona/
+            agent mode (no source document). Default False.
 
     Returns:
         JSON with dataset name and summary. Use with generate_judge and create_eval_config.
@@ -440,6 +450,7 @@ async def generate_qa_pairs(
         "instructions": instructions,
         "numSamples": numSamples,
         "numPersonas": numPersonas,
+        "attachSourceContext": attachSourceContext,
     }
     result = await handle_generate_qa_pairs(bedrock, args)
     return result[0].text

--- a/eval_mcp/tools/generate_qa.py
+++ b/eval_mcp/tools/generate_qa.py
@@ -23,6 +23,8 @@ from eval_mcp.core.document_chunking import (
     chunk_pdf,
     format_chunk_prompt_text,
     format_chunk_prompt_pdf,
+    pdf_to_text,
+    pdf_chunk_to_text,
     MAX_CONTEXT_TOKENS,
 )
 
@@ -31,6 +33,24 @@ MAX_QA_PER_CHUNK = 20
 
 # Structured logger for QA generation
 logger = get_logger("mcp_tools.synthetic.qa")
+
+
+def _attach_context(
+    pairs: List[Dict[str, Any]], context_text: str
+) -> List[Dict[str, Any]]:
+    """Stamp each QA pair with synthetic ``retrieval_context = [context_text]``.
+
+    Synthetic-RAG mode: the chunk a pair was generated from IS that pair's
+    retrieved context, so the RAG scorers (faithfulness, answer_relevancy) can
+    run end-to-end without a real retriever. No-op when ``context_text`` is
+    empty (an image, or a PDF page with no extractable text) — the pair simply
+    carries no ``retrieval_context`` and RAG scoring will skip/flag it.
+    """
+    if not context_text or not context_text.strip():
+        return pairs
+    for pair in pairs:
+        pair["retrieval_context"] = [context_text]
+    return pairs
 
 
 # Tool schema for structured QA output - forces reliable JSON generation
@@ -521,6 +541,7 @@ async def generate_qa_pairs_from_document(
     num_pairs: int,
     prompt: Optional[str] = None,
     instructions: Optional[str] = None,
+    attach_source_context: bool = False,
 ) -> List[Dict[str, Any]]:
     """Generate QA pairs from a single document using multimodal input.
 
@@ -535,9 +556,14 @@ async def generate_qa_pairs_from_document(
         num_pairs: Number of QA pairs to generate (up to MAX_QA_PER_CHUNK per chunk)
         prompt: Optional context about the AI system/use case
         instructions: Optional additional instructions
+        attach_source_context: Synthetic-RAG mode. When True, each pair carries
+            ``retrieval_context`` set to the source chunk it was generated from,
+            so RAG scorers (faithfulness, answer_relevancy) can run without a
+            real retriever. Images yield no text and are left without context.
 
     Returns:
-        List of QA pair dicts with 'question' and 'golden_answer' keys
+        List of QA pair dicts with 'question' and 'golden_answer' keys (plus
+        'retrieval_context' when ``attach_source_context`` is set)
     """
     # Load document content
     content_bytes, media_type = get_document_content(user_id, doc_path)
@@ -550,12 +576,14 @@ async def generate_qa_pairs_from_document(
         if media_type == "application/pdf":
             # PDF: Chunk by pages
             return await _generate_qa_from_pdf_chunks(
-                bedrock, user_id, doc_path, content_bytes, num_pairs, prompt, instructions
+                bedrock, user_id, doc_path, content_bytes, num_pairs, prompt,
+                instructions, attach_source_context=attach_source_context,
             )
         else:
             # Text-based: Chunk by tokens
             return await _generate_qa_from_text_chunks(
-                bedrock, user_id, doc_path, content_bytes, num_pairs, prompt, instructions
+                bedrock, user_id, doc_path, content_bytes, num_pairs, prompt,
+                instructions, attach_source_context=attach_source_context,
             )
 
     # Document is small enough - process as single unit
@@ -584,10 +612,23 @@ async def generate_qa_pairs_from_document(
         text_content = content_bytes.decode("utf-8", errors="replace")
         doc_content = f"<document filename=\"{doc_path}\">\n{text_content}\n</document>"
 
-    return await _generate_qa_from_content(
+    qa_pairs = await _generate_qa_from_content(
         bedrock, user_id, doc_path, doc_content, media_type,
         min(num_pairs, MAX_QA_PER_CHUNK), prompt, instructions
     )
+
+    if attach_source_context:
+        # Whole (small) document is the source context for every pair. PDFs
+        # are extracted to text; images have none and are left uncontextualised.
+        if media_type == "application/pdf":
+            source_text = pdf_to_text(content_bytes)
+        elif media_type.startswith("image/"):
+            source_text = ""
+        else:
+            source_text = content_bytes.decode("utf-8", errors="replace")
+        _attach_context(qa_pairs, source_text)
+
+    return qa_pairs
 
 
 async def _generate_qa_from_text_chunks(
@@ -598,6 +639,7 @@ async def _generate_qa_from_text_chunks(
     num_pairs: int,
     prompt: Optional[str] = None,
     instructions: Optional[str] = None,
+    attach_source_context: bool = False,
 ) -> List[Dict[str, Any]]:
     """Generate QA pairs from a large text document by chunking.
 
@@ -633,6 +675,8 @@ async def _generate_qa_from_text_chunks(
             pairs_for_this_chunk, prompt, instructions,
             chunk_info=f"This is chunk {i + 1} of {len(chunks)} from the document."
         )
+        if attach_source_context:
+            _attach_context(chunk_qa, chunk.content)
         log_event(logger, "info", "chunk_processed",
                   user_id=user_id, document=doc_path,
                   chunk=i + 1, total_chunks=len(chunks),
@@ -667,6 +711,7 @@ async def _generate_qa_from_pdf_chunks(
     num_pairs: int,
     prompt: Optional[str] = None,
     instructions: Optional[str] = None,
+    attach_source_context: bool = False,
 ) -> List[Dict[str, Any]]:
     """Generate QA pairs from a large PDF by processing page ranges.
 
@@ -712,6 +757,8 @@ async def _generate_qa_from_pdf_chunks(
             pairs_for_this_chunk, prompt, instructions,
             chunk_info=page_instructions
         )
+        if attach_source_context:
+            _attach_context(chunk_qa, pdf_chunk_to_text(chunk))
         log_event(logger, "info", "pdf_chunk_processed",
                   user_id=user_id, document=doc_path,
                   chunk=i + 1, total_chunks=len(chunks),
@@ -758,6 +805,7 @@ async def generate_qa_pairs_from_documents(
     num_samples: int,
     prompt: Optional[str] = None,
     instructions: Optional[str] = None,
+    attach_source_context: bool = False,
 ) -> List[Dict[str, Any]]:
     """Generate QA pairs from multiple documents in parallel.
 
@@ -792,7 +840,8 @@ async def generate_qa_pairs_from_documents(
         """
         tasks = [
             generate_qa_pairs_from_document(
-                bedrock, user_id, p, n, prompt, instructions
+                bedrock, user_id, p, n, prompt, instructions,
+                attach_source_context=attach_source_context,
             )
             for p, n in zip(paths, allocs) if n > 0
         ]
@@ -868,6 +917,7 @@ async def handle_generate_qa_pairs(bedrock: BedrockClient, args: Dict[str, Any])
     instructions = args.get("instructions")
     num_samples = args.get("numSamples", 10)
     documents = args.get("documents", [])  # List of document paths
+    attach_source_context = bool(args.get("attachSourceContext", False))
     user_id = args.get("user_id")
 
     # Validate user_id
@@ -934,7 +984,8 @@ async def handle_generate_qa_pairs(bedrock: BedrockClient, args: Dict[str, Any])
                       document_count=len(documents), num_samples=num_samples)
 
             all_qa_pairs = await generate_qa_pairs_from_documents(
-                bedrock, user_id, documents, num_samples, prompt, instructions
+                bedrock, user_id, documents, num_samples, prompt, instructions,
+                attach_source_context=attach_source_context,
             )
 
             summary = {
@@ -942,6 +993,7 @@ async def handle_generate_qa_pairs(bedrock: BedrockClient, args: Dict[str, Any])
                 "requested": num_samples,
                 "mode": "document",
                 "documents": documents,
+                "syntheticRag": attach_source_context,
             }
 
         else:
@@ -1016,12 +1068,16 @@ async def handle_generate_qa_pairs(bedrock: BedrockClient, args: Dict[str, Any])
         test_cases = []
         for qa in all_qa_pairs:
             if "question" in qa and "golden_answer" in qa:
-                test_cases.append({
-                    "vars": {
-                        "question": qa["question"],
-                        "golden_answer": qa["golden_answer"],
-                    },
-                })
+                qa_vars = {
+                    "question": qa["question"],
+                    "golden_answer": qa["golden_answer"],
+                }
+                # Synthetic-RAG: carry the source chunk through as
+                # retrieval_context so create_eval_config's FieldSpec picks it
+                # up (it reads vars.retrieval_context). Only present when set.
+                if qa.get("retrieval_context"):
+                    qa_vars["retrieval_context"] = qa["retrieval_context"]
+                test_cases.append({"vars": qa_vars})
 
         # Generate dataset name with actual count
         dataset_name = f"{safe_name}_{len(test_cases)}"
@@ -1030,7 +1086,8 @@ async def handle_generate_qa_pairs(bedrock: BedrockClient, args: Dict[str, Any])
         if wrapper_path:
             source = {"kind": "synthetic", "mode": "agent", "agent": wrapper_path}
         elif use_documents:
-            source = {"kind": "synthetic", "mode": "document", "documents": documents}
+            source = {"kind": "synthetic", "mode": "document", "documents": documents,
+                      "synthetic_rag": attach_source_context}
         else:
             source = {"kind": "synthetic", "mode": "persona", "prompt": prompt}
 

--- a/tests/test_generate_qa_rag.py
+++ b/tests/test_generate_qa_rag.py
@@ -1,0 +1,128 @@
+"""Unit tests for synthetic-RAG QA generation (attachSourceContext).
+
+Covers the deterministic pieces only — the context-stamping helper and PDF
+text extraction. The end-to-end flow (generate_qa_pairs → save_dataset →
+create_eval_config RAG scoring) needs Bedrock + a subprocess and is exercised
+by running the MCP, not by pytest (see CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eval_mcp.tools.generate_qa import _attach_context
+from eval_mcp.core.document_chunking import (
+    PDFChunk,
+    pdf_to_text,
+    pdf_chunk_to_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# _attach_context — stamps retrieval_context onto each pair
+# ---------------------------------------------------------------------------
+
+
+def test_attach_context_stamps_each_pair():
+    pairs = [
+        {"question": "q1", "golden_answer": "a1"},
+        {"question": "q2", "golden_answer": "a2"},
+    ]
+    _attach_context(pairs, "the source chunk")
+    for p in pairs:
+        assert p["retrieval_context"] == ["the source chunk"]
+
+
+def test_attach_context_is_a_list_of_one():
+    """RAG scorers expect retrieval_context: list[str]. One source chunk → [chunk]."""
+    pairs = [{"question": "q", "golden_answer": "a"}]
+    _attach_context(pairs, "chunk text")
+    rc = pairs[0]["retrieval_context"]
+    assert isinstance(rc, list) and len(rc) == 1 and isinstance(rc[0], str)
+
+
+def test_attach_context_noop_on_empty_text():
+    """An image / blank PDF page yields no text → leave the pair uncontextualised."""
+    pairs = [{"question": "q", "golden_answer": "a"}]
+    _attach_context(pairs, "")
+    assert "retrieval_context" not in pairs[0]
+
+
+def test_attach_context_noop_on_whitespace_only():
+    pairs = [{"question": "q", "golden_answer": "a"}]
+    _attach_context(pairs, "   \n\t  ")
+    assert "retrieval_context" not in pairs[0]
+
+
+def test_attach_context_returns_same_list():
+    pairs = [{"question": "q", "golden_answer": "a"}]
+    assert _attach_context(pairs, "x") is pairs
+
+
+# ---------------------------------------------------------------------------
+# PDF text extraction — pdf_to_text / pdf_chunk_to_text
+# ---------------------------------------------------------------------------
+
+
+def _make_pdf(page_texts: list[str]) -> bytes:
+    """Build a minimal multi-page PDF with one known line of text per page."""
+    fpdf = pytest.importorskip("fpdf")
+    doc = fpdf.FPDF()
+    doc.set_font("helvetica", size=12)
+    for text in page_texts:
+        doc.add_page()
+        doc.cell(0, 10, text)
+    out = doc.output()  # fpdf2 returns a bytearray
+    return bytes(out)
+
+
+def test_pdf_to_text_extracts_all_pages():
+    pdf = _make_pdf(["AlphaPageOne", "BetaPageTwo", "GammaPageThree"])
+    text = pdf_to_text(pdf)
+    assert "AlphaPageOne" in text
+    assert "BetaPageTwo" in text
+    assert "GammaPageThree" in text
+
+
+def test_pdf_to_text_skip_pages_drops_leading_pages():
+    """skip_pages drops a chunk's context-overlap pages from the front."""
+    pdf = _make_pdf(["OverlapContext", "RealContentHere"])
+    text = pdf_to_text(pdf, skip_pages=1)
+    assert "OverlapContext" not in text
+    assert "RealContentHere" in text
+
+
+def test_pdf_chunk_to_text_excludes_context_pages():
+    """A PDFChunk's leading context_page_count pages are overlap — exclude them."""
+    pdf = _make_pdf(["PrevChunkOverlap", "ThisChunkContent"])
+    chunk = PDFChunk(
+        pdf_bytes=pdf,
+        context_page_count=1,  # first page is overlap from the previous chunk
+        content_page_count=1,
+        chunk_start_page=1,
+        chunk_end_page=2,
+    )
+    text = pdf_chunk_to_text(chunk)
+    assert "PrevChunkOverlap" not in text
+    assert "ThisChunkContent" in text
+
+
+def test_pdf_chunk_to_text_first_chunk_keeps_all():
+    """First chunk has no overlap (context_page_count=0) — keep everything."""
+    pdf = _make_pdf(["FirstChunkPageA", "FirstChunkPageB"])
+    chunk = PDFChunk(
+        pdf_bytes=pdf,
+        context_page_count=0,
+        content_page_count=2,
+        chunk_start_page=1,
+        chunk_end_page=2,
+    )
+    text = pdf_chunk_to_text(chunk)
+    assert "FirstChunkPageA" in text
+    assert "FirstChunkPageB" in text
+
+
+def test_pdf_to_text_empty_on_garbage():
+    """Non-PDF bytes shouldn't crash callers — surface as a read error, not a hang."""
+    with pytest.raises(Exception):
+        pdf_to_text(b"not a pdf at all")


### PR DESCRIPTION
## Summary

- Adds `attachSourceContext=True` to `generate_qa_pairs` (document mode): each QA pair gets a `retrieval_context` column set to the source chunk it was generated from, so the RAG scorers from #93 can run end-to-end **without a real retriever**.
- Validly scores the **generator** (`faithfulness`, `answer_relevancy`) — the same idea as DeepEval's Synthesizer. Retriever-side metrics (`contextual_precision/recall/relevancy`) are ~perfect by construction here and documented as not meaningful in this mode.
- Teaches the chat agent (`backend/core/agent.py`) a RAG playbook so "run a RAG eval on this PDF" stops dead-ending.

## Why

After #93, RAG scorers require a `retrieval_context` column — but nothing could produce it from a document: `generate_qa` chunks the doc, writes Q/A from each chunk, then **discarded the chunk**, and there's no retriever tool. So a PDF-only "full RAG eval" was impossible, and the web-app agent overpromised then looped. This stops discarding the chunk — the chunk a pair was generated from *is* its retrieved context.

For a **true** retrieval eval, users still upload their own retriever's chunks via `save_dataset` (unchanged); this mode is the honest path when they only have documents.

## What changed

- `eval_mcp/core/document_chunking.py` — `pdf_to_text` / `pdf_chunk_to_text` (content pages only, skipping a chunk's context-overlap pages).
- `eval_mcp/tools/generate_qa.py` — thread `attach_source_context` through all three generation paths (chunked PDF, chunked text, small-doc); carry `retrieval_context` into `vars` so `create_eval_config`'s `FieldSpec(metadata=["retrieval_context"])` picks it up.
- `eval_mcp/server.py` — `attachSourceContext` param + docstring steering users to `faithfulness`/`answer_relevancy` only.
- `backend/core/agent.py` — RAG section: synthetic-RAG vs upload-your-retriever, and "never claim you can produce retrieval_context without it."

## Test plan

- [x] `pytest tests/test_generate_qa_rag.py` — 10 pass (context-stamping + PDF text extraction via `fpdf`; deterministic only).
- [x] Regression: `pytest -k "qa or create_config or rag or save_dataset or chunk"` — 83 pass, no changes to existing behavior (feature is default-off; QA output byte-for-byte unchanged when flag is unset).
- [x] Lint: new code clean under `ruff` (no new warnings).
- [ ] End-to-end via MCP (post-merge / reviewer): generate with `attachSourceContext=True` on a PDF → `create_eval_config(scorers=["faithfulness","answer_relevancy"])` → `run_evaluation` → viewer shows the Retrieved-context panel.

## Notes

- Builds on #93 (RAG scorers). No frontend changes — the viewer's RAG rendering already shipped in #93.
- PDF text extraction is best-effort (lossy for tables/figures) — acceptable since the judge scores against this text, not a pixel-perfect rendering.
- Follow-ups (out of scope): distractor chunks to make `contextual_*` meaningful in synthetic mode; generalizing the prompt optimizer to any scorer.