### PR TITLE
fix(deps): override shell-quote to ^1.8.4 (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "concurrently": "^9.1.2"
+  },
+  "overrides": {
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
## Summary

- Adds an npm `overrides` to the root `package.json` forcing `shell-quote@^1.8.4`, resolving the only open security alert (Dependabot #130, **critical** — GHSA-w7jw-789q-3m8p).
- Regenerates the root `package-lock.json` so the transitive dep resolves to the patched `1.8.4`.

## Why

`shell-quote` 1.8.3's `quote()` fails to escape newlines in object `.op` values, enabling shell command injection. It comes in transitively as a **dev** dependency of `concurrently` (root `package.json`, used by `start.sh`). `concurrently@9.2.1` pins shell-quote to an exact `1.8.3` and the `9.x` line has no patched release, so a plain `npm update` can't bump it — an `overrides` is the surgical fix. It's a patch-level bump (only adds newline escaping, no API change) and leaves `concurrently` on `9.2.1`. Dev-scoped only, so the published PyPI wheel is unaffected.

## Test plan

- [x] `npm install` → `node_modules/shell-quote` resolves to `1.8.4`
- [x] `npx concurrently "echo A" "echo B"` runs both to completion (override doesn't break the consumer)
- [x] `npm audit` → 0 vulnerabilities
- [x] lockfile diff is exactly the single shell-quote bump, no collateral churn
- [ ] Dependabot alert #130 auto-closes on merge