### PR TITLE
chore(deps): pin inspect-ai floor to 0.3.241 and align local with deployed

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -18,11 +18,10 @@ End-users install via `uvx --from llm-evaluation-system eval-mcp` — do **not**
 ```bash
 git clone https://github.com/awslabs/llm-evaluation-system.git
 cd llm-evaluation-system
-uv venv
-uv pip install -e .
+uv sync
 ```
 
-`-e` installs editable — edits in `eval_mcp/` take effect on next MCP restart without reinstalling.
+`uv sync` installs editable from `uv.lock` — the **same** pinned versions the deployed EKS image builds with (`uv sync --locked` in the `Dockerfile`), so your local inspect-ai matches production exactly rather than floating to whatever PyPI's latest is. Edits in `eval_mcp/` take effect on next MCP restart without reinstalling. After changing a dependency in `pyproject.toml`, run `uv lock` to refresh the lockfile, then `uv sync` again.
 
 ### 2. Pytest for narrow deterministic logic (optional supplement)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,13 @@ classifiers = [
 dependencies = [
     # Core MCP + eval engine
     "mcp>=1.0.0",
-    "inspect-ai>=0.3.0",
+    # Floor (no upper cap) is intentional: we import several private inspect-ai
+    # modules (._view.common, .tool._tool_info, .log._samples, .event._model),
+    # so the floor guarantees those paths exist. The deployed image and local
+    # dev both install from uv.lock, so they stay byte-identical regardless of
+    # what a fresh PyPI resolve picks for wheel users. Bump via
+    # `uv lock --upgrade-package inspect-ai`.
+    "inspect-ai>=0.3.241",
     "boto3>=1.35.0",
     "click>=8.1.7",
     "rich>=13.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.12, <3.15"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/3b96cd8374725c69bc3dae9fcc2082f3f6cafec1be35d24d7af0f8c3265f/agent_client_protocol-0.10.1.tar.gz", hash = "sha256:355c65ca19f0568344aafc2c1552b7066a8fc491df23ab28e7e253c6c9a85a25", size = 81924, upload-time = "2026-05-24T18:46:44.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/18/d8c7ff337cf621ea79a84006a7252ff057bfb5767549bb102cc6649f4ec2/agent_client_protocol-0.10.1-py3-none-any.whl", hash = "sha256:a03d3198f4d772f2e0ec012c00ac1cce131b4710220a3dc9fae3c991d047c750", size = 65401, upload-time = "2026-05-24T18:46:43.202Z" },
+]
+
+[[package]]
 name = "aioboto3"
 version = "15.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1108,17 +1120,18 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.220"
+version = "0.3.241"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "aioboto3" },
-    { name = "aiohttp" },
     { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "click" },
     { name = "debugpy" },
     { name = "docstring-parser" },
+    { name = "fastapi" },
     { name = "fsspec" },
     { name = "httpx" },
     { name = "ijson" },
@@ -1145,13 +1158,14 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typing-extensions" },
     { name = "universal-pathlib" },
+    { name = "uvicorn" },
     { name = "zipfile-zstd", marker = "python_full_version < '3.14'" },
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/b7/5588fe9c5b58a77a162579d463fa75d5399712482e5d8dba0e0258a47306/inspect_ai-0.3.220.tar.gz", hash = "sha256:1b67fd9aaa203c4dae9e602ce867a6cfafa0df7d4f4884b17e4e85b73bac0816", size = 45636909, upload-time = "2026-05-08T13:32:23.774Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/2d/7164fdf06530840dc5a8aa662dd67d87f0b5d6591ee832fb4fdae09de29e/inspect_ai-0.3.241.tar.gz", hash = "sha256:a79eda08dcb573aa2c1459d7b60610220671a3e3318cb68aadf7a42b97822bbf", size = 48450959, upload-time = "2026-06-22T14:39:38.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/f0/e74a150d58d4ebcb3449a5894834899f61809e7e3d98e86da2caf8863e4f/inspect_ai-0.3.220-py3-none-any.whl", hash = "sha256:1d22c9de47c2f98f847650d77183ba91c02609e618a7725441e6d589d36c01c2", size = 36105199, upload-time = "2026-05-08T13:32:01.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/33/068c58116f053f56efe5d85db9505398dd5e91cb09bf2bc40ef9263d540e/inspect_ai-0.3.241-py3-none-any.whl", hash = "sha256:3ef2708d5f4854475f8f7bc4bc42b55079f00ba3eba2b4f5733fab66e3f53fd1", size = 36159399, upload-time = "2026-06-22T14:39:34.325Z" },
 ]
 
 [[package]]
@@ -1493,7 +1507,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'providers'", specifier = ">=1.69.0" },
     { name = "groq", marker = "extra == 'providers'", specifier = ">=0.28.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "inspect-ai", specifier = ">=0.3.0" },
+    { name = "inspect-ai", specifier = ">=0.3.241" },
     { name = "inspect-k8s-sandbox", marker = "extra == 'k8s-sandbox'", specifier = ">=0.4.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },


### PR DESCRIPTION
## Summary

- Raise the `inspect-ai` floor from `>=0.3.0` to `>=0.3.241` in `pyproject.toml` (no upper cap, by choice — documented inline).
- Bump `uv.lock` `0.3.220 → 0.3.241` (pulls in a new transitive dep, `agent-client-protocol`).
- Switch the documented local install in `docs/DEVELOPMENT.md` from `uv pip install -e .` to `uv sync`, so local dev reads the lockfile like the Dockerfile's `uv sync --locked` does.

## Why

Local dev and the deployed EKS image were resolving inspect-ai from **different sources**: `uv pip install -e .` honored only the open `>=0.3.0` constraint and floated to PyPI's latest (0.3.241), while the EKS image built from `uv.lock`'s pinned 0.3.220 — a 21-release drift between what we test locally and what we ship.

That drift is risky here specifically because the code imports several **private** inspect-ai modules (`._view.common`, `.tool._tool_info`, `.log._samples`, `.event._model`) that can move between releases. Making `uv.lock` the single source of truth for both contexts removes the drift; future bumps are a single `uv lock --upgrade-package inspect-ai`.

The published PyPI wheel still resolves the constraint range on the user's machine (inherent to shipping a library) — the floor guarantees the private-API paths exist.

## Test plan

- [x] All inspect-touching `eval_mcp` modules import on 0.3.241.
- [x] `python -m inspect_ai eval` runs a vanilla stock task end-to-end; the MCP's log-read path parses it.
- [x] Full suite: 335 passed; the 8 failures + 21 errors are unrelated EKS-backend `asyncpg`/`backend.*` deps and predate this change.
- [x] `uv lock --check` passes (lock consistent with manifest).

## Follow-ups (not in this PR)

- Add `uv lock --check` to CI so a future pin-bump-without-relock fails loudly.
- Isolate the private-API imports behind one `_inspect_compat.py` adapter so upgrades break in one place.