### PR TITLE
feat(mcp): first-class multi-scorer support — averaged headline + optimize any scorer set

### DIFF
--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -28,6 +28,16 @@ from eval_mcp.core.user_storage import (
 logger = logging.getLogger(__name__)
 
 
+def _mean_scores(scores_by_scorer: dict[str, float]) -> float:
+    """Mean across all scorers — the headline for a multi-scorer run with no
+    jury. Every scorer contributes equally (RAG faithfulness+answer_relevancy,
+    built-in f1+exact, …) so no single scorer silently stands in for the run.
+    """
+    if not scores_by_scorer:
+        return 0.0
+    return sum(scores_by_scorer.values()) / len(scores_by_scorer)
+
+
 # Provider systems whose spans represent on-the-wire LLM calls. When a span
 # tagged with one of these is present for a given model, treat its tokens as
 # canonical and discard any framework-layer tokens for the same model.
@@ -385,12 +395,15 @@ def _build_detail_from_logs(
                         all_criteria.extend(stage.get("criteriaResults", []))
                     score_data["criteriaResults"] = all_criteria
                 else:
-                    # Multi-scorer composition (e.g. jury + f1): prefer
-                    # jury_scorer for the primary score + criteria breakdown
-                    # the UI is designed around. Other scorers are captured
-                    # in scoresByScorer so the frontend can surface them
-                    # alongside without losing data.
-                    primary_name = "jury_scorer" if "jury_scorer" in scorers else next(iter(scorers))
+                    # Multi-scorer composition. With a jury, jury_scorer is the
+                    # canonical headline (its holistic rubric is what the UI is
+                    # designed around) and the rest ride alongside in
+                    # scoresByScorer. WITHOUT a jury, no single scorer is
+                    # "primary" — the headline is the MEAN across all scorers so
+                    # it reflects every signal the run produced (RAG
+                    # faithfulness+answer_relevancy, built-in f1+exact, …),
+                    # not just whichever scorer happened to come first.
+                    has_jury = "jury_scorer" in scorers
                     scores_by_scorer: dict[str, float] = {}
                     for scorer_name, score in scorers.items():
                         metadata = score.get("metadata", {})
@@ -414,7 +427,7 @@ def _build_detail_from_logs(
                                     1.0 if raw_value == "C" else 0.0,
                                 )
                         scores_by_scorer[scorer_name] = sample_score
-                        if scorer_name == primary_name:
+                        if has_jury and scorer_name == "jury_scorer":
                             score_data["score"] = sample_score
                             score_data["passed"] = sample_score > 0.5
                             score_data["explanation"] = score.get("explanation", "")
@@ -422,6 +435,17 @@ def _build_detail_from_logs(
                             score_data["criteriaResults"] = criteria_results
                             for cr in criteria_results:
                                 criteria_set.add(cr["name"])
+                    if not has_jury and scores_by_scorer:
+                        # Average every scorer for the headline. Single-scorer
+                        # runs are unchanged (mean of one == itself), and that
+                        # lone scorer keeps its explanation; a true multi-scorer
+                        # headline has no single explanation (the per-scorer
+                        # detail lives in scoresByScorer).
+                        score_data["score"] = _mean_scores(scores_by_scorer)
+                        score_data["passed"] = score_data["score"] > 0.5
+                        if len(scorers) == 1:
+                            only_score = next(iter(scorers.values()))
+                            score_data["explanation"] = only_score.get("explanation", "")
                     # Always include scoresByScorer when we have any
                     # entry — the frontend uses it not just for the
                     # multi-scorer chip row but also to label

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -912,12 +912,13 @@ async def get_evaluation_details(
 @mcp.tool(annotations=CREATE_REMOTE)
 async def optimize_prompt(
     dataset: DatasetName,
-    judge: JudgeName,
+    judge: JudgeName = None,
     initial_prompt: str = "{question}",
     providers: ProvidersList = None,
     max_iterations: int = 3,
     sample_size: int = 10,
     test_holdout: float = 0.4,
+    scorers: list = None,
     user_id: str = None,
 ) -> str:
     """
@@ -926,17 +927,25 @@ async def optimize_prompt(
 
     Splits the dataset into train (60%) / test (40%). Each iteration:
       1. Score the current prompt on a random train sample.
-      2. Show the optimizer LLM the failures + per-criterion improvement
-         notes from the judges.
+      2. Show the optimizer LLM the failures + per-scorer improvement
+         notes (jury criteria, or RAG/built-in scorer reasons).
       3. The optimizer proposes a new prompt — edits, not rewrites, when
          the current prompt is long and structured.
       4. Repeat up to `max_iterations` or until train converges.
     Finally evaluates every attempted prompt on the held-out test set;
-    winner is the highest test pass rate. Ties broken by earlier iter.
+    winner is the highest test score. Ties broken by earlier iter.
+
+    Works with any scorer, not just the jury. When `scorers` names more than
+    one, the objective is the MEAN across them — e.g. `["jury", "faithfulness"]`
+    optimises rubric quality and groundedness together. RAG scorers require the
+    dataset to carry a `retrieval_context` column (see generate_qa_pairs's
+    attachSourceContext, or save_dataset).
 
     Args:
         dataset: Dataset name from list_datasets.
-        judge: Judge name from list_judges (provides the criteria).
+        judge: Judge name from list_judges (provides the jury criteria).
+            Required only when `scorers` includes "jury" (the default);
+            optional for pure RAG/built-in scorer runs.
         initial_prompt: Starting prompt template. MUST contain `{question}`.
             Defaults to `{question}` (pass-through, no wrapping).
         providers: Provider model IDs. Stored for reference; v1 scores
@@ -944,6 +953,9 @@ async def optimize_prompt(
         max_iterations: Hard ceiling on refinement passes (default 3).
         sample_size: Train samples scored per iteration (default 10).
         test_holdout: Fraction of dataset held out for test scoring (default 0.4).
+        scorers: Scorer names to optimise against (default ["jury"]). Any mix of
+            "jury", RAG ("faithfulness", "answer_relevancy", "contextual_*"),
+            and built-ins ("f1", "exact", ...). Objective = mean across them.
 
     Returns:
         JSON: optimization_id, winner_iter, winner_test_score, winner_prompt,
@@ -959,6 +971,7 @@ async def optimize_prompt(
         "max_iterations": max_iterations,
         "sample_size": sample_size,
         "test_holdout": test_holdout,
+        "scorers": scorers,
     }
     result = await handle_optimize_prompt(bedrock, args)
     return result[0].text

--- a/eval_mcp/tools/optimize_prompt.py
+++ b/eval_mcp/tools/optimize_prompt.py
@@ -73,7 +73,12 @@ from eval_mcp.core.user_storage import (
     get_user_log_dir,
     save_optimization_to_db,
 )
-from eval_mcp.tools.create_config import create_inspect_task_file
+from eval_mcp.tools.create_config import (
+    create_inspect_task_file,
+    has_rag_scorer,
+    RAG_SCORERS,
+    _validate_scorers,
+)
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
     _running_evaluations,
@@ -219,6 +224,22 @@ def _format_failures_for_optimizer(failures: List[Dict[str, Any]]) -> str:
                     note = note_entry.get("note", "")
                     if note:
                         lines.append(f"        [{judge}] {note}")
+        # Non-jury scorers (RAG faithfulness/answer_relevancy, built-in f1/…)
+        # carry no criteria; surface their per-scorer score + reason instead so
+        # the optimizer still sees WHY a sample scored low, not just that it did.
+        breakdown = f.get("scorer_breakdown", {})
+        low_scorers = [
+            (name, d) for name, d in breakdown.items()
+            if name != "jury_scorer" and d.get("score", 1.0) < 1.0
+        ]
+        if low_scorers:
+            lines.append("  Low scorers:")
+            for name, d in low_scorers:
+                label = name.replace("_scorer", "")
+                lines.append(f"    - {label}: {d.get('score', 0.0):.2f}")
+                reason = (d.get("explanation") or "").strip()
+                if reason:
+                    lines.append(f"        {reason[:300]}")
         lines.append("")
     return "\n".join(lines)
 
@@ -274,10 +295,14 @@ def _write_temp_dataset(user_dir: Path, fragment: str, samples: List[Dict[str, s
     temp_dir = user_dir / "temp"
     temp_dir.mkdir(parents=True, exist_ok=True)
     out_path = temp_dir / f"{fragment}.json"
-    inspect_samples = [
-        {"question": s["question"], "golden_answer": s["golden_answer"]}
-        for s in samples
-    ]
+    inspect_samples = []
+    for s in samples:
+        row = {"question": s["question"], "golden_answer": s["golden_answer"]}
+        # Carry retrieval_context through so RAG scorers can run on optimizer
+        # iterations (create_inspect_task_file reads vars.retrieval_context).
+        if s.get("retrieval_context"):
+            row["retrieval_context"] = s["retrieval_context"]
+        inspect_samples.append(row)
     out_path.write_text(json.dumps(inspect_samples, indent=2))
     return out_path
 
@@ -290,9 +315,14 @@ def _write_inspect_config(
     judge_config: JudgeConfig,
     prompts: Optional[List[str]],
     description: str,
+    scorers: Optional[List[str]] = None,
 ) -> Path:
     """Generate task file + config JSON via ``create_inspect_task_file``
-    and write both to ``<user_dir>/configs/``. Returns the .py path."""
+    and write both to ``<user_dir>/configs/``. Returns the .py path.
+
+    ``scorers`` defaults (in create_inspect_task_file) to ``["jury"]``; pass a
+    RAG/built-in set to optimise against those instead of (or alongside) the
+    jury."""
     config_dir = user_dir / "configs"
     config_dir.mkdir(parents=True, exist_ok=True)
 
@@ -304,6 +334,7 @@ def _write_inspect_config(
         judge_config=judge_config,
         description=description,
         prompts=prompts,
+        scorers=scorers,
     )
     py_path = config_dir / f"{config_name}.py"
     py_path.write_text(task_code)
@@ -424,34 +455,60 @@ async def _spawn_inspect_eval(
         logger.debug("inspect eval stderr (rc=0) for %s: %s", config_name, stderr)
 
 
-def _extract_rows_from_log(log: Any) -> List[Dict[str, Any]]:
-    """Pull per-sample rows out of an Inspect eval log. Each row carries
-    the question, golden, model answer, jury score, and the
-    ``criteria_results`` metadata where improvement notes live.
+def _coerce_score_value(value: Any) -> Optional[float]:
+    """Coerce an Inspect Score.value to float; None if not numeric.
 
-    The optimizer always writes its temp configs with the default
-    ``scorers=["jury"]``, but read defensively: prefer the ``jury_scorer``
-    entry by name in case other scorers were composed in. Built-in
-    scorers (``f1``/``exact``/...) carry no ``criteria_results`` metadata,
-    so they're useless to the optimizer; we fall back to the first
-    available scorer only so a malformed log doesn't crash."""
+    Jury and RAG/built-in scorers all return numeric 0..1 values, so this
+    covers every scorer the optimizer drives. Categorical "C"/"I" fall back
+    to 1.0/0.0; anything else is dropped from the mean."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        if value == "C":
+            return 1.0
+        if value == "I":
+            return 0.0
+        return None
+
+
+def _extract_rows_from_log(log: Any) -> List[Dict[str, Any]]:
+    """Pull per-sample rows out of an Inspect eval log. Each row carries the
+    question, golden, model answer, the headline ``sample_score``, jury
+    ``criteria_results`` (when present), and a per-scorer breakdown.
+
+    The optimizer can now drive any scorer set (jury, RAG, built-in, or a
+    mix). The headline ``sample_score`` is the MEAN across every scorer on the
+    sample — the same objective the viewer headline uses — so the loop
+    optimises the combined signal, not just whichever scorer came first.
+    ``criteria_results`` (jury) and ``scorer_breakdown`` (RAG/built-in reasons)
+    both feed the failure context shown to the optimizer LLM."""
     rows: List[Dict[str, Any]] = []
     for sample in (log.samples or []):
-        score_obj = None
-        if sample.scores:
-            score_obj = sample.scores.get("jury_scorer") or next(
-                iter(sample.scores.values()), None
-            )
-
-        sample_score = 0.0
+        scores = sample.scores or {}
+        scorer_breakdown: Dict[str, Dict[str, Any]] = {}
+        numeric_values: List[float] = []
         criteria_results: List[Dict[str, Any]] = []
-        if score_obj is not None:
-            try:
-                sample_score = float(score_obj.value) if score_obj.value is not None else 0.0
-            except (TypeError, ValueError):
-                sample_score = 0.0
+
+        for name, score_obj in scores.items():
+            val = _coerce_score_value(getattr(score_obj, "value", None))
+            if val is not None:
+                scorer_breakdown[name] = {
+                    "score": val,
+                    "explanation": getattr(score_obj, "explanation", "") or "",
+                }
+                numeric_values.append(val)
             meta = getattr(score_obj, "metadata", None) or {}
-            criteria_results = meta.get("criteria_results", []) or []
+            if name == "jury_scorer":
+                criteria_results = meta.get("criteria_results", []) or []
+
+        # Headline objective = mean across all scorers (matches the viewer).
+        sample_score = (
+            sum(numeric_values) / len(numeric_values) if numeric_values else 0.0
+        )
 
         answer = ""
         if sample.output and sample.output.completion:
@@ -463,6 +520,7 @@ def _extract_rows_from_log(log: Any) -> List[Dict[str, Any]]:
             "answer": answer,
             "sample_score": sample_score,
             "criteria_results": criteria_results,
+            "scorer_breakdown": scorer_breakdown,
         })
     return rows
 
@@ -482,6 +540,7 @@ async def _run_inspect_iteration(
     prompt_template: str,
     providers: List[str],
     judge_config: JudgeConfig,
+    scorers: Optional[List[str]] = None,
 ) -> Tuple[Optional[str], List[Dict[str, Any]]]:
     """Single optimizer iteration as a real Inspect AI eval. Returns
     ``(run_id, rows)`` where ``rows`` is per-sample data ready for failure
@@ -496,6 +555,7 @@ async def _run_inspect_iteration(
         judge_config=judge_config,
         prompts=[prompt_template],
         description=f"Optimizer iteration: {config_name}",
+        scorers=scorers,
     )
 
     before = await _snapshot_log_set(log_dir)
@@ -522,6 +582,7 @@ async def _run_inspect_test_ranking(
     prompts_by_iter: List[Tuple[int, str]],
     providers: List[str],
     judge_config: JudgeConfig,
+    scorers: Optional[List[str]] = None,
 ) -> Tuple[Optional[str], Dict[int, float]]:
     """Run every prompt in history against the test split in a single
     Inspect job. ``prompts_by_iter`` preserves iteration order so we can
@@ -542,6 +603,7 @@ async def _run_inspect_test_ranking(
         judge_config=judge_config,
         prompts=prompts_in_order,
         description=f"Optimizer test-time ranking: {optimization_id}",
+        scorers=scorers,
     )
 
     before = await _snapshot_log_set(log_dir)
@@ -638,10 +700,16 @@ async def optimize_prompt_loop(
     max_iter: int = DEFAULT_MAX_ITERATIONS,
     sample_size: int = DEFAULT_SAMPLE_SIZE,
     test_holdout: float = DEFAULT_TEST_HOLDOUT,
+    scorers: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Run the optimization loop. Each iteration is a real Inspect AI
     eval; iteration ``eval_run_id`` is stored in history so the UI can
-    deep-link to it. Returns the full record ready for persistence."""
+    deep-link to it. Returns the full record ready for persistence.
+
+    ``scorers`` selects what each iteration scores against (default
+    ``["jury"]``). The optimisation objective is the mean across the selected
+    scorers, so passing e.g. ``["jury", "faithfulness"]`` or
+    ``["faithfulness", "answer_relevancy"]`` optimises that combined signal."""
 
     train, test = _split_train_test(qa_pairs, holdout=test_holdout)
     if not train:
@@ -687,6 +755,7 @@ async def optimize_prompt_loop(
             prompt_template=initial_prompt,
             providers=providers,
             judge_config=judge_config,
+            scorers=scorers,
         )
         last_rows = iter_0_rows
         initial_train_rate = _pass_rate(iter_0_rows)
@@ -741,6 +810,7 @@ async def optimize_prompt_loop(
                 prompt_template=candidate,
                 providers=providers,
                 judge_config=judge_config,
+                scorers=scorers,
             )
             cand_rate = _pass_rate(cand_rows)
 
@@ -778,6 +848,7 @@ async def optimize_prompt_loop(
                 prompts_by_iter=[(h["iter"], h["prompt"]) for h in history],
                 providers=providers,
                 judge_config=judge_config,
+                scorers=scorers,
             )
         except Exception as e:
             logger.warning("Test-time ranking failed: %s. Falling back to train scores.", e)
@@ -822,12 +893,23 @@ async def handle_optimize_prompt(
     def _err(msg: str) -> List[TextContent]:
         return [TextContent(type="text", text=json.dumps({"success": False, "error": msg}))]
 
+    # Scorer set to optimise against. Defaults to ["jury"] — unchanged from
+    # before. Any registered scorer (RAG, built-in) or a mix is allowed; the
+    # objective is the mean across them.
+    try:
+        scorers = _validate_scorers(args.get("scorers") or ["jury"])
+    except Exception as e:
+        return _err(str(e))
+    uses_jury = "jury" in scorers
+    uses_rag = has_rag_scorer(scorers)
+
     if not user_id:
         return _err("user_id is required")
     if not dataset_name:
         return _err("dataset is required — use list_datasets to see what's available")
-    if not judge_name:
-        return _err("judge is required — use list_judges to see what's available")
+    # The jury scorer needs a judge (criteria); RAG/built-in scorers don't.
+    if uses_jury and not judge_name:
+        return _err("judge is required when optimising the jury scorer — use list_judges")
     if not providers:
         return _err("providers is required — at least one model under test")
     if "{question}" not in initial_prompt:
@@ -836,27 +918,49 @@ async def handle_optimize_prompt(
     dataset = get_dataset_by_name(user_id, dataset_name)
     if not dataset:
         return _err(f"Dataset '{dataset_name}' not found")
-    judge = get_judge_by_name(user_id, judge_name)
-    if not judge:
-        return _err(f"Judge '{judge_name}' not found")
 
-    criteria = (judge.get("config") or {}).get("criteria") or []
-    if not criteria:
-        return _err(f"Judge '{judge_name}' has no criteria")
-
-    # Build the JudgeConfig the same way create_eval_config does, so the
-    # jury_scorer template renders with identical judges + criteria as a
-    # normal eval would.
+    # Build a JudgeConfig the same way create_eval_config does so the
+    # jury_scorer template renders identical judges + criteria. When no jury
+    # is selected the judge is optional and the config is unused.
     judge_models_arg = args.get("judge_models")
     custom_judges = {m: m for m in judge_models_arg} if judge_models_arg else None
-    judge_config = JudgeConfig(criteria=criteria, judges=custom_judges)
+    criteria: List[Dict[str, Any]] = []
+    if judge_name:
+        judge = get_judge_by_name(user_id, judge_name)
+        if not judge:
+            return _err(f"Judge '{judge_name}' not found")
+        criteria = (judge.get("config") or {}).get("criteria") or []
+        if uses_jury and not criteria:
+            return _err(f"Judge '{judge_name}' has no criteria")
+    judge_config = (
+        JudgeConfig(criteria=criteria, judges=custom_judges)
+        if criteria else JudgeConfig(judges=custom_judges)
+    )
 
-    qa_pairs = [
-        {"question": t["vars"]["question"], "golden_answer": t["vars"]["golden_answer"]}
-        for t in dataset.get("tests", [])
-    ]
+    qa_pairs = []
+    missing_rc = 0
+    for t in dataset.get("tests", []):
+        v = t.get("vars", t)
+        pair = {
+            "question": v.get("question", ""),
+            "golden_answer": v.get("golden_answer", ""),
+        }
+        rc = v.get("retrieval_context")
+        if rc:
+            pair["retrieval_context"] = rc
+        elif uses_rag:
+            missing_rc += 1
+        qa_pairs.append(pair)
     if len(qa_pairs) < 2:
         return _err("Dataset needs at least 2 QA pairs for train/test split")
+    if uses_rag and missing_rc:
+        return _err(
+            f"Dataset '{dataset_name}' has {missing_rc} sample(s) without "
+            f"retrieval_context, required by the RAG scorers "
+            f"{sorted(set(scorers) & RAG_SCORERS)}. Generate it with "
+            f"generate_qa_pairs(attachSourceContext=True) or upload your "
+            f"retriever's chunks via save_dataset."
+        )
 
     optimization_id = f"opt_{int(time.time() * 1000)}"
     started_at = int(time.time() * 1000)
@@ -872,6 +976,7 @@ async def handle_optimize_prompt(
         max_iter=max_iter,
         sample_size=sample_size,
         test_holdout=test_holdout,
+        scorers=scorers,
     )
 
     record = {
@@ -880,6 +985,7 @@ async def handle_optimize_prompt(
         "dataset": dataset_name,
         "judge": judge_name,
         "providers": providers,
+        "scorers": scorers,
         "max_iterations": max_iter,
         "sample_size": sample_size,
         "test_holdout": test_holdout,

--- a/tests/test_eval_results_headline.py
+++ b/tests/test_eval_results_headline.py
@@ -1,0 +1,31 @@
+"""Headline aggregation across scorers (eval_results._mean_scores).
+
+The viewer headline for a multi-scorer run with no jury must reflect EVERY
+scorer, not just whichever came first. Regression test for the bug where a
+RAG run (faithfulness + answer_relevancy) showed only faithfulness as the
+overall score.
+"""
+
+from __future__ import annotations
+
+from eval_mcp.core.eval_results import _mean_scores
+
+
+def test_mean_of_two_scorers():
+    # faithfulness 0.79 + answer_relevancy 0.95 → 0.87, not 0.79.
+    assert _mean_scores({"faithfulness": 0.79, "answer_relevancy": 0.95}) == 0.87
+
+
+def test_mean_single_scorer_is_itself():
+    assert _mean_scores({"f1": 0.47}) == 0.47
+
+
+def test_mean_empty_is_zero():
+    assert _mean_scores({}) == 0.0
+
+
+def test_mean_is_unweighted():
+    # Every scorer contributes equally regardless of insertion order.
+    a = _mean_scores({"x": 0.0, "y": 1.0})
+    b = _mean_scores({"y": 1.0, "x": 0.0})
+    assert a == b == 0.5

--- a/tests/test_langchain_subprocess_e2e.py
+++ b/tests/test_langchain_subprocess_e2e.py
@@ -26,7 +26,10 @@ import pytest
 def _aws_creds_available() -> bool:
     try:
         import boto3
-        s = boto3.Session()
+        # Default the region like the other Bedrock-gated guards, so a box
+        # with creds but no AWS_REGION env (e.g. an EC2 instance profile)
+        # runs this instead of spuriously skipping on an unresolved region.
+        s = boto3.Session(region_name=os.environ.get("AWS_REGION", "us-west-2"))
         return s.get_credentials() is not None and s.region_name is not None
     except Exception:
         return False

--- a/tests/test_optimize_multiscorer.py
+++ b/tests/test_optimize_multiscorer.py
@@ -1,0 +1,157 @@
+"""Optimizer multi-scorer support (optimize_prompt).
+
+Covers the deterministic pieces: score coercion, the mean-across-scorers
+objective in _extract_rows_from_log, and that the optimizer's failure context
+surfaces non-jury scorer reasons. The full loop needs Bedrock + Inspect
+subprocesses and is exercised by running the MCP.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from eval_mcp.tools.optimize_prompt import (
+    _coerce_score_value,
+    _extract_rows_from_log,
+    _format_failures_for_optimizer,
+    _pass_rate,
+    _select_failures,
+)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_score_value
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_numeric_and_string():
+    assert _coerce_score_value(0.5) == 0.5
+    assert _coerce_score_value(1) == 1.0
+    assert _coerce_score_value("0.73") == 0.73
+
+
+def test_coerce_categorical():
+    assert _coerce_score_value("C") == 1.0
+    assert _coerce_score_value("I") == 0.0
+
+
+def test_coerce_none_and_garbage():
+    assert _coerce_score_value(None) is None
+    assert _coerce_score_value("banana") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_rows_from_log — sample_score is the MEAN across scorers
+# ---------------------------------------------------------------------------
+
+
+def _score(value, explanation="", metadata=None):
+    return SimpleNamespace(value=value, explanation=explanation, metadata=metadata or {})
+
+
+def _sample(scores: dict, answer="ans", inp="q", target="g"):
+    return SimpleNamespace(
+        scores=scores,
+        input=inp,
+        target=target,
+        output=SimpleNamespace(completion=answer),
+    )
+
+
+def test_sample_score_is_mean_across_scorers():
+    """faithfulness 0.6 + answer_relevancy 1.0 → headline 0.8 (not 0.6)."""
+    log = SimpleNamespace(samples=[
+        _sample({
+            "faithfulness": _score(0.6),
+            "answer_relevancy": _score(1.0),
+        })
+    ])
+    rows = _extract_rows_from_log(log)
+    assert rows[0]["sample_score"] == 0.8
+
+
+def test_jury_plus_rag_averaged():
+    """jury 0.5 + faithfulness 1.0 → 0.75, combining both signals."""
+    log = SimpleNamespace(samples=[
+        _sample({
+            "jury_scorer": _score(0.5, metadata={"criteria_results": [{"name": "accuracy", "score": 0.5}]}),
+            "faithfulness": _score(1.0),
+        })
+    ])
+    rows = _extract_rows_from_log(log)
+    assert rows[0]["sample_score"] == 0.75
+    # jury criteria still captured for the failure context
+    assert rows[0]["criteria_results"][0]["name"] == "accuracy"
+
+
+def test_scorer_breakdown_captured():
+    log = SimpleNamespace(samples=[
+        _sample({"faithfulness": _score(0.3, explanation="contradicts chunk 2")})
+    ])
+    rows = _extract_rows_from_log(log)
+    bd = rows[0]["scorer_breakdown"]
+    assert bd["faithfulness"]["score"] == 0.3
+    assert "contradicts" in bd["faithfulness"]["explanation"]
+
+
+def test_no_scores_is_zero():
+    log = SimpleNamespace(samples=[_sample({})])
+    rows = _extract_rows_from_log(log)
+    assert rows[0]["sample_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Failure context surfaces non-jury scorer reasons
+# ---------------------------------------------------------------------------
+
+
+def test_failure_context_shows_rag_reason():
+    failures = [{
+        "question": "What year?",
+        "golden": "1889",
+        "answer": "1900",
+        "criteria_results": [],  # no jury
+        "scorer_breakdown": {
+            "faithfulness": {"score": 0.0, "explanation": "answer 1900 contradicts the context (1889)"},
+            "answer_relevancy": {"score": 1.0, "explanation": ""},
+        },
+    }]
+    out = _format_failures_for_optimizer(failures)
+    assert "Low scorers:" in out
+    assert "faithfulness: 0.00" in out
+    assert "contradicts the context" in out
+    # answer_relevancy passed (1.0) → not listed as a low scorer
+    assert "answer_relevancy" not in out
+
+
+def test_failure_context_prefers_jury_criteria():
+    failures = [{
+        "question": "q",
+        "golden": "g",
+        "answer": "a",
+        "criteria_results": [
+            {"name": "accuracy", "score": 0.0, "votes_for": 1, "total": 4,
+             "improvement_notes": [{"judge": "claude", "note": "missed the date"}]},
+        ],
+        "scorer_breakdown": {"jury_scorer": {"score": 0.0, "explanation": ""}},
+    }]
+    out = _format_failures_for_optimizer(failures)
+    assert "Failed criteria (jury):" in out
+    assert "missed the date" in out
+
+
+# ---------------------------------------------------------------------------
+# Objective plumbing — _pass_rate / _select_failures use the mean score
+# ---------------------------------------------------------------------------
+
+
+def test_pass_rate_and_failure_selection_use_sample_score():
+    rows = [
+        {"sample_score": 1.0},
+        {"sample_score": 0.5},
+        {"sample_score": 0.0},
+    ]
+    assert _pass_rate(rows) == 0.5
+    failing = _select_failures(rows)
+    # fully-passing row dropped; worst first
+    assert [r["sample_score"] for r in failing] == [0.0, 0.5]

--- a/tests/test_optimize_prompt.py
+++ b/tests/test_optimize_prompt.py
@@ -394,7 +394,7 @@ def test_loop_iterates_then_converges(judge_config, qa_pairs):
     rows_iter1 = _mock_rows(1.0)
 
     async def fake_run(user_id, user_dir, log_dir, config_name, samples,
-                       prompt_template, providers, judge_config):
+                       prompt_template, providers, judge_config, scorers=None):
         if prompt_template == "{question} now better":
             return f"run_{config_name}", rows_iter1
         return f"run_{config_name}", rows_iter0

--- a/tests/test_subprocess_otlp_integration.py
+++ b/tests/test_subprocess_otlp_integration.py
@@ -24,7 +24,10 @@ def _aws_creds_available() -> bool:
     """
     try:
         import boto3
-        session = boto3.Session()
+        # Default the region like the other Bedrock-gated guards, so a box
+        # with creds but no AWS_REGION env (e.g. an EC2 instance profile)
+        # runs this instead of spuriously skipping on an unresolved region.
+        session = boto3.Session(region_name=os.environ.get("AWS_REGION", "us-west-2"))
         creds = session.get_credentials()
         return creds is not None and session.region_name is not None
     except Exception:


### PR DESCRIPTION
## Summary

Two fixes unified by one idea: a multi-scorer run should reflect **every** scorer, not just whichever came first.

1. **Viewer headline** (`eval_results.py`) — fixes the bug where a RAG run (faithfulness + answer_relevancy) showed *only faithfulness* as the overall score. With no jury, the headline is now the **mean across all scorers**.
2. **Prompt optimizer** (`optimize_prompt.py` + `server.py`) — was hardwired to the jury. Now optimises against **any scorer set** (RAG, built-in, or a mix), with the objective = mean across them.

## Why

- The headline bug: an eval with `["faithfulness", "answer_relevancy"]` set `score_data["score"]` to `next(iter(scorers))` — the first scorer — so the run/sample headline silently dropped every other scorer. Reported from a real run (headline `79` == faithfulness, `answer_relevancy` 95% ignored).
- The optimizer couldn't optimise RAG (or built-in) evals at all: `_write_temp_dataset` dropped `retrieval_context` and `_write_inspect_config` never passed `scorers`, so every iteration re-ran the jury regardless of the eval's actual scorers.

## What changed

**Viewer (`eval_results.py`)**
- New `_mean_scores()` helper. No-jury multi-scorer headline = mean of all scorers. Jury runs unchanged (jury stays headline + criteria breakdown). Single-scorer runs unchanged (mean of one == itself).

**Optimizer (`optimize_prompt.py`, `server.py`)**
- `optimize_prompt` gains `scorers=[...]` (default `["jury"]`); `judge` is now optional — required only when `jury` is selected.
- Objective = **mean across selected scorers**: `["jury","faithfulness"]`, `["faithfulness","answer_relevancy"]`, `["f1","exact"]` all work.
- `retrieval_context` threads through the temp datasets; `scorers` threads into every iteration + the test-ranking run.
- Failure context generalised: jury criteria when present, else each non-jury scorer's score + reason (so the optimizer LLM still sees *why* a sample scored low).
- Fail-fast when RAG scorers are selected but the dataset lacks `retrieval_context` (points at `generate_qa_pairs(attachSourceContext=True)` / `save_dataset`).

## Test plan

- [x] 14 new deterministic unit tests: `test_eval_results_headline.py` (mean aggregation) + `test_optimize_multiscorer.py` (score coercion, mean-across-scorers objective, failure-context rendering).
- [x] Updated one existing optimizer stub for the new `scorers` kwarg.
- [x] **Full suite: 353 passed, 2 skipped** (Bedrock-gated integration), zero new lint.
- [ ] End-to-end via MCP (reviewer / post-merge): `optimize_prompt(dataset=<rag set>, scorers=["faithfulness","answer_relevancy"], providers=[...])` and verify the headline + per-iter scores reflect both metrics.

## Notes

- Independent of #96 (synthetic-RAG generation) — different files, merges on its own. The two compose: #96 produces RAG datasets, this lets you optimise prompts against them.
- No frontend changes — the headline value is computed server-side in `eval_results.py`; the viewer renders whatever it's given.