### PR TITLE
feat(web): cross-user eval sharing — users, teams, org, viewer, chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Point Claude Code at your editable install by setting `command` in `~/.claude.js
 
 Pytest is **only useful for narrow deterministic logic** (parsing, validation, regex). End-to-end coverage requires running the MCP from Claude Code — mocks of Bedrock/subprocesses/user-dirs produce false greens. See `docs/DEVELOPMENT.md` section 2.
 
+**Testing the web app for real** — pytest greens don't prove the web app works; exercise it against the live `make dev` stack in layers: (1) `pytest` for pure logic; (2) `curl`/`urllib` against `:4001` for `/api/*` routes (the `verify_*.py` scripts are the template); (3) **chat/agent behavior → POST `/api/chat/message` with `{"stream":false}` and assert on the reply** — this is how you prove the model actually invokes an MCP tool, and it needs Bedrock creds (which `make dev` already exports, so it's never a blocker); (4) **browser UI → the `webapp-testing` skill (Playwright)**. Don't conflate (3) and (4): chat behavior is curl-the-chat-endpoint, the browser skill is for what renders. Full methodology + the two-identity trick in `docs/DEVELOPMENT.md` ("How to *really* test the web app").
+
 ### Frontend / viewer
 
 ```bash

--- a/backend/api/compare.py
+++ b/backend/api/compare.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 
 from backend.core.inspect_viewer import _is_within_dir
+from backend.core import sharing
 from eval_mcp.core.eval_results import precompute_eval_results
 from eval_mcp.core.user_storage import get_user_log_dir, load_eval_detail, load_eval_groups
 
@@ -29,28 +30,126 @@ async def _get_user_id(request: Request) -> str:
     return user_id
 
 
+def _db():
+    """The shared Database global (set in main.py lifespan). 503 if absent."""
+    from backend.api.main import db
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not initialized")
+    return db
+
+
+async def _resolve_owner(caller_id: str, group_id: str,
+                         owner: Optional[str]) -> str:
+    """Return the owner_id to read (group_id) as, after authorizing caller.
+
+    `owner` is the owner hint the SPA carries on each row (from /groups). When
+    it's absent or equals the caller, this is a normal own-eval read. When it
+    names another user, the caller must hold a grant — deny-by-default via the
+    sharing resolver. Raises 403 otherwise. The returned owner_id is what every
+    storage read must be scoped to (NEVER trust `owner` without this check).
+    """
+    if not owner or owner == caller_id:
+        return caller_id
+    allowed = await sharing.can_read(_db(), caller_id, owner, group_id)
+    if not allowed:
+        logger.warning(
+            f"[ACCESS] denied {caller_id} -> owner={owner} group={group_id}"
+        )
+        raise HTTPException(status_code=403, detail="Access denied")
+    return owner
+
+
+def _tag_owner(groups_blob: Optional[dict], owner_id: str) -> list:
+    """Return the group elements from a user's _groups.json, each tagged with
+    its owner so the SPA can badge shared evals and carry the owner hint back
+    on /detail. A missing blob yields []."""
+    if not groups_blob:
+        return []
+    out = []
+    for g in groups_blob.get("groups", []):
+        tagged = dict(g)
+        tagged["owner"] = owner_id
+        out.append(tagged)
+    return out
+
+
 @router.get("/groups")
 async def get_comparison_groups(user_id: str = Depends(_get_user_id)):
-    """List evaluation comparison groups for the user, served from the pre-computed cache."""
-    cached = load_eval_groups(user_id)
-    if cached:
-        return cached
-    await precompute_eval_results(user_id)
-    return load_eval_groups(user_id) or {"groups": []}
+    """List evaluation comparison groups visible to the user.
+
+    Returns the caller's own groups plus any shared with them (per-eval, team,
+    or org grants), each element tagged with its `owner`. Own evals are served
+    from the pre-computed cache (recomputed on a cold miss).
+    """
+    own = load_eval_groups(user_id)
+    if not own:
+        await precompute_eval_results(user_id)
+        own = load_eval_groups(user_id)
+    groups = _tag_owner(own, user_id)
+
+    # Merge in evals shared with the caller. Each scope is (ownerId, groupId,
+    # role); groupId=None means all of that owner's evals. We read each owner's
+    # precomputed blob and include only the granted groups.
+    try:
+        scopes = await sharing.list_shared_scopes(_db(), user_id)
+    except Exception as e:
+        # Sharing is additive — never let a grant-store hiccup hide the user's
+        # OWN evals. Log and return just the own set.
+        logger.warning(f"[ACCESS] shared-scope listing failed for {user_id}: {e}")
+        return {"groups": groups}
+
+    # Group scopes by owner so we load each owner's blob once.
+    owners: dict[str, set] = {}
+    share_all: set = set()
+    for s in scopes:
+        owner = s["ownerId"]
+        if s["groupId"] is None:
+            share_all.add(owner)
+        owners.setdefault(owner, set()).add(s["groupId"])
+
+    seen_owners = set()
+    for owner in set(list(owners.keys()) + list(share_all)):
+        seen_owners.add(owner)
+        blob = load_eval_groups(owner)
+        if not blob:
+            continue
+        allow_all = owner in share_all
+        allowed_ids = owners.get(owner, set())
+        for g in blob.get("groups", []):
+            if allow_all or g.get("id") in allowed_ids:
+                tagged = dict(g)
+                tagged["owner"] = owner
+                tagged["shared"] = True
+                groups.append(tagged)
+
+    return {"groups": groups}
 
 
 @router.get("/detail")
-async def get_comparison_detail(group_id: str, user_id: str = Depends(_get_user_id)):
-    """Get full comparison data for a specific evaluation group."""
-    data = load_eval_detail(user_id, group_id)
+async def get_comparison_detail(
+    group_id: str,
+    owner: Optional[str] = Query(None),
+    user_id: str = Depends(_get_user_id),
+):
+    """Get full comparison data for a specific evaluation group.
+
+    `owner` is the owner hint carried by the SPA from /groups. For a shared
+    eval it names another user; the caller must hold a grant (enforced by
+    _resolve_owner). All storage reads are scoped to the resolved owner_id.
+    """
+    owner_id = await _resolve_owner(user_id, group_id, owner)
+
+    data = load_eval_detail(owner_id, group_id)
     if data:
         return data
 
-    # Fallback: compute this group on demand
-    await precompute_eval_results(user_id)
-    data = load_eval_detail(user_id, group_id)
-    if data:
-        return data
+    # Fallback: compute on demand. Only recompute the caller's OWN evals —
+    # a viewer must not trigger writes into the owner's store.
+    if owner_id == user_id:
+        await precompute_eval_results(user_id)
+        data = load_eval_detail(user_id, group_id)
+        if data:
+            return data
     raise HTTPException(status_code=404, detail="Group not found")
 
 
@@ -70,18 +169,37 @@ async def rebuild_results(user_id: str = Depends(_get_user_id)):
 async def get_sample_detail(
     log_file: str,
     sample_id: str,
+    group_id: Optional[str] = Query(None),
+    owner: Optional[str] = Query(None),
     user_id: str = Depends(_get_user_id),
 ):
-    """Get full detail for a single sample including judge reasoning."""
+    """Get full detail for a single sample including judge reasoning.
+
+    `log_file` is a raw caller-supplied path, so this is the sensitive surface
+    (the PR #106 boundary). It is gated TWICE: (1) the caller must own the eval
+    or hold a grant on (owner, group_id); (2) the resolved owner's log dir is
+    the boundary the path must fall within. A grant can therefore never be
+    turned into a traversal out of the grantor's own subtree.
+    """
     from eval_mcp.core.eval_results import _read_full_logs
     from eval_mcp.core.user_storage import get_user_log_dir
 
-    # Real path-boundary check (normalized, separator-anchored) against the
-    # caller's own log dir. The previous `startswith OR "/users/{uid}/" in path`
-    # was a substring test and bypassable (a path merely CONTAINING the segment
-    # passed). get_user_log_dir already includes the user_id, so this confines
-    # reads to {.../users/{user_id}/logs}.
-    if not _is_within_dir(log_file, get_user_log_dir(user_id)):
+    # (1) Authorize, resolving which owner's data this is. Own path needs no
+    # grant; a foreign owner requires an explicit grant (deny-by-default).
+    owner_id = await _resolve_owner(user_id, group_id or "", owner)
+
+    # (2) Separator-anchored boundary check against the RESOLVED owner's dir.
+    # The previous code only ever checked the caller's own dir; for shared
+    # reads we must check the owner's, but only after (1) authorized it.
+    if owner_id == user_id:
+        in_scope = _is_within_dir(log_file, get_user_log_dir(user_id))
+    else:
+        in_scope = sharing.assert_path_within_owner(log_file, owner_id)
+    if not in_scope:
+        logger.warning(
+            f"[ACCESS] denied sample read {user_id} -> {log_file} "
+            f"(owner={owner_id})"
+        )
         raise HTTPException(status_code=403, detail="Access denied")
 
     full_logs = await _read_full_logs([log_file])
@@ -164,6 +282,7 @@ async def generate_report_pdf(
     group_id: str,
     session_id: Optional[str] = Query(None),
     monthly_volume: int = Query(10000, ge=100, le=10_000_000),
+    owner: Optional[str] = Query(None),
     user_id: str = Depends(_get_user_id),
 ):
     """Generate a PDF report for an evaluation group.
@@ -175,13 +294,17 @@ async def generate_report_pdf(
         group_id: Evaluation group to report on.
         session_id: Optional chat session ID to pull transcript for context.
         monthly_volume: Projected monthly call volume for cost projections.
+        owner: Owner hint for a shared eval; gated by the sharing resolver.
     """
     from eval_mcp.core.bedrock_client import BedrockClient
     from eval_mcp.core.pdf_report import generate_pdf_report
 
-    # Load evaluation data
-    detail = load_eval_detail(user_id, group_id)
-    if not detail:
+    # Authorize + resolve which owner's eval data to read.
+    owner_id = await _resolve_owner(user_id, group_id, owner)
+
+    # Load evaluation data scoped to the resolved owner.
+    detail = load_eval_detail(owner_id, group_id)
+    if not detail and owner_id == user_id:
         await precompute_eval_results(user_id)
         detail = load_eval_detail(user_id, group_id)
     if not detail:
@@ -293,3 +416,76 @@ async def download_report(group_id: str, user_id: str = Depends(_get_user_id)):
             "Content-Disposition": f'attachment; filename="eval_report_{safe_id}.pdf"',
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# Share management. A user manages grants on THEIR OWN evals only — owner_id is
+# always the authenticated caller, never client-supplied, so a caller can't
+# create or revoke grants on someone else's data.
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel, Field  # noqa: E402
+
+
+class ShareRequest(BaseModel):
+    principal_type: str = Field(..., pattern="^(user|team|org)$")
+    principal_id: Optional[str] = None   # required for user/team, ignored for org
+    group_id: Optional[str] = None       # None = share ALL of caller's evals
+    role: str = Field("viewer", pattern="^(viewer|editor|owner)$")
+
+
+@router.post("/shares")
+async def create_share(req: ShareRequest, user_id: str = Depends(_get_user_id)):
+    """Grant another user/team/org read access to the caller's eval(s).
+
+    owner_id is the authenticated caller. group_id=None shares ALL the caller's
+    evals (including future ones) — the UI must surface this explicitly.
+    """
+    if req.principal_type in ("user", "team") and not req.principal_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"principal_id required for principal_type={req.principal_type}",
+        )
+    principal_id = None if req.principal_type == "org" else req.principal_id
+    # Only read-sharing is supported in v1; reject editor/owner until the write
+    # paths are gated (deny-by-default rather than silently granting more).
+    if req.role != "viewer":
+        raise HTTPException(
+            status_code=400,
+            detail="only role=viewer is supported in this version",
+        )
+    grant_id = await _db().add_grant(
+        owner_id=user_id,
+        group_id=req.group_id,
+        principal_type=req.principal_type,
+        principal_id=principal_id,
+        granted_by=user_id,
+        role=req.role,
+    )
+    return {"id": grant_id, "ok": True}
+
+
+@router.get("/shares")
+async def list_my_shares(user_id: str = Depends(_get_user_id)):
+    """List grants the caller has created on their own evals."""
+    return {"shares": await _db().list_grants_by_owner(user_id)}
+
+
+@router.get("/users/search")
+async def search_users(
+    q: str = Query(..., min_length=1),
+    user_id: str = Depends(_get_user_id),
+):
+    """Find users to share with, by id or email substring. Auth-gated like
+    every route; returns only {id, email} (no other PII). Grants key on id."""
+    return {"users": await _db().search_users(q, limit=10)}
+
+
+@router.delete("/shares/{grant_id}")
+async def revoke_share(grant_id: str, user_id: str = Depends(_get_user_id)):
+    """Revoke a grant. Scoped to the caller's own grants (owner_id check in
+    the query), so a caller can't revoke grants on another user's evals."""
+    deleted = await _db().remove_grant(grant_id, owner_id=user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Grant not found")
+    return {"ok": True}

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1577,6 +1577,14 @@ async def get_current_user(request: Request):
     if not user_id:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
+    # Record the user + their email on login so the share-by-email picker can
+    # resolve email → id. Best-effort: a DB hiccup must not break auth.
+    if db:
+        try:
+            await db.create_user(user_id, user_id, email=email)
+        except Exception as e:
+            logger.warning(f"create_user on auth failed for {user_id}: {e}")
+
     user = {
         "id": user_id,
         "email": email,
@@ -1838,6 +1846,7 @@ async def delete_judge(
 
 from backend.api.compare import router as compare_router
 from backend.api.optimizations import router as optimizations_router
+from backend.api.teams import router as teams_router
 from backend.core.inspect_viewer import create_viewer_app, get_viewer_dist_directory
 from inspect_ai._view.fastapi_server import _InspectStaticFiles
 from inspect_ai._util.file import filesystem
@@ -1846,6 +1855,7 @@ from inspect_ai._view._dist import resolve_dist_directory
 # Mount comparison API before the Inspect viewer (include_router takes priority over mount)
 app.include_router(compare_router, prefix="/api/compare")
 app.include_router(optimizations_router, prefix="/api/optimizations")
+app.include_router(teams_router, prefix="/api/teams")
 
 _log_dir = os.environ.get("INSPECT_LOG_DIR", os.environ.get("USER_STORAGE_BASE", "backend/users"))
 _fs = filesystem(_log_dir)

--- a/backend/api/teams.py
+++ b/backend/api/teams.py
@@ -1,0 +1,108 @@
+"""Teams API — a team is a principal that eval grants can target.
+
+Identity comes only from X-Forwarded-User (same shim as compare.py). All
+membership/admin checks are deny-by-default: a caller must be a member to see
+a team, and an admin to mutate it. See docs/EVAL_SHARING_DESIGN.md §8/§9.
+"""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+async def _get_user_id(request: Request) -> str:
+    user_id = request.headers.get("X-Forwarded-User")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return user_id
+
+
+def _db():
+    from backend.api.main import db
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not initialized")
+    return db
+
+
+class CreateTeamRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+
+
+class AddMemberRequest(BaseModel):
+    user_id: str = Field(..., min_length=1)
+    role: str = Field("member", pattern="^(admin|member)$")
+
+
+async def _require_member(team_id: str, user_id: str) -> str:
+    """Return the caller's role in the team, or 403 if they're not a member."""
+    role = await _db().get_team_role(team_id, user_id)
+    if role is None:
+        logger.warning(f"[TEAM] denied {user_id} -> team {team_id} (not a member)")
+        raise HTTPException(status_code=403, detail="Not a team member")
+    return role
+
+
+async def _require_admin(team_id: str, user_id: str) -> None:
+    if await _require_member(team_id, user_id) != "admin":
+        raise HTTPException(status_code=403, detail="Team admin required")
+
+
+@router.post("")
+async def create_team(req: CreateTeamRequest, user_id: str = Depends(_get_user_id)):
+    """Create a team; the caller becomes its first admin member."""
+    team_id = uuid.uuid4().hex[:16]
+    # Ensure the creator exists as a user (FK target) before team rows.
+    await _db().create_user(user_id, user_id)
+    await _db().create_team(team_id, req.name, user_id)
+    logger.info(f"[TEAM] {user_id} created team {team_id} ({req.name})")
+    return {"id": team_id, "name": req.name}
+
+
+@router.get("")
+async def list_my_teams(user_id: str = Depends(_get_user_id)):
+    """List teams the caller belongs to (with names + the caller's role)."""
+    return {"teams": await _db().list_teams_for_user_detailed(user_id)}
+
+
+@router.get("/{team_id}/members")
+async def list_members(team_id: str, user_id: str = Depends(_get_user_id)):
+    """List a team's members. Caller must be a member to view."""
+    await _require_member(team_id, user_id)
+    return {"members": await _db().list_team_members(team_id)}
+
+
+@router.post("/{team_id}/members")
+async def add_member(
+    team_id: str, req: AddMemberRequest, user_id: str = Depends(_get_user_id)
+):
+    """Add a member to a team. Admin only."""
+    await _require_admin(team_id, user_id)
+    # The new member must exist as a user row (FK). They may not have logged in
+    # yet — create a stub keyed on the id they were invited by.
+    await _db().create_user(req.user_id, req.user_id)
+    await _db().add_team_member(team_id, req.user_id, req.role)
+    logger.info(f"[TEAM] {user_id} added {req.user_id} ({req.role}) to {team_id}")
+    return {"ok": True}
+
+
+@router.delete("/{team_id}/members/{member_id}")
+async def remove_member(
+    team_id: str, member_id: str, user_id: str = Depends(_get_user_id)
+):
+    """Remove a member from a team. Admin only (a member may remove themselves
+    too — that's a self-service leave)."""
+    if member_id != user_id:
+        await _require_admin(team_id, user_id)
+    else:
+        await _require_member(team_id, user_id)
+    deleted = await _db().remove_team_member(team_id, member_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Member not found")
+    logger.info(f"[TEAM] {user_id} removed {member_id} from {team_id}")
+    return {"ok": True}

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -6,6 +6,7 @@ Supports two authentication modes controlled by POSTGRES_USE_IAM_AUTH:
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -212,6 +213,15 @@ class Database:
                     created_at TIMESTAMP NOT NULL DEFAULT NOW()
                 )
             """)
+            # email is added idempotently (older deployments predate it). It
+            # backs user discovery for the share-by-email picker — grants are
+            # still keyed on the id (X-Forwarded-User), email is only a lookup.
+            await conn.execute(
+                "ALTER TABLE users ADD COLUMN IF NOT EXISTS email TEXT"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)"
+            )
 
             # Chat sessions table
             await conn.execute("""
@@ -263,8 +273,76 @@ class Database:
                 )
             """)
 
-    async def create_user(self, user_id: str, username: str) -> None:
-        """Create a new user.
+            # Teams — a team is just another principal that grants can
+            # target. Membership lives in team_members. See
+            # docs/EVAL_SHARING_DESIGN.md.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS teams (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    FOREIGN KEY (created_by) REFERENCES users (id)
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS team_members (
+                    team_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    role TEXT NOT NULL DEFAULT 'member'
+                        CHECK (role IN ('admin', 'member')),
+                    added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (team_id, user_id),
+                    FOREIGN KEY (team_id) REFERENCES teams (id),
+                    FOREIGN KEY (user_id) REFERENCES users (id)
+                )
+            """)
+
+            # Eval sharing grants. One row expresses every sharing case:
+            # share-one (group_id set) or share-all (group_id NULL), to a
+            # user/team/org principal. Authorization is resolved against
+            # (owner_id, group_id) — group_id alone is NOT globally unique
+            # (it's Inspect's run_id), so owner_id supplies the scope. We do
+            # NOT FK principal_id/group_id: a grantee may not have logged in
+            # yet (users are created lazily) and group_id is not a DB row.
+            # principal_type/role are CHECK-constrained so an unknown value
+            # can't silently fail open. Deny-by-default makes a dangling
+            # principal harmless. See docs/EVAL_SHARING_DESIGN.md.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS eval_grants (
+                    id TEXT PRIMARY KEY,
+                    owner_id TEXT NOT NULL,
+                    group_id TEXT,
+                    principal_type TEXT NOT NULL
+                        CHECK (principal_type IN ('user', 'team', 'org')),
+                    principal_id TEXT,
+                    role TEXT NOT NULL DEFAULT 'viewer'
+                        CHECK (role IN ('viewer', 'editor', 'owner')),
+                    granted_by TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    FOREIGN KEY (owner_id) REFERENCES users (id),
+                    FOREIGN KEY (granted_by) REFERENCES users (id),
+                    UNIQUE (owner_id, group_id, principal_type, principal_id)
+                )
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_grants_principal
+                ON eval_grants(principal_type, principal_id)
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_grants_owner
+                ON eval_grants(owner_id)
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_team_members_user
+                ON team_members(user_id)
+            """)
+
+    async def create_user(
+        self, user_id: str, username: str, email: Optional[str] = None
+    ) -> None:
+        """Create a user (idempotent). If `email` is provided, it is recorded /
+        refreshed so the share-by-email picker can resolve it to this id.
 
         Raises:
             DatabaseError: If the user cannot be created.
@@ -272,12 +350,37 @@ class Database:
         await self._ensure_pool_fresh()
         try:
             async with self._pool.acquire() as conn:
+                # COALESCE keeps an existing email if this call passes none,
+                # and updates it when a fresh one arrives on a later login.
                 await conn.execute(
-                    "INSERT INTO users (id, username, created_at) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING",
-                    user_id, username, datetime.now(),
+                    """
+                    INSERT INTO users (id, username, email, created_at)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (id) DO UPDATE
+                      SET email = COALESCE(EXCLUDED.email, users.email)
+                    """,
+                    user_id, username, email, datetime.now(),
                 )
         except asyncpg.PostgresError as e:
             raise DatabaseError(f"Failed to create user {user_id}: {e}") from e
+
+    async def search_users(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Find users by id or email substring (case-insensitive), for the
+        share recipient picker. Returns [{id, email}]. Empty query → []."""
+        q = (query or "").strip()
+        if not q:
+            return []
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, email FROM users
+                WHERE id ILIKE '%' || $1 || '%' OR email ILIKE '%' || $1 || '%'
+                ORDER BY id LIMIT $2
+                """,
+                q, limit,
+            )
+            return [{"id": r["id"], "email": r["email"]} for r in rows]
 
     async def create_session(self, session_id: str, user_id: str, title: str = "New Chat") -> None:
         """Create a new chat session.
@@ -429,6 +532,301 @@ class Database:
             # next poll catches it.
             logger.warning(f"Failed to check cancellation for {session_id}: {e}")
             return None
+
+    # ------------------------------------------------------------------
+    # Eval sharing: grants + teams. See docs/EVAL_SHARING_DESIGN.md.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _grant_id(owner_id: str, group_id: Optional[str],
+                  principal_type: str, principal_id: Optional[str]) -> str:
+        """Deterministic id for a grant tuple.
+
+        Used as the PRIMARY KEY so ON CONFLICT dedupes idempotently. The
+        composite UNIQUE constraint alone can't, because Postgres treats
+        NULLs (share-all group_id, org principal_id) as distinct — so two
+        identical share-all grants would otherwise both insert. Hashing the
+        normalized tuple gives a stable id that collides on a true duplicate.
+        """
+        key = "\x1f".join([
+            owner_id,
+            group_id or "",
+            principal_type,
+            principal_id or "",
+        ])
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+
+    async def add_grant(
+        self,
+        owner_id: str,
+        group_id: Optional[str],
+        principal_type: str,
+        principal_id: Optional[str],
+        granted_by: str,
+        role: str = "viewer",
+    ) -> str:
+        """Create a sharing grant. Returns the grant id.
+
+        group_id=None means "all of owner's evals" (including future ones).
+        principal_type='org' means everyone; principal_id is then ignored.
+        Idempotent via the deterministic id.
+
+        Raises:
+            DatabaseError: If the grant cannot be created.
+        """
+        grant_id = self._grant_id(owner_id, group_id, principal_type, principal_id)
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO eval_grants
+                        (id, owner_id, group_id, principal_type, principal_id,
+                         role, granted_by, created_at)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                    ON CONFLICT (id) DO NOTHING
+                    """,
+                    grant_id, owner_id, group_id, principal_type,
+                    principal_id, role, granted_by,
+                )
+        except asyncpg.PostgresError as e:
+            raise DatabaseError(f"Failed to add grant {grant_id}: {e}") from e
+        logger.info(
+            f"[GRANT] {granted_by} granted {principal_type}:{principal_id} "
+            f"{role} on owner={owner_id} group={group_id or '*'}"
+        )
+        return grant_id
+
+    async def remove_grant(self, grant_id: str, owner_id: str) -> bool:
+        """Revoke a grant. owner_id is required so a caller can only delete
+        grants on their OWN evals (defense in depth — the route also checks).
+        Returns True if a row was deleted.
+
+        Raises:
+            DatabaseError: If the delete fails.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM eval_grants WHERE id = $1 AND owner_id = $2",
+                    grant_id, owner_id,
+                )
+        except asyncpg.PostgresError as e:
+            raise DatabaseError(f"Failed to remove grant {grant_id}: {e}") from e
+        deleted = result.endswith(" 1")
+        if deleted:
+            logger.info(f"[GRANT] {owner_id} revoked grant {grant_id}")
+        return deleted
+
+    async def list_grants_by_owner(self, owner_id: str) -> List[Dict[str, Any]]:
+        """List grants the owner has created (for the 'who can see my evals' UI)."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, group_id, principal_type, principal_id, role, created_at
+                FROM eval_grants WHERE owner_id = $1 ORDER BY created_at DESC
+                """,
+                owner_id,
+            )
+            return [
+                {
+                    "id": row["id"],
+                    "groupId": row["group_id"],
+                    "principalType": row["principal_type"],
+                    "principalId": row["principal_id"],
+                    "role": row["role"],
+                    "createdAt": row["created_at"].isoformat(),
+                }
+                for row in rows
+            ]
+
+    async def list_grants_for_principals(
+        self, principals: List[tuple]
+    ) -> List[Dict[str, Any]]:
+        """Return all grants visible to a caller given their resolved
+        principals — a list of (principal_type, principal_id) tuples, e.g.
+        [('user', caller), ('team', t1), ('org', None)].
+
+        This is the read side of the resolver: it yields the (owner_id,
+        group_id) scopes the caller may read. group_id NULL = all of that
+        owner's evals.
+        """
+        if not principals:
+            return []
+        await self._ensure_pool_fresh()
+        # Build an OR of (principal_type, principal_id) pairs. principal_id
+        # may be NULL (org), so compare with IS NOT DISTINCT FROM.
+        clauses = []
+        args: List[Any] = []
+        for ptype, pid in principals:
+            args.append(ptype)
+            args.append(pid)
+            n = len(args)
+            clauses.append(
+                f"(principal_type = ${n - 1} "
+                f"AND principal_id IS NOT DISTINCT FROM ${n})"
+            )
+        where = " OR ".join(clauses)
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT owner_id, group_id, role
+                FROM eval_grants
+                WHERE {where}
+                """,
+                *args,
+            )
+            return [
+                {
+                    "ownerId": row["owner_id"],
+                    "groupId": row["group_id"],
+                    "role": row["role"],
+                }
+                for row in rows
+            ]
+
+    async def get_teams_for_user(self, user_id: str) -> List[str]:
+        """Return the team ids a user belongs to (for principal resolution)."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT team_id FROM team_members WHERE user_id = $1",
+                user_id,
+            )
+            return [row["team_id"] for row in rows]
+
+    async def create_team(self, team_id: str, name: str, created_by: str) -> None:
+        """Create a team and add the creator as an admin member.
+
+        Raises:
+            DatabaseError: If the team cannot be created.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                async with conn.transaction():
+                    await conn.execute(
+                        """
+                        INSERT INTO teams (id, name, created_by, created_at)
+                        VALUES ($1, $2, $3, NOW())
+                        ON CONFLICT (id) DO NOTHING
+                        """,
+                        team_id, name, created_by,
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO team_members (team_id, user_id, role, added_at)
+                        VALUES ($1, $2, 'admin', NOW())
+                        ON CONFLICT (team_id, user_id) DO NOTHING
+                        """,
+                        team_id, created_by,
+                    )
+        except asyncpg.PostgresError as e:
+            raise DatabaseError(f"Failed to create team {team_id}: {e}") from e
+
+    async def add_team_member(
+        self, team_id: str, user_id: str, role: str = "member"
+    ) -> None:
+        """Add a user to a team.
+
+        Raises:
+            DatabaseError: If the member cannot be added.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO team_members (team_id, user_id, role, added_at)
+                    VALUES ($1, $2, $3, NOW())
+                    ON CONFLICT (team_id, user_id) DO UPDATE SET role = EXCLUDED.role
+                    """,
+                    team_id, user_id, role,
+                )
+        except asyncpg.PostgresError as e:
+            raise DatabaseError(
+                f"Failed to add member {user_id} to team {team_id}: {e}"
+            ) from e
+
+    async def remove_team_member(self, team_id: str, user_id: str) -> bool:
+        """Remove a member from a team. Returns True if a row was deleted.
+
+        Raises:
+            DatabaseError: If the delete fails.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM team_members WHERE team_id = $1 AND user_id = $2",
+                    team_id, user_id,
+                )
+        except asyncpg.PostgresError as e:
+            raise DatabaseError(
+                f"Failed to remove member {user_id} from team {team_id}: {e}"
+            ) from e
+        return result.endswith(" 1")
+
+    async def list_teams_for_user_detailed(self, user_id: str) -> List[Dict[str, Any]]:
+        """Teams the user belongs to, with names + the caller's role in each.
+        Powers the team-management UI (get_teams_for_user returns bare ids for
+        the resolver hot path)."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT t.id, t.name, t.created_by, tm.role
+                FROM team_members tm JOIN teams t ON t.id = tm.team_id
+                WHERE tm.user_id = $1 ORDER BY t.name
+                """,
+                user_id,
+            )
+            return [
+                {"id": r["id"], "name": r["name"],
+                 "createdBy": r["created_by"], "role": r["role"]}
+                for r in rows
+            ]
+
+    async def list_team_members(self, team_id: str) -> List[Dict[str, Any]]:
+        """Members of a team, with their email (for display) and role."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT tm.user_id, tm.role, u.email
+                FROM team_members tm LEFT JOIN users u ON u.id = tm.user_id
+                WHERE tm.team_id = $1 ORDER BY tm.role, tm.user_id
+                """,
+                team_id,
+            )
+            return [
+                {"userId": r["user_id"], "role": r["role"], "email": r["email"]}
+                for r in rows
+            ]
+
+    async def is_team_member(self, team_id: str, user_id: str) -> bool:
+        """True if user_id belongs to team_id. Used to authorize team-scoped
+        reads/management (deny-by-default: missing row → False)."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2",
+                team_id, user_id,
+            )
+            return row is not None
+
+    async def get_team_role(self, team_id: str, user_id: str) -> Optional[str]:
+        """The caller's role in a team ('admin'/'member'), or None if not a
+        member. Used to gate admin-only team operations."""
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT role FROM team_members WHERE team_id = $1 AND user_id = $2",
+                team_id, user_id,
+            )
+            return row["role"] if row else None
 
     async def close(self):
         """Close all connections in the pool. Sets _closed so any

--- a/backend/core/inspect_viewer.py
+++ b/backend/core/inspect_viewer.py
@@ -67,8 +67,67 @@ def _is_within_user_scope(path: str, user_id: str, log_root: str) -> bool:
     return _is_within_dir(path, f"{root}/{user_id}")
 
 
+def _owner_of(path: str, log_root: str) -> str | None:
+    """Extract the owning user id from a `{log_root}/{owner}/...` path.
+
+    Returns None for the bare root or a path outside the root. Used to decide
+    WHOSE subtree a shared read is targeting before consulting grants. Uses the
+    same scheme-stripping/`..`-collapsing normalization as the boundary check,
+    so it can't be fooled by a crafted prefix or traversal.
+    """
+    norm = _normalize_key(path)
+    root = _normalize_key(log_root).rstrip("/")
+    if not norm or not root:
+        return None
+    if norm == root:
+        return None
+    if not (norm + "/").startswith(root + "/"):
+        return None
+    rest = norm[len(root):].lstrip("/")
+    if not rest:
+        return None
+    return rest.split("/")[0]
+
+
+async def _run_id_of(file: str) -> str | None:
+    """Best-effort read of an eval log's run_id (== its sharing group_id).
+
+    Lets the viewer honor PER-GROUP grants on raw `.eval` paths. On any failure
+    we return None, which means only share-all/team/org grants will match — a
+    safe UNDER-grant, never an over-grant.
+    """
+    try:
+        from inspect_ai.log import read_eval_log_async
+        log = await read_eval_log_async(file, header_only=True)
+        return log.eval.run_id
+    except Exception:
+        return None
+
+
+async def _has_grant(caller_id: str, owner_id: str, group_id: str | None) -> bool:
+    """Consult the sharing resolver for a cross-user read. Lazy imports avoid a
+    circular dependency with backend.api.main (which imports this module) and
+    keep the eval_mcp package free of any DB dependency. Fails closed."""
+    if not caller_id or not owner_id:
+        return False
+    try:
+        from backend.api.main import db
+        if db is None:
+            return False
+        from backend.core import sharing
+        return await sharing.can_read(db, caller_id, owner_id, group_id)
+    except Exception:
+        return False
+
+
 class UserAccessPolicy:
-    """Multi-tenant access policy. Scopes log access to the authenticated user."""
+    """Multi-tenant access policy.
+
+    Reads (can_read/can_list) are scoped to the caller's own subtree OR any
+    owner the caller has a sharing grant from. Mutations (can_delete/can_write)
+    remain STRICTLY self-only — sharing is read-only, so a grantee can never
+    delete or edit the owner's logs via /api/log-delete or /api/log-edit.
+    """
 
     def __init__(self, log_root: str):
         # Normalize once (strip scheme, collapse) so the bare equality check in
@@ -76,26 +135,45 @@ class UserAccessPolicy:
         self._log_root = _normalize_key(log_root).rstrip("/")
 
     async def can_read(self, request: Request, file: str) -> bool:
-        return _is_within_user_scope(file, _get_user_id(request), self._log_root)
+        user_id = _get_user_id(request)
+        # Own subtree → allow (fast path, unchanged from the pre-sharing code).
+        if _is_within_user_scope(file, user_id, self._log_root):
+            return True
+        # Otherwise it must be inside some owner's subtree AND the caller must
+        # hold a grant on it. Resolve the run_id so per-group grants apply;
+        # share-all/team/org grants apply even when the run_id can't be read.
+        owner = _owner_of(file, self._log_root)
+        if not owner:
+            return False
+        run_id = await _run_id_of(file)
+        return await _has_grant(user_id, owner, run_id)
 
     async def can_delete(self, request: Request, file: str) -> bool:
-        return await self.can_read(request, file)
+        # Self-only — NOT delegated to can_read. Sharing is read-only.
+        return _is_within_user_scope(file, _get_user_id(request), self._log_root)
 
     async def can_write(self, request: Request, file: str) -> bool:
-        return await self.can_read(request, file)
+        # Self-only — NOT delegated to can_read. Sharing is read-only.
+        return _is_within_user_scope(file, _get_user_id(request), self._log_root)
 
     async def can_list(self, request: Request, dir: str) -> bool:
         user_id = _get_user_id(request)
         if not user_id:
             return False
-        # Allow the user's own subtree, OR the shared root itself — the root is
-        # the viewer's default listing target, and the mapping policy rewrites
-        # it down to THIS user's logs dir (see map()), so listing the root can
-        # never enumerate another tenant. Any OTHER explicit dir (another
-        # user's subtree, /tmp, …) is denied here.
+        # Own subtree, OR the shared root itself (the default listing target,
+        # which map() rewrites down to THIS user's logs dir so it can't
+        # enumerate another tenant).
         if _is_within_user_scope(dir, user_id, self._log_root):
             return True
-        return _normalize_key(dir) == self._log_root
+        if _normalize_key(dir) == self._log_root:
+            return True
+        # A granted owner's subtree may be listed. Directory listing has no
+        # run_id, so only owner-level grants (share-all / team / org) authorize
+        # it — a per-group-only grant won't open the whole dir.
+        owner = _owner_of(dir, self._log_root)
+        if not owner:
+            return False
+        return await _has_grant(user_id, owner, None)
 
 
 class UserFileMappingPolicy:
@@ -112,10 +190,20 @@ class UserFileMappingPolicy:
         # Already inside this user's subtree → pass through unchanged.
         if _is_within_user_scope(file, user_id, self._log_root):
             return file
+        # A path inside a granted owner's subtree must PASS THROUGH unchanged —
+        # otherwise can_read would authorize the shared read but map would
+        # silently rewrite it to the caller's own (empty) dir, breaking it.
+        # This is gated by the same grant check, so an ungranted foreign path
+        # still falls through to the rewrite below.
+        owner = _owner_of(file, self._log_root)
+        if owner and owner != user_id:
+            run_id = await _run_id_of(file)
+            if await _has_grant(user_id, owner, run_id):
+                return file
         # The shared root (the default listing target) or any other absolute
-        # path under the root that is NOT this user's → force into the user's
-        # own logs dir. A caller-supplied path can never escape the per-user
-        # prefix this way.
+        # path under the root that is NOT this user's and NOT granted → force
+        # into the user's own logs dir. A caller-supplied path can never escape
+        # the per-user prefix this way.
         if _is_within_dir(file, self._log_root):
             return user_logs
         # A relative filename → resolve under the user's logs dir.

--- a/backend/core/mcp_client.py
+++ b/backend/core/mcp_client.py
@@ -241,18 +241,40 @@ class MultiMCPClient:
         """
         self.user_id = user_id
 
+    async def _shared_scopes(self) -> list:
+        """Evals shared with the current caller, as [{ownerId, groupId}] (a
+        groupId of None means all of that owner's evals). Resolved from grants
+        with the trusted caller identity. Lazy imports keep the eval_mcp
+        package DB-free and avoid a circular import with backend.api.main.
+        Fails closed (returns [])."""
+        try:
+            from backend.api.main import db
+            if db is None or not self.user_id:
+                return []
+            from backend.core import sharing
+            scopes = await sharing.list_shared_scopes(db, self.user_id)
+            return [
+                {"ownerId": s["ownerId"], "groupId": s["groupId"]}
+                for s in scopes
+            ]
+        except Exception as e:
+            self.logger.warning(f"shared-scope resolution failed: {e}")
+            return []
+
+    # Params the backend injects server-side and the model must never set.
+    _INJECTED_PARAMS = ("user_id", "shared_scopes", "owner_id")
+
     def _filter_user_id_from_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
-        """Remove user_id from tool schema so agent doesn't see it."""
+        """Remove backend-injected params from a tool schema so the agent never
+        sees (or tries to set) them."""
         import copy
         filtered = copy.deepcopy(schema)
 
-        # Remove from properties
-        if "properties" in filtered and "user_id" in filtered["properties"]:
-            del filtered["properties"]["user_id"]
-
-        # Remove from required list
-        if "required" in filtered and "user_id" in filtered["required"]:
-            filtered["required"] = [r for r in filtered["required"] if r != "user_id"]
+        for param in self._INJECTED_PARAMS:
+            if "properties" in filtered and param in filtered["properties"]:
+                del filtered["properties"][param]
+            if "required" in filtered and param in filtered["required"]:
+                filtered["required"] = [r for r in filtered["required"] if r != param]
 
         return filtered
 
@@ -285,8 +307,10 @@ class MultiMCPClient:
                 for tool in result.tools:
                     input_schema = tool.inputSchema
 
-                    # Hide user_id from tools that auto-inject it
-                    if server_name in ("synthetic-eval", "dataset") and input_schema:
+                    # Hide backend-injected params from the model. (The unified
+                    # server registers as "eval"; the older split names are kept
+                    # for backward compat.)
+                    if server_name in ("eval", "synthetic-eval", "dataset") and input_schema:
                         input_schema = self._filter_user_id_from_schema(input_schema)
 
                     all_tools.append({
@@ -350,6 +374,22 @@ class MultiMCPClient:
         if self.user_id:
             arguments = arguments or {}
             arguments["user_id"] = self.user_id
+
+        # For read tools, also inject the evals SHARED with this caller, so
+        # shared results surface in chat. This is computed server-side from
+        # grants using the trusted caller identity (NEVER from the model), so
+        # the model cannot widen its own access. The eval_mcp tools stay
+        # DB-free — they just receive an authorized list of {ownerId, groupId}.
+        if self.user_id and tool_name in (
+            "list_evaluations", "get_evaluation_details", "generate_report",
+        ):
+            arguments = arguments or {}
+            arguments["shared_scopes"] = await self._shared_scopes()
+
+        # Strip any model-supplied owner_id — cross-user reads are authorized
+        # only via the injected shared_scopes, never a raw owner the model names.
+        if arguments and "owner_id" in arguments:
+            del arguments["owner_id"]
 
         # Log tool call
         self.logger.info(

--- a/backend/core/sharing.py
+++ b/backend/core/sharing.py
@@ -1,0 +1,122 @@
+"""Cross-user eval sharing: the authorization resolver.
+
+This is the single policy decision point every read path calls. It is
+deny-by-default: it returns access ONLY on an explicit ownership match or an
+explicit grant match, and returns None / False otherwise.
+
+It composes the boundary primitives from the PR #106 tenant-isolation fix
+rather than reimplementing them:
+- identity is the authenticated caller (X-Forwarded-User), never client input;
+- the resolved owner is turned into a path via get_user_log_dir() and the
+  candidate read path is re-validated with _is_within_dir(), so a grant can
+  never be leveraged to read OUTSIDE the grantor's own subtree.
+
+See docs/EVAL_SHARING_DESIGN.md for the full design and threat model.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# A principal is a (type, id) tuple. id is None for the 'org' (everyone)
+# principal. These are what a grant can target.
+Principal = Tuple[str, Optional[str]]
+
+
+async def resolve_principals(db, caller_id: str) -> List[Principal]:
+    """The set of principals a caller acts as: themselves, every team they
+    belong to, and the org-wide 'everyone' principal.
+
+    A grant targeting any of these grants the caller access.
+    """
+    principals: List[Principal] = [("user", caller_id), ("org", None)]
+    try:
+        for team_id in await db.get_teams_for_user(caller_id):
+            principals.append(("team", team_id))
+    except Exception as e:
+        # Team lookup failure must not fail OPEN by accident, but it also
+        # shouldn't deny a user their OWN evals — we already have ('user',
+        # caller) and ('org', None). Log and continue with what we have.
+        logger.warning(f"[ACCESS] team resolution failed for {caller_id}: {e}")
+    return principals
+
+
+def _grant_covers(grant: Dict[str, Any], owner_id: str,
+                  group_id: Optional[str]) -> bool:
+    """True iff a grant row authorizes reading (owner_id, group_id).
+
+    A grant with groupId=None is a share-all over that owner's evals. A grant
+    with a groupId matches only that specific group. Both require the owner to
+    match — group_id is not globally unique, so owner scopes it.
+    """
+    if grant["ownerId"] != owner_id:
+        return False
+    g = grant["groupId"]
+    return g is None or g == group_id
+
+
+async def can_read(db, caller_id: str, owner_id: str,
+                   group_id: Optional[str] = None) -> bool:
+    """Deny-by-default read check for (owner_id, group_id) by caller_id.
+
+    Returns True only if the caller owns the eval, or a grant explicitly
+    authorizes one of the caller's principals to read it. Everything else
+    (including any error path) returns False.
+    """
+    if not caller_id or not owner_id:
+        return False
+
+    # 1. Ownership fast path.
+    if caller_id == owner_id:
+        return True
+
+    # 2. Grant path.
+    try:
+        principals = await resolve_principals(db, caller_id)
+        grants = await db.list_grants_for_principals(principals)
+    except Exception as e:
+        logger.warning(
+            f"[ACCESS] grant lookup failed for {caller_id} -> "
+            f"{owner_id}/{group_id}: {e}"
+        )
+        return False
+
+    for grant in grants:
+        if _grant_covers(grant, owner_id, group_id):
+            return True
+
+    return False
+
+
+def assert_path_within_owner(read_path: str, owner_id: str) -> bool:
+    """Re-validate that a concrete read path stays within the resolved
+    owner's log subtree, using the PR #106 boundary primitive.
+
+    Call this AFTER can_read() returns True, on any code path that touches a
+    raw filesystem/S3 path (e.g. /api/compare/sample). It guarantees a grant
+    can't be turned into a traversal out of the grantor's own dir. Returns
+    False on any escape — callers turn that into a 403.
+    """
+    # Imported lazily so the pure authz logic (can_read) stays free of the
+    # inspect_ai / filesystem dependency chain and is unit-testable stack-free.
+    from backend.core.inspect_viewer import _is_within_dir
+    from eval_mcp.core.user_storage import get_user_log_dir
+
+    try:
+        owner_root = get_user_log_dir(owner_id)
+    except ValueError:
+        return False
+    return _is_within_dir(read_path, owner_root)
+
+
+async def list_shared_scopes(db, caller_id: str) -> List[Dict[str, Any]]:
+    """Return the (ownerId, groupId, role) scopes shared with the caller —
+    excluding the caller's own evals. Used by /api/compare/groups to merge a
+    'Shared with me' section. groupId=None means all of that owner's evals.
+    """
+    principals = await resolve_principals(db, caller_id)
+    grants = await db.list_grants_for_principals(principals)
+    # Drop self-grants (a user sharing with themselves) — own evals are
+    # already listed via the normal path.
+    return [g for g in grants if g["ownerId"] != caller_id]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,6 +153,33 @@ AWS_PROFILE=my-profile make dev    # from repo root: builds the SPA, then docker
 
 Opens http://localhost:4001. `make dev` builds the static SPA into `frontend/dist`, which nginx serves directly and proxies the gated paths (`/api`, `/inspect`) to the backend (no Node frontend container — nginx stands in for the EKS edge, where CloudFront serves the SPA from a private S3 bucket and routes the gated paths to the ALB/oauth2-proxy/backend). The backend hot-reloads on Python edits; for frontend edits rerun `make dev-spa` and refresh. See [`local/README.md`](../local/README.md) for commands (`make logs`, `make restart s=backend`, etc.) and the architecture diagram.
 
+## How to *really* test the web app (the layers that count)
+
+Pytest mocks produce false greens for anything touching Bedrock, the MCP subprocess, the agent loop, or per-user storage (same caveat as the MCP — see section 2). For the web app, "tested" means **exercised against the live `make dev` stack**, layered cheapest-first. Use the right layer for the surface you changed:
+
+| Layer | Tool | What it proves | When |
+|---|---|---|---|
+| 1. Pure logic | `pytest tests/` | deny-by-default decisions, path-boundary math, parsing | authz resolvers, validators, regex — anything deterministic |
+| 2. HTTP/API E2E | `curl`/`urllib` against `:4001` (or backend `:8080` direct) | real routes, real DB, real auth-gating | any `/api/*` route; the `verify_*.py` scripts are the model |
+| 3. **Agent/chat E2E** | `curl` the **`/api/chat/message`** endpoint (`{"stream":false}`) | the **model actually invokes the MCP tool** and the result flows back | anything the chat agent drives — MCP tools, tool-arg injection, shared-eval surfacing |
+| 4. Browser UI | **`webapp-testing` skill (Playwright)** | components render, forms submit, modals/nav work | any change the SPA renders — pages, modals, badges, columns |
+
+**Key distinction (don't conflate layers 3 and 4):**
+- **Chat behavior is layer 3, not Playwright.** To prove the agent really lists/reads what it should, POST to `/api/chat/message` with `{"stream": false}` and assert on the model's reply. Example — proving an eval surfaces in chat only when it should:
+  ```bash
+  # turn 1 (no grant): the agent must NOT see it
+  curl -s -X POST http://localhost:4001/api/chat/message -H 'Content-Type: application/json' \
+    -d '{"message":"List my evaluations. Is run id FOO123 present? yes/no.","stream":false}' \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["response"])'
+  # ...create the grant, then re-ask in a fresh turn → the agent now names it.
+  ```
+  This needs Bedrock creds (the agent calls Bedrock) — `make dev` already exports them from your AWS profile, so it Just Works; it is **not** a blocker.
+- **Two identities locally:** the nginx stub pins every `:4001` request to `local-user`. To act as a second user, hit the backend container directly with your own header — `docker compose -f local/compose.yaml exec -T backend curl ... -H 'X-Forwarded-User: other-user' http://localhost:8080/...` — or plant the other user's data/grants under `/data/users/<id>/` and via `psql`. See [`verify_grant_isolation.py`](../verify_grant_isolation.py) and [`verify_tenant_isolation.py`](../verify_tenant_isolation.py) for the full pattern (plant → assert deny → grant → assert allow → revoke → assert deny).
+- **Browser UI is layer 4 — the `webapp-testing` skill.** It spins up Playwright headless and clicks through real pages (`:4001`). Use it for what the user *sees*; use layer 3 for what the agent *does*.
+- **Clean up after E2E:** these layers write real rows/files. Remove planted `/data/users/<id>/` dirs and `psql DELETE` test grants/teams/users in a `finally`, and verify zero leftovers (the `verify_*.py` scripts do this).
+
+**Deployed verification (real AWS):** after `./deploy.sh`, the same layers apply, plus in-pod checks via `kubectl exec -n eval-managed <backend-pod> -c backend -- python3 -c '...'` against production RDS (read/describe first; clean up any test rows). CI runs none of this — these are manual, run them before shipping anything non-trivial.
+
 ## Architecture
 
 System architecture, request flow, and security boundaries are in

--- a/docs/EVAL_SHARING_DESIGN.md
+++ b/docs/EVAL_SHARING_DESIGN.md
@@ -1,0 +1,290 @@
+# Design: cross-user eval sharing (web app)
+
+Status: **implemented (all phases 0–4)** · Scope: **EKS web app only** (`backend/` + `frontend/` + `helm/` + `infra/`) · Applies to: multi-user Cognito deployment, **not** the local MCP package
+
+> **Implementation note (all phases shipped).** Grants key on the composite `(owner_id, group_id)` rather than a separate minted `eval_id` registry — `owner_id` supplies the uniqueness `group_id` (Inspect's `run_id`) lacks, which delivered the same authorization guarantees without the storage-layer refactor of phase 0. The owner travels with each request as a hint (`?owner=`), and is always re-authorized server-side via the resolver. Phases delivered: user→user + share-all (`eval_grants`), teams (`teams`/`team_members` + `/api/teams`), org-wide (`org` principal), the Inspect raw viewer (`inspect_viewer.py` grant-aware `can_read`/`can_list`, read-only), and chat/MCP (backend-injected `shared_scopes`). The `eval_mcp/` package stays DB-free — all grant resolution lives in `backend/`.
+
+This document specifies how one web-app user shares their evaluation results with another user — progressively, from person-to-person up to teams and the whole org — under the first user's permission and read-only. It is grounded in the authorization primitives this repo already ships (the PR #106 tenant-isolation fix) and in OWASP / NIST guidance for access control.
+
+> **Out of scope.** The standalone `eval-mcp` PyPI package has no database and stays single-user; its only "sharing" is the S3 `projects/` broadcast prefix (`eval_mcp/s3_sync.py`), a separate mechanism. Teams/org sharing is inherently a server-side, multi-user concept and lives only in the web app.
+
+---
+
+## 1. Why this is non-trivial today
+
+Today every read is scoped by **one `user_id`** (the `X-Forwarded-User` header from oauth2-proxy) that becomes a storage path/prefix `users/{user_id}/...`. Ownership and storage location are welded together. Two structural facts make naive sharing unsafe:
+
+1. **`group_id` is not globally unique.** It is Inspect AI's `run_id` (or a filename fallback) — `eval_mcp/core/eval_results.py:261`. Two users can hold the same `group_id`; isolation comes purely from the path prefix. A sharing grant keyed on `group_id` alone is ambiguous.
+2. **The groups list is one JSON blob per user** (`_groups.json`) with **no owner field** in any element (`eval_results.py:311`). You cannot hand a viewer the owner's blob — that would leak all of the owner's evals.
+
+The fix is the standard production move: **decouple identity from location.** Give each shareable eval a stable global id and an explicit owner recorded as *data*, then authorize reads against a grant store.
+
+---
+
+## 2. Goals & non-goals
+
+**Goals**
+- Read-only sharing: a viewer reads the owner's data in place; bytes never copied, never leave the owner's prefix.
+- Progressive scope with **one mechanism**: user → user, user → team, user → org.
+- A **single server-side resolver** every read path calls. Deny by default.
+- Ship with the same isolation-test rigor as the PR #106 breach fix.
+
+**Non-goals (v1)**
+- No write/delete/re-run on shared evals (`role` column reserved for later; only `viewer` is issued).
+- No deep inheritance ("share a folder → children inherit recursively"). See §8 — that is the ReBAC trigger, deliberately deferred.
+- No changes to the local MCP package.
+
+---
+
+## 3. Architecture: two stores, one resolver
+
+| Concern | Where it lives | New? |
+|---|---|---|
+| **Authorization** — registry (eval → owner), teams, memberships, grants | **RDS Postgres** (existing `backend/core/database.py`) | New *tables*, same DB instance |
+| **Eval data** — `.eval` logs, precomputed JSON, reports | **S3** `users/{owner_id}/...`, unchanged | No change — files don't move |
+
+RDS answers "who can see what" (a join); S3 holds the bytes. The **registry row is the bridge**: it lives in RDS but maps a stable `eval_id` → `(owner_id, run_id)`, i.e. the existing S3 location. Files stay put; only identity becomes queryable.
+
+```mermaid
+flowchart TB
+    Client["SPA (Results page)"]
+    subgraph Edge["Edge (already airtight)"]
+        CF["CloudFront + WAF"]
+        ALB["internal ALB"]
+        OAP["oauth2-proxy<br/>sets X-Forwarded-User"]
+    end
+    subgraph Pod["backend pod"]
+        API["FastAPI /api/compare/*"]
+        Resolver["can_read(caller, eval_id)<br/>deny-by-default resolver"]
+    end
+    RDS[("RDS Postgres<br/>registry · teams · members · grants")]
+    S3[("S3 users/{owner_id}/...<br/>.eval logs + JSON")]
+
+    Client --> CF --> ALB --> OAP --> API
+    API --> Resolver
+    Resolver -->|"owner + grant lookup"| RDS
+    Resolver -->|"on allow: read as owner"| S3
+```
+
+---
+
+## 4. Schema (added to `init_db()`, `backend/core/database.py:204`)
+
+Idempotent `CREATE TABLE IF NOT EXISTS` blocks, matching existing style (`TEXT` ids, FK to `users(id)`, `TIMESTAMPTZ`, `CHECK` constraints, indexes).
+
+```sql
+-- (1) Registry: stable id + explicit owner. Decouples identity from S3 path.
+CREATE TABLE IF NOT EXISTS eval_registry (
+    eval_id    TEXT PRIMARY KEY,                    -- stable UUID we mint
+    owner_id   TEXT NOT NULL REFERENCES users(id),
+    run_id     TEXT,                                -- Inspect's old group_id (S3 locator)
+    task       TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (owner_id, run_id)                        -- owner_id supplies the uniqueness run_id lacks
+);
+CREATE INDEX IF NOT EXISTS idx_registry_owner ON eval_registry(owner_id);
+
+-- (2) Teams: a team is just another principal.
+CREATE TABLE IF NOT EXISTS teams (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    created_by TEXT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS team_members (
+    team_id  TEXT NOT NULL REFERENCES teams(id),
+    user_id  TEXT NOT NULL REFERENCES users(id),
+    role     TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('admin','member')),
+    added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, user_id)
+);
+
+-- (3) Grants: one row expresses every sharing case.
+CREATE TABLE IF NOT EXISTS grants (
+    id             BIGSERIAL PRIMARY KEY,
+    owner_id       TEXT NOT NULL REFERENCES users(id),   -- whose evals
+    resource_id    TEXT,                                  -- eval_id, OR NULL = "all of owner's evals"
+    principal_type TEXT NOT NULL CHECK (principal_type IN ('user','team','org')),
+    principal_id   TEXT,                                  -- user_id / team_id, OR NULL for 'org'
+    role           TEXT NOT NULL DEFAULT 'viewer'
+                       CHECK (role IN ('viewer','editor','owner')),
+    granted_by     TEXT NOT NULL REFERENCES users(id),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_grants_principal ON grants(principal_type, principal_id);
+CREATE INDEX IF NOT EXISTS idx_grants_owner     ON grants(owner_id);
+```
+
+One table, every case:
+
+| Want | Grant row |
+|---|---|
+| Share eval X with Bob | `resource_id=X, principal_type=user, principal_id=bob` |
+| Share eval X with a team | `resource_id=X, principal_type=team, principal_id=team7` |
+| Share **all** my evals with a team | `resource_id=NULL, owner_id=me, principal_type=team` |
+| Org-wide | `principal_type=org, principal_id=NULL` |
+
+> **Note: `principal_id`/`resource_id` are intentionally NOT foreign keys.** A grantee may not exist in `users` yet (users are created lazily on first hit — `create_user(user_id, user_id)`, `main.py:1136`), and `resource_id=NULL` is the share-all wildcard. The resolver validates existence at read time; deny-by-default makes a dangling principal harmless.
+
+---
+
+## 5. The resolver — deny by default, reuse existing primitives
+
+A **single** `can_read(caller_id, eval_id)` that every read path calls. It **composes** the PR #106 primitives rather than duplicating them.
+
+```python
+async def can_read(caller_id: str, eval_id: str) -> Optional[str]:
+    """Return the owner_id to read as if caller may read this eval, else None.
+
+    Deny-by-default: returns None unless an explicit owner-match or grant-match
+    succeeds. Mirrors UserAccessPolicy.can_list (inspect_viewer.py:87).
+    """
+    reg = await db.get_registry(eval_id)        # eval_id -> (owner_id, run_id)
+    if not reg:
+        return None                              # unknown resource -> deny
+
+    owner_id = reg["owner_id"]
+
+    # 1. Ownership fast path.
+    if owner_id == caller_id:
+        return owner_id
+
+    # 2. Grant path. Resolve caller's principals: self + teams + org.
+    principals = {("user", caller_id), ("org", None)}
+    for t in await db.get_teams_for_user(caller_id):
+        principals.add(("team", t))
+
+    if await db.has_grant(owner_id, eval_id, principals):  # role >= 'viewer'
+        return owner_id
+
+    return None                                  # deny
+```
+
+Every consuming endpoint then:
+
+```python
+owner_id = await can_read(caller_id, eval_id)
+if owner_id is None:
+    logger.warning(f"[ACCESS] denied {caller_id} -> eval {eval_id}")
+    raise HTTPException(status_code=403, detail="Access denied")
+
+# CRITICAL: build the path through the SAFE helper, scoped to the resolved owner.
+# A grant can never be leveraged to read OUTSIDE the grantor's own subtree, because
+# the path is rebuilt from owner_id via get_user_log_dir (user_storage.py:141) and
+# re-validated with _is_within_dir (inspect_viewer.py:42).
+detail = load_eval_detail(owner_id, run_id)
+```
+
+**Primitives reused as-is (do not reinvent):**
+
+| Primitive | File:line | Role in the resolver |
+|---|---|---|
+| `get_current_user_id` / `_get_user_id` | `main.py:86`, `compare.py:25` | Caller identity from `X-Forwarded-User` **only** — never client body/query |
+| MCP force-injection of `user_id` | `mcp_client.py:351` | Model/client cannot spoof identity in the chat path |
+| `_is_within_dir(path, scope)` | `inspect_viewer.py:42` | Separator-anchored boundary — defeats traversal/substring/sibling-prefix |
+| `_normalize_key` | `inspect_viewer.py:23` | Strip scheme + collapse `..` before any comparison |
+| `safe_user_path` / `get_user_log_dir` | `user_storage.py:53` / `141` | Build owner-scoped path that cannot escape; never string-concat owner id |
+| `UserAccessPolicy.can_list` shape | `inspect_viewer.py:87` | The deny-by-default template the resolver mirrors |
+
+**The only genuinely new code is the grant store + lookup.** Boundary checks, identity resolution, spoof-prevention, and path construction already exist.
+
+---
+
+## 6. Read-path chokepoints
+
+Every endpoint that returns eval data must route through `can_read`. Inventory:
+
+| Route / surface | File:line | Class |
+|---|---|---|
+| `GET /api/compare/groups` | `compare.py:32` | **(a)** easy — list own + granted, tag each with `owner` |
+| `GET /api/compare/detail` | `compare.py:42` | **(a)** easy — resolve owner, `load_eval_detail(owner, run_id)` |
+| `GET /api/compare/report/*` | `compare.py:162,245` | **(a)** easy — same owner resolution |
+| `GET /api/compare/progress` | `compare.py:107` | **(a)** easy |
+| `GET /api/compare/sample` | `compare.py:69,84` | **(b) sensitive** — raw `log_file` path; reuse `_is_within_dir` against resolved owner |
+| Inspect viewer `/api/log*` | `inspect_viewer.py` policies | **(b) sensitive** — the PR #106 surface; not used by the SPA |
+| MCP `list_evaluations` / `get_evaluation_details` / `generate_report` | `eval_mcp/tools/*` | **(c) chat flow** — needs explicit non-injected target param |
+
+**v1 gates category (a) only** — that fully powers the visible Results UI (the SPA rides entirely on `/api/compare/*`; it never links to `/inspect/*` and does not call `/api/compare/sample`). Categories (b) and (c) are explicitly deferred and remain **blocked**, not silently bypassing the check (§8).
+
+---
+
+## 7. Security requirements (acceptance criteria)
+
+Aligned with OWASP Top 10 **A01 Broken Access Control (the #1 risk)** and its prevention bullets, plus this repo's own trust model.
+
+### 7.1 MUST-FIX before ship — in-cluster network isolation
+
+The `X-Forwarded-User` trust boundary is airtight at the **edge** (WAF → internal-only ALB → CloudFront path-split → oauth2-proxy strips client-supplied auth headers) but **has no in-cluster enforcement**:
+
+- Backend Service is `ClusterIP` on `:8080`, binds `0.0.0.0`, and **no NetworkPolicy isolates it** (`helm/eval/templates/service.yaml:13`; the only NetworkPolicy is `agent-pods-deny-internal` for sandbox pods, `infra/platform/sandbox-security.tf:195`).
+- **Consequence:** any in-cluster workload can `curl http://backend:8080/api/... -H "X-Forwarded-User: victim"` and impersonate any user. For a feature where this header decides who reads whose data, this is the dominant blast radius.
+
+**Required:**
+1. Add a `NetworkPolicy` (or `CiliumNetworkPolicy`) on `app: backend` allowing ingress on `8080` **only from oauth2-proxy pods** + the ALB node CIDR for the `/health` target group (`alb.tf:60`).
+2. Pin oauth2-proxy header behavior **explicitly** in `helm/eval/values-aws.yaml` (`skip_auth_strip_headers` / `pass_user_headers`) — today the inbound-strip is an implicit subchart default that a version bump could flip.
+3. Keep the `/health` handler strictly identity-free (it is the one direct-to-backend ALB path); add no other routes to that target group.
+
+### 7.2 Deny by default
+The resolver returns no-access unless an explicit owner-match or grant-match succeeds. Never "allow unless a deny rule matches." Unknown `eval_id`, unrecognized `role`, empty `caller_id` → deny.
+
+### 7.3 Identity from server, never client
+Caller identity comes only from `X-Forwarded-User` (`get_current_user_id`). Only `eval_id` may come from the client. The chat path preserves the force-injection invariant (`mcp_client.py:351`); any shared-eval-in-chat feature adds a **separate, explicitly-resolved target param** — it must not relax the injected `user_id`.
+
+### 7.4 Enforce record ownership via the registry
+Reads resolve through `eval_registry.owner_id`, not a client-supplied owner. Path is always rebuilt from the resolved `owner_id` via `get_user_log_dir` and re-validated with `_is_within_dir` — a grant can never read outside the grantor's subtree.
+
+### 7.5 Constrained roles & explicit share-all
+`role`/`principal_type` are `CHECK`-constrained enums (no free-text typos failing open). The `resource_id=NULL` "share all" grant auto-includes **future** evals — it MUST be surfaced explicitly in the UI ("Bob can see ALL your evals, including future ones"), be audit-logged, and be revocable.
+
+### 7.6 Audit logging (net-new pattern)
+No audit facility exists today; denials currently raise 403 silently. Establish the convention using the repo's `logging.getLogger(__name__)` + bracketed-tag f-string style:
+- `logger.info(f"[GRANT] {owner} granted {grantee} {role} on {resource}")` on create/revoke.
+- `logger.warning(f"[ACCESS] denied {caller} -> eval {eval_id}")` immediately before every 403.
+
+### 7.7 Isolation testing (mirror PR #106 rigor)
+- New `verify_grant_isolation.py` (root, mirroring `verify_tenant_isolation.py`): plant owner A's eval via `docker compose exec backend`; simulate a 2nd identity by hitting backend `:8080` directly with a per-request `X-Forwarded-User` (the nginx stub pins `local-user`). Assert B is **denied ungranted** and **allowed granted**, and that **revoke flips 200 → 403**.
+- Plus a stack-free pytest in `tests/` unit-testing the `can_read` decision helper — **CI runs no tests today** (`.github/workflows/publish.yml` only publishes), so the pytest layer is the only one with automated reach.
+
+---
+
+## 8. Future-proofing: RBAC now, ReBAC-compatible by design
+
+Per OWASP / OpenFGA / NIST guidance, relationship-based access (ReBAC: Google Zanzibar, OpenFGA, SpiceDB) is the recommended pattern once you need **deep inherited hierarchies** ("share a folder → all child evals inherit, recursively"). v1 deliberately does **not** need it — the model here is flat (owner → resource → principal).
+
+The grant row `(owner, resource_id, principal_type, principal_id, role)` is already **relationship-shaped** (a subject–relation–object tuple). This is intentional: if inheritance is needed later, the migration is *moving tuples into OpenFGA/SpiceDB*, not rewriting the model. We avoid the "role explosion" anti-pattern (a named role per sharing combination) by keeping grants per-resource. **Do not** adopt OpenFGA infrastructure for v1 — that would be over-engineering for flat sharing.
+
+---
+
+## 9. Rollout — each phase ships independently, none is a rewrite
+
+| Phase | Adds | New behavior |
+|---|---|---|
+| **0. Identity** | `eval_registry` + backfill (mirror the `/api/compare/rebuild` precompute pattern) | None — caller sees only own evals, now keyed by stable `eval_id` |
+| **1. Person-to-person** | `grants` + resolver + share modal (mirror Report button, `ResultsHeader.tsx:111`) + `owner` badge (`RunRail.tsx:206`) + email lookup | Share with a user |
+| **2. Teams** | `teams`, `team_members`, team-management UI | Grant to a team — **`grants` table unchanged**, only `principal_type` differs |
+| **3. Org** | built-in org principal | Org-wide toggle |
+| **4. (deferred, sensitive)** | extend Inspect viewer + `/api/compare/sample` + MCP chat via the same resolver | Shared evals in the raw viewer + chat |
+
+**Phase 0 is the real cost** — minting `eval_id`s, the registry, backfilling existing evals, and migrating the API/frontend from `group_id` to `eval_id` (touches `eval_results.py`, `user_storage.py`, `compare.py`, `RunRail.tsx`, `ComparisonView.tsx`). It is the production-correct foundation; everything after is additive.
+
+**Frontend gap:** no user-discovery endpoint exists today and `users` doesn't store email. Phase 1 needs either a free-text recipient field or (better) storing `X-Forwarded-Email` on login (`create_user` is already called lazily) + a lookup endpoint feeding a picker.
+
+---
+
+## 10. Open questions
+
+1. **Recipient picker** — free-text user id (ships fastest) vs. email-based lookup (friendlier, needs `users.email` + endpoint) vs. full autocomplete directory.
+2. **`eval_id` minting** — UUID generated at eval-completion time and written into the registry by the same hook that triggers precompute (`run_eval.py:546`), vs. backfilled lazily on first read.
+3. **Backfill strategy** — eager one-shot migration job vs. lazy registry-population on first `groups` read.
+4. Whether phase 4 (Inspect viewer / chat sharing) is ever needed, given the SPA Results UI rides entirely on `/api/compare/*`.
+
+---
+
+## References
+
+- PR #106 — tenant-isolation fix; primitives in `backend/core/inspect_viewer.py`, test in `verify_tenant_isolation.py`.
+- OWASP Top 10 2021 **A01 Broken Access Control** — deny by default, implement once & reuse, enforce record ownership, log failures.
+- OWASP Authorization Cheat Sheet — server-side/centralized enforcement; prefers ABAC/ReBAC; least privilege.
+- NIST RBAC FAQ / SP 800-162 (ABAC) — RBAC suits role/SoD; relationship-based access needs constraints beyond core RBAC.
+- Google Zanzibar paper / OpenFGA / SpiceDB — ReBAC for hierarchical, inherited, multi-tenant sharing.

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -903,6 +903,7 @@ async def list_evaluations(
     limit: LimitParam = 20,
     offset: OffsetParam = 0,
     response_format: ResponseFormat = "json",
+    shared_scopes: list = None,
 ) -> str:
     """
     List completed evaluations.
@@ -927,6 +928,7 @@ async def list_evaluations(
         "limit": limit,
         "offset": offset,
         "response_format": response_format,
+        "shared_scopes": shared_scopes or [],
     }
     result = await handle_list_evaluations(args)
     return result[0].text
@@ -936,6 +938,7 @@ async def list_evaluations(
 async def get_evaluation_details(
     evalId: EvalId,
     user_id: str = None,
+    shared_scopes: list = None,
 ) -> str:
     """
     Get detailed results for a specific evaluation.
@@ -949,7 +952,11 @@ async def get_evaluation_details(
         JSON with detailed evaluation results
     """
     _auto_pull(user_id)
-    args = {"evalId": evalId, "user_id": _user(user_id)}
+    args = {
+        "evalId": evalId,
+        "user_id": _user(user_id),
+        "shared_scopes": shared_scopes or [],
+    }
     result = await handle_get_evaluation_details(args)
     return result[0].text
 
@@ -1454,6 +1461,7 @@ async def generate_report(
     context: str = None,
     monthly_volume: MonthlyVolume = 10000,
     user_id: str = None,
+    shared_scopes: list = None,
 ) -> str:
     """
     Generate a PDF report for a completed evaluation.
@@ -1480,6 +1488,7 @@ async def generate_report(
         "group_id": group_id,
         "context": context,
         "monthly_volume": monthly_volume,
+        "shared_scopes": shared_scopes or [],
     }
     result = await handle_generate_report(args)
     return result[0].text

--- a/eval_mcp/tools/generate_report.py
+++ b/eval_mcp/tools/generate_report.py
@@ -47,6 +47,18 @@ async def handle_generate_report(args: Dict[str, Any]) -> List[TextContent]:
         if not detail:
             await precompute_eval_results(user_id)
             detail = load_eval_detail(user_id, group_id)
+        # Not the caller's own eval — try owners who shared this group. The
+        # report PDF is still written to the CALLER's own dir below (their
+        # artifact); we only read the shared owner's detail data.
+        if not detail:
+            shared_scopes = args.get("shared_scopes") or []
+            for s in shared_scopes:
+                owner = s.get("ownerId")
+                gid = s.get("groupId")
+                if owner and owner != user_id and (gid is None or gid == group_id):
+                    detail = load_eval_detail(owner, group_id)
+                    if detail:
+                        break
         if not detail:
             return [TextContent(type="text", text=json.dumps({
                 "success": False,

--- a/eval_mcp/tools/get_evaluation_details.py
+++ b/eval_mcp/tools/get_evaluation_details.py
@@ -33,30 +33,40 @@ async def handle_get_evaluation_details(args: Dict[str, Any]) -> List[TextConten
                 )
             ]
 
-        log_dir = get_user_log_dir(user_id)
-        eval_log_infos = await list_eval_logs_async(log_dir)
+        # Search the caller's own dir first, then any owner who shared with
+        # them. shared_scopes is injected by the backend from grants (never the
+        # model): {ownerId, groupId}, groupId=None = all of that owner's evals.
+        # Restricting the foreign search to scopes that match eval_id (or are
+        # share-all) is what enforces per-group grants here.
+        shared_scopes = args.get("shared_scopes") or []
+        search_owners = [user_id]
+        for s in shared_scopes:
+            owner = s.get("ownerId")
+            gid = s.get("groupId")
+            if owner and owner != user_id and (gid is None or gid == eval_id):
+                if owner not in search_owners:
+                    search_owners.append(owner)
 
-        if not eval_log_infos:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"success": False, "error": "No evaluations found."}),
-                )
-            ]
-
-        # Find the matching log file by filename or run_id
+        # Find the matching log file by filename or run_id, across owners.
         target_log = None
-        for info in eval_log_infos:
-            if eval_id in info.name:
-                target_log = info.name
-                break
+        for owner in search_owners:
             try:
-                log = await read_eval_log_async(info.name, header_only=True)
-                if log.eval.run_id == eval_id:
-                    target_log = info.name
-                    break
+                owner_infos = await list_eval_logs_async(get_user_log_dir(owner))
             except Exception:
                 continue
+            for info in owner_infos:
+                if eval_id in info.name:
+                    target_log = info.name
+                    break
+                try:
+                    log = await read_eval_log_async(info.name, header_only=True)
+                    if log.eval.run_id == eval_id:
+                        target_log = info.name
+                        break
+                except Exception:
+                    continue
+            if target_log:
+                break
 
         if not target_log:
             return [

--- a/eval_mcp/tools/list_evaluations.py
+++ b/eval_mcp/tools/list_evaluations.py
@@ -38,6 +38,35 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
         log_dir = get_user_log_dir(user_id)
         eval_log_infos = await list_eval_logs_async(log_dir)
 
+        # Append evals shared with this caller. shared_scopes is injected by the
+        # backend from grants (never the model): a list of {ownerId, groupId},
+        # groupId=None meaning all of that owner's evals. We tag each shared
+        # info with the owner so detail/report lookups can scope correctly.
+        shared_scopes = args.get("shared_scopes") or []
+        owner_of_info: Dict[str, str] = {}
+        if shared_scopes:
+            by_owner: Dict[str, set] = {}
+            for s in shared_scopes:
+                by_owner.setdefault(s.get("ownerId"), set()).add(s.get("groupId"))
+            for owner, gids in by_owner.items():
+                if not owner or owner == user_id:
+                    continue
+                try:
+                    owner_infos = await list_eval_logs_async(get_user_log_dir(owner))
+                except Exception:
+                    continue
+                allow_all = None in gids
+                for oi in owner_infos:
+                    try:
+                        if not allow_all:
+                            olog = await read_eval_log_async(oi.name, header_only=True)
+                            if olog.eval.run_id not in gids:
+                                continue
+                        eval_log_infos.append(oi)
+                        owner_of_info[oi.name] = owner
+                    except Exception:
+                        continue
+
         if not eval_log_infos:
             empty_text = (
                 json.dumps({
@@ -64,13 +93,14 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
         # deserialize once (same summary UI/PDF consume).
         detail_cache: Dict[str, Dict[str, Any] | None] = {}
 
-        def _detail_for(run_id: str) -> Dict[str, Any] | None:
-            if run_id not in detail_cache:
+        def _detail_for(run_id: str, owner: str) -> Dict[str, Any] | None:
+            cache_key = f"{owner}:{run_id}"
+            if cache_key not in detail_cache:
                 try:
-                    detail_cache[run_id] = load_eval_detail(user_id, run_id)
+                    detail_cache[cache_key] = load_eval_detail(owner, run_id)
                 except Exception:
-                    detail_cache[run_id] = None
-            return detail_cache[run_id]
+                    detail_cache[cache_key] = None
+            return detail_cache[cache_key]
 
         evaluations = []
         for info in page_infos:
@@ -79,7 +109,8 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
 
                 run_id = log.eval.run_id
                 model_id = log.eval.model
-                detail = _detail_for(run_id)
+                owner = owner_of_info.get(info.name, user_id)
+                detail = _detail_for(run_id, owner)
                 # Score-only runs log model="none/none"; the detail builder
                 # relabels to "pre-generated" — surface the same label here
                 # so the list view doesn't say one thing and the detail view
@@ -113,6 +144,10 @@ async def handle_list_evaluations(args: Dict[str, Any]) -> List[TextContent]:
                     "status": log.status,
                     "logFile": info.name,
                 }
+                # Mark shared (non-own) evals so the chat agent can attribute them.
+                if owner != user_id:
+                    eval_data["owner"] = owner
+                    eval_data["shared"] = True
 
                 if log.stats and log.stats.model_usage:
                     total_tokens = {}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -15,6 +15,7 @@ const NAV: NavItem[] = [
   { href: "/results", label: "Results" },
   { href: "/data", label: "Data" },
   { href: "/optimizations", label: "Optimized" },
+  { href: "/teams", label: "Teams", fullOnly: true },
 ];
 
 export default function Header() {

--- a/frontend/src/components/results/ComparisonView.tsx
+++ b/frontend/src/components/results/ComparisonView.tsx
@@ -82,14 +82,22 @@ interface SelectedCell {
   model: string;
 }
 
-export default function ComparisonView({ groupId }: { groupId: string }) {
+export default function ComparisonView({
+  groupId,
+  owner,
+}: {
+  groupId: string;
+  owner?: string | null;
+}) {
   const [data, setData] = useState<ComparisonData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedCell, setSelectedCell] = useState<SelectedCell | null>(null);
 
   useEffect(() => {
-    fetch(`/api/compare/detail?group_id=${encodeURIComponent(groupId)}`)
+    const qs = new URLSearchParams({ group_id: groupId });
+    if (owner) qs.set("owner", owner);
+    fetch(`/api/compare/detail?${qs.toString()}`)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to load: ${res.status}`);
         return res.json();
@@ -102,7 +110,7 @@ export default function ComparisonView({ groupId }: { groupId: string }) {
         setError(err.message);
         setLoading(false);
       });
-  }, [groupId]);
+  }, [groupId, owner]);
 
   if (loading) {
     return (

--- a/frontend/src/components/results/ResultsHeader.tsx
+++ b/frontend/src/components/results/ResultsHeader.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocation, useNavigate } from "react-router-dom";
+import ShareModal from "./ShareModal";
 
 interface ResultsHeaderProps {
   groupId: string | null;
+  // Owner of the selected eval. Absent/self = caller's own eval. A shared
+  // eval (owner != caller) can't be re-shared and the report read must carry
+  // the owner hint for the backend resolver.
+  owner?: string | null;
   sessionId?: string | null;
 }
 
@@ -19,19 +24,28 @@ const NAV: NavItem[] = [
   { href: "/results", label: "Results" },
   { href: "/data", label: "Data" },
   { href: "/optimizations", label: "Optimized" },
+  { href: "/teams", label: "Teams", fullOnly: true },
 ];
 
-export default function ResultsHeader({ groupId }: ResultsHeaderProps) {
+export default function ResultsHeader({ groupId, owner }: ResultsHeaderProps) {
   const { user, logoutUrl, mode } = useAuth();
   const navigate = useNavigate();
   const pathname = useLocation().pathname;
   const visibleNav = NAV.filter((item) => !(mode === "viewer" && item.fullOnly));
   const [downloading, setDownloading] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  // A shared eval (owner present and not the caller) is not the caller's to
+  // re-share. Only own evals get the Share affordance.
+  const isOwn = !owner || owner === user?.id;
 
   const handleDownloadReport = async () => {
     if (!groupId) return;
     setDownloading(true);
     try {
+      // This serves the caller's OWN previously-generated PDF. For a shared
+      // eval the viewer won't have one yet (report generation for shared evals
+      // is a later phase), so this 404s and prompts them to generate one.
       const response = await fetch(
         `/api/compare/report/${encodeURIComponent(groupId)}`,
       );
@@ -108,6 +122,14 @@ export default function ResultsHeader({ groupId }: ResultsHeaderProps) {
         </nav>
 
         <div className="flex items-center gap-3">
+          {groupId && isOwn && (
+            <button
+              onClick={() => setShareOpen(true)}
+              className="eyebrow inline-flex items-center gap-2 border border-rule px-3 py-1.5 transition-colors hover:border-bone-mute hover:text-bone-dim"
+            >
+              <span className="font-mono">⤷</span> Share
+            </button>
+          )}
           {groupId && (
             <button
               onClick={handleDownloadReport}
@@ -144,6 +166,9 @@ export default function ResultsHeader({ groupId }: ResultsHeaderProps) {
           )}
         </div>
       </div>
+      {shareOpen && groupId && (
+        <ShareModal groupId={groupId} onClose={() => setShareOpen(false)} />
+      )}
     </header>
   );
 }

--- a/frontend/src/components/results/RunRail.tsx
+++ b/frontend/src/components/results/RunRail.tsx
@@ -9,11 +9,17 @@ interface EvalGroup {
   sampleCount: number;
   status: string;
   scores: Record<string, Record<string, number>>;
+  // Present on every row from /api/compare/groups. `owner` is the eval's
+  // owner id; `shared` is true when it was shared with the caller (not their
+  // own). The owner hint must travel back on /detail and /report so the
+  // backend resolver can authorize the cross-user read.
+  owner?: string;
+  shared?: boolean;
 }
 
 interface Props {
   selectedId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, owner?: string) => void;
 }
 
 function relativeTime(iso: string): string {
@@ -168,9 +174,9 @@ export default function RunRail({ selectedId, onSelect }: Props) {
               const uniqueModels = [...new Set(group.models)];
               const title = group.configName || group.task || "Untitled run";
               return (
-                <li key={group.id}>
+                <li key={`${group.owner ?? ""}:${group.id}`}>
                   <button
-                    onClick={() => onSelect(group.id)}
+                    onClick={() => onSelect(group.id, group.owner)}
                     className={`group flex w-full flex-col gap-2 border-b border-rule-soft border-l-2 px-4 py-3.5 text-left transition-colors ${
                       active
                         ? "border-l-ember bg-ink-raised"
@@ -193,6 +199,14 @@ export default function RunRail({ selectedId, onSelect }: Props) {
                       >
                         {title}
                       </span>
+                      {group.shared && (
+                        <span
+                          title={`Shared by ${group.owner}`}
+                          className="shrink-0 rounded-sm border border-rule px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-eyebrow text-bone-mute"
+                        >
+                          shared
+                        </span>
+                      )}
                       {typeof best === "number" && (
                         <span
                           className="font-sans text-lg tabular-nums"

--- a/frontend/src/components/results/ShareModal.tsx
+++ b/frontend/src/components/results/ShareModal.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from "react";
+
+interface Share {
+  id: string;
+  groupId: string | null;
+  principalType: string;
+  principalId: string | null;
+  role: string;
+  createdAt: string;
+}
+
+interface Props {
+  groupId: string;
+  onClose: () => void;
+}
+
+/**
+ * Share dialog for an eval the caller OWNS. Lets them grant another user (by
+ * id), a team, or the whole org read access — either this one eval or all of
+ * their evals. Mirrors the backend /api/compare/shares endpoints. Read-only
+ * (viewer) is the only role in v1.
+ */
+export default function ShareModal({ groupId, onClose }: Props) {
+  const [shares, setShares] = useState<Share[]>([]);
+  const [principalType, setPrincipalType] = useState("user");
+  const [principalId, setPrincipalId] = useState("");
+  const [shareAll, setShareAll] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<{ id: string; email: string | null }[]>([]);
+
+  const loadShares = () => {
+    fetch("/api/compare/shares")
+      .then((r) => (r.ok ? r.json() : { shares: [] }))
+      .then((d) => setShares(d.shares || []))
+      .catch(() => setShares([]));
+  };
+
+  useEffect(loadShares, []);
+
+  // Email/id autocomplete for the "user" principal. Debounced; grants still
+  // key on the resolved id, email is only the lookup.
+  useEffect(() => {
+    if (principalType !== "user" || principalId.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    const t = setTimeout(() => {
+      fetch(`/api/compare/users/search?q=${encodeURIComponent(principalId.trim())}`)
+        .then((r) => (r.ok ? r.json() : { users: [] }))
+        .then((d) => setSuggestions(d.users || []))
+        .catch(() => setSuggestions([]));
+    }, 250);
+    return () => clearTimeout(t);
+  }, [principalId, principalType]);
+
+  const submit = async () => {
+    setError(null);
+    if (principalType !== "org" && !principalId.trim()) {
+      setError("Enter a user or team id.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/compare/shares", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          principal_type: principalType,
+          principal_id: principalType === "org" ? null : principalId.trim(),
+          group_id: shareAll ? null : groupId,
+          role: "viewer",
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail || `Failed: ${res.status}`);
+      }
+      setPrincipalId("");
+      loadShares();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to share");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revoke = async (id: string) => {
+    await fetch(`/api/compare/shares/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+    loadShares();
+  };
+
+  const describe = (s: Share) => {
+    const who =
+      s.principalType === "org"
+        ? "Everyone (org)"
+        : `${s.principalType}: ${s.principalId}`;
+    const what = s.groupId ? "this eval" : "ALL my evals";
+    return `${who} · ${what}`;
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/80 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg border border-rule bg-ink-elev p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-baseline justify-between">
+          <p className="eyebrow">Share evaluation</p>
+          <button
+            onClick={onClose}
+            className="font-mono text-bone-mute hover:text-bone"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-5 flex flex-col gap-3">
+          <div className="flex gap-2">
+            <select
+              value={principalType}
+              onChange={(e) => setPrincipalType(e.target.value)}
+              className="border border-rule bg-transparent px-2 py-1.5 font-mono text-[12px] text-bone focus:outline-none"
+            >
+              <option value="user">User</option>
+              <option value="team">Team</option>
+              <option value="org">Everyone</option>
+            </select>
+            {principalType !== "org" && (
+              <div className="relative flex-1">
+                <input
+                  value={principalId}
+                  onChange={(e) => setPrincipalId(e.target.value)}
+                  placeholder={
+                    principalType === "user" ? "user id or email" : "team id"
+                  }
+                  className="w-full border border-rule bg-transparent px-2 py-1.5 font-mono text-[12px] text-bone placeholder:text-bone-mute focus:border-bone-mute focus:outline-none"
+                />
+                {suggestions.length > 0 && (
+                  <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-y-auto border border-rule bg-ink-elev">
+                    {suggestions.map((u) => (
+                      <li key={u.id}>
+                        <button
+                          onClick={() => {
+                            setPrincipalId(u.id);
+                            setSuggestions([]);
+                          }}
+                          className="block w-full px-2 py-1.5 text-left font-mono text-[11px] text-bone-dim hover:bg-ink-raised"
+                        >
+                          {u.email ? `${u.email} · ${u.id}` : u.id}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+            <button
+              onClick={submit}
+              disabled={busy}
+              className="eyebrow border border-rule px-3 py-1.5 hover:border-bone-mute hover:text-bone-dim disabled:opacity-50"
+            >
+              Share
+            </button>
+          </div>
+
+          <label className="flex items-center gap-2 font-mono text-[11px] text-bone-dim">
+            <input
+              type="checkbox"
+              checked={shareAll}
+              onChange={(e) => setShareAll(e.target.checked)}
+            />
+            Share ALL my evals (including future ones), not just this one
+          </label>
+
+          {principalType === "org" && (
+            <p className="font-mono text-[11px] text-ember">
+              ⚠ This makes {shareAll ? "ALL your evals" : "this eval"} readable
+              by EVERYONE in the organization.
+            </p>
+          )}
+
+          {error && (
+            <p className="font-mono text-[11px] text-oxide">{error}</p>
+          )}
+        </div>
+
+        <div className="mt-6">
+          <p className="eyebrow mb-2">Current shares</p>
+          {shares.length === 0 ? (
+            <p className="font-mono text-[11px] text-bone-mute">
+              Not shared with anyone yet.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {shares.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex items-center justify-between border-b border-rule-soft py-1.5 font-mono text-[11px] text-bone-dim"
+                >
+                  <span>{describe(s)}</span>
+                  <button
+                    onClick={() => revoke(s.id)}
+                    className="text-bone-mute hover:text-oxide"
+                  >
+                    revoke
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -13,9 +13,16 @@ export default function ResultsPage() {
   // manual history.pushState/popstate plumbing that used to live here.)
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedId = searchParams.get("group");
+  // owner travels in the URL so deep links / refreshes keep the cross-user
+  // read authorized. Absent (or self) means the caller's own eval.
+  const selectedOwner = searchParams.get("owner");
 
-  const handleSelect = (id: string | null) => {
-    setSearchParams(id ? { group: id } : {});
+  const handleSelect = (id: string | null, owner?: string) => {
+    if (!id) {
+      setSearchParams({});
+      return;
+    }
+    setSearchParams(owner ? { group: id, owner } : { group: id });
   };
 
   useEffect(() => {
@@ -41,14 +48,14 @@ export default function ResultsPage() {
 
   return (
     <div className="flex h-screen flex-col bg-ink">
-      <ResultsHeader groupId={selectedId} />
+      <ResultsHeader groupId={selectedId} owner={selectedOwner} />
 
       <div className="flex flex-1 overflow-hidden">
         <RunRail selectedId={selectedId} onSelect={handleSelect} />
 
         <div className="flex-1 overflow-hidden">
           {selectedId ? (
-            <ComparisonView groupId={selectedId} />
+            <ComparisonView groupId={selectedId} owner={selectedOwner} />
           ) : (
             <div className="flex h-full items-center justify-center px-8">
               <div className="max-w-md text-center">

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react";
+import { useAuth, login } from "@/contexts/AuthContext";
+import Header from "@/components/Header";
+
+interface Team {
+  id: string;
+  name: string;
+  createdBy: string;
+  role: string;
+}
+
+interface Member {
+  userId: string;
+  role: string;
+  email: string | null;
+}
+
+/**
+ * Team management. A team is a sharing principal: create one, add members,
+ * and use its id in the Share dialog to grant the whole team access to an
+ * eval. Membership is what makes a team grant resolve for a given user.
+ */
+export default function TeamsPage() {
+  const { user, isLoading } = useAuth();
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [selected, setSelected] = useState<Team | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [newTeamName, setNewTeamName] = useState("");
+  const [newMember, setNewMember] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const loadTeams = () => {
+    fetch("/api/teams")
+      .then((r) => (r.ok ? r.json() : { teams: [] }))
+      .then((d) => setTeams(d.teams || []))
+      .catch(() => setTeams([]));
+  };
+
+  const loadMembers = (teamId: string) => {
+    fetch(`/api/teams/${encodeURIComponent(teamId)}/members`)
+      .then((r) => (r.ok ? r.json() : { members: [] }))
+      .then((d) => setMembers(d.members || []))
+      .catch(() => setMembers([]));
+  };
+
+  useEffect(() => {
+    if (!isLoading && !user) login();
+  }, [isLoading, user]);
+
+  useEffect(loadTeams, []);
+  useEffect(() => {
+    if (selected) loadMembers(selected.id);
+  }, [selected]);
+
+  const createTeam = async () => {
+    setError(null);
+    if (!newTeamName.trim()) return;
+    const res = await fetch("/api/teams", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newTeamName.trim() }),
+    });
+    if (res.ok) {
+      setNewTeamName("");
+      loadTeams();
+    } else {
+      setError(`Failed to create team (${res.status})`);
+    }
+  };
+
+  const addMember = async () => {
+    if (!selected || !newMember.trim()) return;
+    setError(null);
+    const res = await fetch(
+      `/api/teams/${encodeURIComponent(selected.id)}/members`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_id: newMember.trim(), role: "member" }),
+      },
+    );
+    if (res.ok) {
+      setNewMember("");
+      loadMembers(selected.id);
+    } else {
+      const b = await res.json().catch(() => ({}));
+      setError(b.detail || `Failed to add member (${res.status})`);
+    }
+  };
+
+  const removeMember = async (memberId: string) => {
+    if (!selected) return;
+    await fetch(
+      `/api/teams/${encodeURIComponent(selected.id)}/members/${encodeURIComponent(memberId)}`,
+      { method: "DELETE" },
+    );
+    loadMembers(selected.id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-ink">
+        <span className="eyebrow">
+          Identifying
+          <span className="cursor-block ml-2 align-baseline" />
+        </span>
+      </div>
+    );
+  }
+  if (!user) return null;
+
+  const isAdmin = selected?.role === "admin";
+
+  return (
+    <div className="flex h-screen flex-col bg-ink">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        {/* Team list + create */}
+        <aside className="flex w-96 flex-col border-r border-rule bg-ink-elev">
+          <div className="border-b border-rule-soft px-5 py-4">
+            <p className="eyebrow">Teams</p>
+          </div>
+          <div className="border-b border-rule-soft px-5 py-3">
+            <div className="flex gap-2">
+              <input
+                value={newTeamName}
+                onChange={(e) => setNewTeamName(e.target.value)}
+                placeholder="New team name…"
+                className="flex-1 border-b border-rule bg-transparent py-1.5 font-mono text-[12px] text-bone placeholder:text-bone-mute focus:border-bone-mute focus:outline-none"
+              />
+              <button
+                onClick={createTeam}
+                className="eyebrow border border-rule px-3 py-1 hover:border-bone-mute hover:text-bone-dim"
+              >
+                Create
+              </button>
+            </div>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {teams.length === 0 ? (
+              <p className="px-5 py-6 text-sm italic text-bone-mute">
+                No teams yet. Create one to share evals with a group.
+              </p>
+            ) : (
+              <ul>
+                {teams.map((t) => (
+                  <li key={t.id}>
+                    <button
+                      onClick={() => setSelected(t)}
+                      className={`flex w-full flex-col gap-1 border-b border-rule-soft border-l-2 px-4 py-3 text-left transition-colors ${
+                        selected?.id === t.id
+                          ? "border-l-ember bg-ink-raised"
+                          : "border-l-transparent hover:border-l-rule hover:bg-ink-raised/40"
+                      }`}
+                    >
+                      <span className="text-[14px] text-bone-dim">{t.name}</span>
+                      <span className="font-mono text-[10px] uppercase tracking-eyebrow text-bone-mute">
+                        {t.role} · id {t.id}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </aside>
+
+        {/* Member panel */}
+        <div className="flex-1 overflow-y-auto px-8 py-6">
+          {!selected ? (
+            <div className="flex h-full items-center justify-center">
+              <div className="max-w-md text-center">
+                <p className="eyebrow">No team selected</p>
+                <h3 className="font-display mt-3 text-4xl leading-tight text-bone">
+                  <em className="text-ember">Pick</em> a team to manage members.
+                </h3>
+                <p className="mt-4 text-sm text-bone-dim">
+                  Share an eval with a team's id and every member can read it.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="max-w-2xl">
+              <p className="eyebrow">{selected.name}</p>
+              <p className="mt-1 font-mono text-[11px] text-bone-mute">
+                Team id <span className="text-bone-dim">{selected.id}</span> —
+                use this in the Share dialog.
+              </p>
+
+              {isAdmin && (
+                <div className="mt-5 flex gap-2">
+                  <input
+                    value={newMember}
+                    onChange={(e) => setNewMember(e.target.value)}
+                    placeholder="member user id (email)"
+                    className="flex-1 border border-rule bg-transparent px-2 py-1.5 font-mono text-[12px] text-bone placeholder:text-bone-mute focus:border-bone-mute focus:outline-none"
+                  />
+                  <button
+                    onClick={addMember}
+                    className="eyebrow border border-rule px-3 py-1.5 hover:border-bone-mute hover:text-bone-dim"
+                  >
+                    Add
+                  </button>
+                </div>
+              )}
+              {error && (
+                <p className="mt-2 font-mono text-[11px] text-oxide">{error}</p>
+              )}
+
+              <div className="mt-6">
+                <p className="eyebrow mb-2">Members</p>
+                <ul className="flex flex-col gap-1">
+                  {members.map((m) => (
+                    <li
+                      key={m.userId}
+                      className="flex items-center justify-between border-b border-rule-soft py-1.5 font-mono text-[11px] text-bone-dim"
+                    >
+                      <span>
+                        {m.email || m.userId}
+                        <span className="ml-2 text-bone-mute">{m.role}</span>
+                      </span>
+                      {(isAdmin || m.userId === user.id) && (
+                        <button
+                          onClick={() => removeMember(m.userId)}
+                          className="text-bone-mute hover:text-oxide"
+                        >
+                          {m.userId === user.id ? "leave" : "remove"}
+                        </button>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import History from "@/pages/History";
 import Results from "@/pages/Results";
 import Data from "@/pages/Data";
 import Optimizations from "@/pages/Optimizations";
+import Teams from "@/pages/Teams";
 
 // Flat routes — the app has no nested layouts. Query params (?session, ?group,
 // ?id) are read inside each page via react-router's useSearchParams, which
@@ -19,6 +20,7 @@ export function AppRoutes() {
       <Route path="/results" element={<Results />} />
       <Route path="/data" element={<Data />} />
       <Route path="/optimizations" element={<Optimizations />} />
+      <Route path="/teams" element={<Teams />} />
     </Routes>
   );
 }

--- a/helm/eval/templates/networkpolicy.yaml
+++ b/helm/eval/templates/networkpolicy.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.backend.networkPolicy.enabled }}
+# Backend ingress isolation (MUST-FIX for eval sharing — see
+# docs/EVAL_SHARING_DESIGN.md §7.1).
+#
+# The backend trusts the X-Forwarded-User header for identity. That is only
+# safe if the backend is unreachable EXCEPT through oauth2-proxy, which strips
+# any client-supplied copy of the header. Without this policy, ANY pod in the
+# cluster can `curl http://backend:8080/api/... -H "X-Forwarded-User: victim"`
+# and impersonate any user — the entire sharing authz model is forgeable.
+#
+# This policy denies all ingress to backend pods on :8080 except from:
+#   1. the oauth2-proxy pods (the authenticated edge), and
+#   2. the ALB/VPC CIDRs (for the /health target group, which the ALB hits
+#      directly — that handler is identity-free; see infra/platform/alb.tf).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: backend
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    # (1) oauth2-proxy — the authenticated path for all /api and /inspect
+    # traffic. Matched by the subchart's standard label in this namespace.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: oauth2-proxy
+      ports:
+        - protocol: TCP
+          port: 8080
+    # (2) ALB direct path for /health (and any in-VPC source). Restricted to
+    # the VPC/node CIDRs so it is not internet-reachable. The /health handler
+    # ignores the identity header, so this is not an impersonation surface.
+    {{- if .Values.backend.networkPolicy.allowedHealthCheckCIDRs }}
+    - from:
+        {{- range .Values.backend.networkPolicy.allowedHealthCheckCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+{{- end }}

--- a/helm/eval/values-aws.yaml
+++ b/helm/eval/values-aws.yaml
@@ -30,6 +30,14 @@ backend:
     maxReplicas: 6
     targetCPUUtilization: 70
     targetMemoryUtilization: 80
+  # MUST-FIX (docs/EVAL_SHARING_DESIGN.md §7.1): isolate :8080 to oauth2-proxy.
+  # Without this, any in-cluster pod can forge X-Forwarded-User. The /health
+  # ALB target group hits the pod directly from node IPs in the VPC, so allow
+  # the VPC CIDR for that identity-free path only.
+  networkPolicy:
+    enabled: true
+    allowedHealthCheckCIDRs:
+      - "10.0.0.0/16"
 
 # oauth2-proxy subchart - handles all authentication at the edge
 oauth2-proxy:
@@ -61,6 +69,15 @@ oauth2-proxy:
       set_xauthrequest = true
       pass_access_token = false
       pass_authorization_header = false
+      # Identity trust boundary (docs/EVAL_SHARING_DESIGN.md §7.1): pin the
+      # header behavior explicitly rather than relying on subchart defaults.
+      # skip_auth_strip_headers=true makes oauth2-proxy STRIP any inbound
+      # client-supplied X-Auth-Request-*/X-Forwarded-User before proxying, then
+      # set them from the validated session — so a client cannot inject its own
+      # identity. pass_user_headers stays false (we use set_xauthrequest's
+      # X-Auth-Request-User, surfaced upstream as X-Forwarded-User by the ALB).
+      skip_auth_strip_headers = true
+      pass_user_headers = false
       silence_ping_logging = true
       reverse_proxy = true
       upstream_timeout = "120s"

--- a/helm/eval/values.yaml
+++ b/helm/eval/values.yaml
@@ -35,6 +35,13 @@ backend:
     maxReplicas: 10
     targetCPUUtilization: 70
     targetMemoryUtilization: 80
+  # Ingress isolation. Off by default (local/dev has no oauth2-proxy pod);
+  # enabled in values-aws.yaml. See docs/EVAL_SHARING_DESIGN.md §7.1.
+  networkPolicy:
+    enabled: false
+    # CIDRs allowed to reach :8080 directly for the ALB /health target group.
+    # Set to the VPC/node CIDRs in the AWS overlay.
+    allowedHealthCheckCIDRs: []
 
 # MCP Sidecar Resources
 mcp:

--- a/tests/test_inspect_viewer_sharing.py
+++ b/tests/test_inspect_viewer_sharing.py
@@ -1,0 +1,132 @@
+"""Unit tests for grant-aware Inspect viewer policies (the PR #106 surface).
+
+Stack-free: a fake Request carries X-Forwarded-User, and _has_grant is
+monkeypatched so we test the policy LOGIC (own-scope, grant-scope, read-only,
+map pass-through) without a DB. The boundary primitives (_normalize_key /
+_is_within_dir) run for real, so traversal/sibling-prefix defenses are exercised.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.inspect_viewer as iv
+
+ROOT = "/data/users"
+
+
+class FakeRequest:
+    def __init__(self, user):
+        self.headers = {"X-Forwarded-User": user} if user else {}
+
+
+def _patch_grants(monkeypatch, allowed):
+    """allowed: set of (caller, owner, group_id) tuples that should pass."""
+    async def fake_has_grant(caller, owner, group_id):
+        return (caller, owner, group_id) in allowed or (caller, owner, None) in allowed
+    monkeypatch.setattr(iv, "_has_grant", fake_has_grant)
+    # run_id resolution is I/O; pin it deterministically.
+    async def fake_run_id(file):
+        return "g1" if "g1" in file else None
+    monkeypatch.setattr(iv, "_run_id_of", fake_run_id)
+
+
+# --------------------------------------------------------------------------
+# can_read
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_can_read_own_subtree(monkeypatch):
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserAccessPolicy(ROOT)
+    assert await pol.can_read(FakeRequest("alice"), f"{ROOT}/alice/logs/g1.eval") is True
+
+
+@pytest.mark.asyncio
+async def test_can_read_foreign_denied_without_grant(monkeypatch):
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserAccessPolicy(ROOT)
+    assert await pol.can_read(FakeRequest("bob"), f"{ROOT}/alice/logs/g1.eval") is False
+
+
+@pytest.mark.asyncio
+async def test_can_read_foreign_allowed_with_grant(monkeypatch):
+    _patch_grants(monkeypatch, {("bob", "alice", "g1")})
+    pol = iv.UserAccessPolicy(ROOT)
+    assert await pol.can_read(FakeRequest("bob"), f"{ROOT}/alice/logs/g1.eval") is True
+
+
+@pytest.mark.asyncio
+async def test_can_read_traversal_resolves_to_real_owner(monkeypatch):
+    # A path that traverses into alice must be grant-checked against ALICE,
+    # not whatever prefix it started with. With no grant on alice → denied.
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserAccessPolicy(ROOT)
+    sneaky = f"{ROOT}/bob/logs/../../alice/logs/g1.eval"
+    assert await pol.can_read(FakeRequest("bob"), sneaky) is False
+
+
+# --------------------------------------------------------------------------
+# Read-only: delete/write stay self-only even WITH a read grant
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_can_delete_self_only_despite_grant(monkeypatch):
+    _patch_grants(monkeypatch, {("bob", "alice", "g1")})  # bob may READ alice
+    pol = iv.UserAccessPolicy(ROOT)
+    f = f"{ROOT}/alice/logs/g1.eval"
+    assert await pol.can_read(FakeRequest("bob"), f) is True       # read: yes
+    assert await pol.can_delete(FakeRequest("bob"), f) is False    # delete: no
+    assert await pol.can_write(FakeRequest("bob"), f) is False     # write: no
+
+
+# --------------------------------------------------------------------------
+# can_list
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_can_list_root_allowed(monkeypatch):
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserAccessPolicy(ROOT)
+    assert await pol.can_list(FakeRequest("alice"), ROOT) is True
+
+
+@pytest.mark.asyncio
+async def test_can_list_foreign_needs_owner_level_grant(monkeypatch):
+    # A per-group grant does NOT open the whole dir (listing has no run_id);
+    # only a share-all/team/org (group_id=None) grant authorizes a dir listing.
+    _patch_grants(monkeypatch, {("bob", "alice", "g1")})  # group-specific only
+    pol = iv.UserAccessPolicy(ROOT)
+    assert await pol.can_list(FakeRequest("bob"), f"{ROOT}/alice/logs") is False
+
+    _patch_grants(monkeypatch, {("bob", "alice", None)})  # share-all
+    assert await pol.can_list(FakeRequest("bob"), f"{ROOT}/alice/logs") is True
+
+
+# --------------------------------------------------------------------------
+# Mapping policy: granted paths pass through; ungranted get rewritten
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_map_passes_through_granted_path(monkeypatch):
+    _patch_grants(monkeypatch, {("bob", "alice", "g1")})
+    pol = iv.UserFileMappingPolicy(ROOT)
+    f = f"{ROOT}/alice/logs/g1.eval"
+    # Must NOT be rewritten to bob's dir — else the authorized read breaks.
+    assert await pol.map(FakeRequest("bob"), f) == f
+
+
+@pytest.mark.asyncio
+async def test_map_rewrites_ungranted_foreign_path(monkeypatch):
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserFileMappingPolicy(ROOT)
+    f = f"{ROOT}/alice/logs/g1.eval"
+    # No grant → rewritten into bob's own logs dir (can't read alice's).
+    assert await pol.map(FakeRequest("bob"), f) == f"{ROOT}/bob/logs"
+
+
+@pytest.mark.asyncio
+async def test_map_own_path_unchanged(monkeypatch):
+    _patch_grants(monkeypatch, set())
+    pol = iv.UserFileMappingPolicy(ROOT)
+    f = f"{ROOT}/bob/logs/g1.eval"
+    assert await pol.map(FakeRequest("bob"), f) == f

--- a/tests/test_sharing_resolver.py
+++ b/tests/test_sharing_resolver.py
@@ -1,0 +1,216 @@
+"""Unit tests for the cross-user eval sharing authorization resolver.
+
+Stack-free: drives backend.core.sharing.can_read / list_shared_scopes against
+a fake in-memory db, so it runs under `pytest tests/` with no Postgres. This is
+the only automated reach the feature has (CI runs no integration tests), so it
+covers the deny-by-default invariants directly.
+
+The companion live-stack test is verify_grant_isolation.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.sharing import (
+    assert_path_within_owner,
+    can_read,
+    list_shared_scopes,
+    resolve_principals,
+)
+
+
+class FakeDB:
+    """Minimal stand-in for Database — only the methods the resolver calls.
+
+    grants: list of dicts {ownerId, groupId, role, _principal: (type, id)}.
+    The _principal field is what list_grants_for_principals filters on,
+    mirroring the real (principal_type, principal_id) match.
+    """
+
+    def __init__(self, grants=None, teams=None, fail_teams=False, fail_grants=False):
+        self._grants = grants or []
+        self._teams = teams or {}
+        self._fail_teams = fail_teams
+        self._fail_grants = fail_grants
+
+    async def get_teams_for_user(self, user_id):
+        if self._fail_teams:
+            raise RuntimeError("team store down")
+        return self._teams.get(user_id, [])
+
+    async def list_grants_for_principals(self, principals):
+        if self._fail_grants:
+            raise RuntimeError("grant store down")
+        pset = set(principals)
+        return [
+            {"ownerId": g["ownerId"], "groupId": g["groupId"], "role": g["role"]}
+            for g in self._grants
+            if g["_principal"] in pset
+        ]
+
+
+def _grant(owner, group, principal, role="viewer"):
+    return {"ownerId": owner, "groupId": group, "role": role, "_principal": principal}
+
+
+# --------------------------------------------------------------------------
+# Ownership
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_owner_can_read_own():
+    db = FakeDB()
+    assert await can_read(db, "alice", "alice", "g1") is True
+
+
+@pytest.mark.asyncio
+async def test_stranger_denied_by_default():
+    db = FakeDB()
+    assert await can_read(db, "bob", "alice", "g1") is False
+
+
+@pytest.mark.asyncio
+async def test_empty_ids_denied():
+    db = FakeDB()
+    assert await can_read(db, "", "alice", "g1") is False
+    assert await can_read(db, "bob", "", "g1") is False
+
+
+# --------------------------------------------------------------------------
+# Per-eval user grant
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_user_grant_specific_group_allows_only_that_group():
+    db = FakeDB(grants=[_grant("alice", "g1", ("user", "bob"))])
+    assert await can_read(db, "bob", "alice", "g1") is True
+    # A different group is NOT covered by a group-specific grant.
+    assert await can_read(db, "bob", "alice", "g2") is False
+
+
+@pytest.mark.asyncio
+async def test_grant_to_other_user_does_not_leak():
+    # Grant is to carol, not bob.
+    db = FakeDB(grants=[_grant("alice", "g1", ("user", "carol"))])
+    assert await can_read(db, "bob", "alice", "g1") is False
+
+
+# --------------------------------------------------------------------------
+# Share-all (group_id is None)
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_share_all_covers_any_group_including_unknown():
+    db = FakeDB(grants=[_grant("alice", None, ("user", "bob"))])
+    assert await can_read(db, "bob", "alice", "g1") is True
+    assert await can_read(db, "bob", "alice", "g999") is True
+    # ...but only for alice's evals, not some other owner.
+    assert await can_read(db, "bob", "dave", "g1") is False
+
+
+# --------------------------------------------------------------------------
+# Team grant
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_team_grant_allows_members_only():
+    db = FakeDB(
+        grants=[_grant("alice", "g1", ("team", "team7"))],
+        teams={"bob": ["team7"], "carol": ["team9"]},
+    )
+    assert await can_read(db, "bob", "alice", "g1") is True    # bob in team7
+    assert await can_read(db, "carol", "alice", "g1") is False  # carol not in team7
+
+
+# --------------------------------------------------------------------------
+# Org-wide grant
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_org_grant_allows_everyone():
+    db = FakeDB(grants=[_grant("alice", "g1", ("org", None))])
+    assert await can_read(db, "anyone", "alice", "g1") is True
+
+
+# --------------------------------------------------------------------------
+# Fail-closed on errors
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_grant_store_error_denies():
+    db = FakeDB(grants=[_grant("alice", "g1", ("user", "bob"))], fail_grants=True)
+    # Even though a valid grant exists, a store error must fail CLOSED.
+    assert await can_read(db, "bob", "alice", "g1") is False
+
+
+@pytest.mark.asyncio
+async def test_team_store_error_still_allows_self_and_explicit_user_grant():
+    # Team lookup fails, but a direct user grant must still work (we degrade
+    # to user+org principals, not total denial).
+    db = FakeDB(grants=[_grant("alice", "g1", ("user", "bob"))], fail_teams=True)
+    assert await can_read(db, "bob", "alice", "g1") is True
+
+
+@pytest.mark.asyncio
+async def test_owner_unaffected_by_team_store_error():
+    db = FakeDB(fail_teams=True)
+    assert await can_read(db, "alice", "alice", "g1") is True
+
+
+# --------------------------------------------------------------------------
+# resolve_principals
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_resolve_principals_includes_self_org_and_teams():
+    db = FakeDB(teams={"bob": ["t1", "t2"]})
+    principals = await resolve_principals(db, "bob")
+    assert ("user", "bob") in principals
+    assert ("org", None) in principals
+    assert ("team", "t1") in principals
+    assert ("team", "t2") in principals
+
+
+# --------------------------------------------------------------------------
+# list_shared_scopes excludes own evals
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_shared_scopes_excludes_self():
+    db = FakeDB(grants=[
+        _grant("alice", "g1", ("user", "bob")),
+        _grant("bob", None, ("user", "bob")),   # bob shared with himself somehow
+    ])
+    scopes = await list_shared_scopes(db, "bob")
+    owners = {s["ownerId"] for s in scopes}
+    assert "alice" in owners
+    assert "bob" not in owners
+
+
+# --------------------------------------------------------------------------
+# Path boundary re-validation
+# --------------------------------------------------------------------------
+
+def test_assert_path_within_owner_rejects_traversal(monkeypatch):
+    # get_user_log_dir is imported lazily inside the function, so patch it at
+    # its source module (eval_mcp.core.user_storage), not on sharing.
+    import eval_mcp.core.user_storage as us
+    monkeypatch.setattr(us, "get_user_log_dir",
+                        lambda uid: f"/data/users/{uid}/logs")
+    # In-scope read.
+    assert assert_path_within_owner("/data/users/alice/logs/x.eval", "alice") is True
+    # Traversal out of alice into bob must be rejected.
+    assert assert_path_within_owner(
+        "/data/users/alice/logs/../../bob/logs/secret.eval", "alice") is False
+    # Sibling-prefix bypass must be rejected.
+    assert assert_path_within_owner("/data/users/alice-evil/logs/x.eval", "alice") is False
+
+
+def test_assert_path_within_owner_denies_invalid_owner(monkeypatch):
+    import eval_mcp.core.user_storage as us
+
+    def _raise(uid):
+        raise ValueError("invalid user_id")
+
+    monkeypatch.setattr(us, "get_user_log_dir", _raise)
+    assert assert_path_within_owner("/data/users/x/logs/a.eval", "../etc") is False

--- a/verify_grant_isolation.py
+++ b/verify_grant_isolation.py
@@ -1,0 +1,237 @@
+"""Grant-isolation E2E — cross-user eval SHARING authorization.
+
+Companion to verify_tenant_isolation.py. Where that script proves a tenant
+CANNOT reach another's evals at all, this proves the sharing feature opens
+exactly the right door and no more: a viewer is denied an ungranted eval,
+allowed once a grant exists, and denied again after revoke — all scoped to the
+specific (owner, group) the grant names.
+
+Two identities locally: the nginx stub pins every request through :4001 to
+`local-user`, so we drive the backend container directly with an explicit
+X-Forwarded-User header (the stub only APPENDS its header, and Starlette's
+.get returns the first, so our value wins). `local-user` plays the OWNER
+(matching the data we plant under their dir); `viewer-carol` plays the VIEWER.
+
+Needs the local stack up (`make dev`). Exit 0 = passed.
+"""
+
+import json
+import subprocess
+import sys
+
+COMPOSE = ["docker", "compose", "-f", "local/compose.yaml"]
+
+OWNER = "local-user"          # the stub identity; we plant data under them
+VIEWER = "viewer-carol"       # a second identity, sent via header
+GROUP = "run-abc123"          # a fake Inspect run_id / group id
+OTHER_GROUP = "run-zzz999"    # owner has this too, but never shares it
+SECRET = "SECRET-jury-reasoning-for-abc123"
+
+failures: list[str] = []
+
+
+def check(name, cond, detail=""):
+    print(f"[{'PASS' if cond else 'FAIL'}] {name}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _exec(cmd: str) -> str:
+    """Run a shell command inside the backend container, return stdout."""
+    r = subprocess.run(
+        COMPOSE + ["exec", "-T", "backend", "sh", "-c", cmd],
+        capture_output=True, text=True,
+    )
+    return r.stdout
+
+
+def _curl(path: str, user: str, method: str = "GET", body: str | None = None):
+    """Hit the backend directly (bypassing the nginx stub) as `user`.
+
+    Returns (status:int, body:str). Uses curl inside the container so we can
+    set an arbitrary X-Forwarded-User — the way two identities are simulated.
+    """
+    parts = [
+        "curl", "-s", "-o", "/tmp/resp.body", "-w", "%{http_code}",
+        "-H", f"'X-Forwarded-User: {user}'",
+        "-X", method,
+    ]
+    if body is not None:
+        parts += ["-H", "'Content-Type: application/json'", "--data", f"'{body}'"]
+    parts.append(f"'http://localhost:8080{path}'")
+    code = _exec(" ".join(parts)).strip()
+    resp_body = _exec("cat /tmp/resp.body 2>/dev/null || true")
+    try:
+        status = int(code[-3:])
+    except ValueError:
+        status = -1
+    return status, resp_body
+
+
+def plant_owner_data():
+    """Plant the owner's precomputed groups/detail JSON + a raw .eval log.
+
+    Mirrors the on-disk layout user_storage.py writes:
+      /data/users/<owner>/store/eval_results/_groups.json
+      /data/users/<owner>/store/eval_results/detail_<group>.json
+      /data/users/<owner>/logs/<group>.eval
+    """
+    store = f"/data/users/{OWNER}/store/eval_results"
+    logs = f"/data/users/{OWNER}/logs"
+    groups = json.dumps({"groups": [
+        {"id": GROUP, "task": "t", "configName": "shared-cfg", "created": "2026-06-01T00:00:00",
+         "models": ["m1"], "sampleCount": 3, "status": "success", "scores": {}},
+        {"id": OTHER_GROUP, "task": "t", "configName": "private-cfg", "created": "2026-06-02T00:00:00",
+         "models": ["m1"], "sampleCount": 3, "status": "success", "scores": {}},
+    ]})
+    detail = json.dumps({"groupId": GROUP, "task": "t", "models": ["m1"],
+                         "criteria": [], "criteriaDescriptions": {}, "aggregate": {},
+                         "samples": [], "stats": {}, "note": SECRET})
+    _exec(f"mkdir -p {store} {logs}")
+    # Use base64 to avoid shell-quoting hell with the JSON payloads.
+    import base64
+    g64 = base64.b64encode(groups.encode()).decode()
+    d64 = base64.b64encode(detail.encode()).decode()
+    _exec(f"echo {g64} | base64 -d > {store}/_groups.json")
+    _exec(f"echo {d64} | base64 -d > {store}/detail_{GROUP}.json")
+    _exec(f"printf '%s' '{SECRET}' > {logs}/{GROUP}.eval")
+
+
+def cleanup():
+    _exec(f"rm -rf /data/users/{VIEWER}")
+    _exec(f"rm -f /data/users/{OWNER}/store/eval_results/_groups.json "
+          f"/data/users/{OWNER}/store/eval_results/detail_{GROUP}.json "
+          f"/data/users/{OWNER}/logs/{GROUP}.eval")
+    # Best-effort: drop grants, team rows, and the test users this run created.
+    sql = (
+        f"DELETE FROM eval_grants WHERE owner_id='{OWNER}'; "
+        f"DELETE FROM team_members WHERE team_id IN (SELECT id FROM teams WHERE created_by='{OWNER}'); "
+        f"DELETE FROM teams WHERE created_by='{OWNER}'; "
+        f"DELETE FROM users WHERE id LIKE 'deploytest-%';"
+    )
+    _exec(f"psql -h postgres -U node -d evaldb -c \"{sql}\" 2>/dev/null || true")
+
+
+def _grant_count() -> str:
+    return _exec(
+        "psql -h postgres -U node -d evaldb -tA -c "
+        f"\"SELECT count(*) FROM eval_grants WHERE owner_id='{OWNER}';\" 2>/dev/null"
+    ).strip()
+
+
+def run():
+    detail_path = f"/api/compare/detail?group_id={GROUP}&owner={OWNER}"
+    sample_log = f"/data/users/{OWNER}/logs/{GROUP}.eval"
+    sample_path = (
+        f"/api/compare/sample?log_file={sample_log}&sample_id=1"
+        f"&group_id={GROUP}&owner={OWNER}"
+    )
+
+    # --- Owner can always read their own eval (sanity) ---
+    status, _ = _curl(f"/api/compare/detail?group_id={GROUP}", OWNER)
+    check("owner reads own detail", status == 200, f"status={status}")
+
+    # --- BEFORE grant: viewer denied the shared eval ---
+    status, body = _curl(detail_path, VIEWER)
+    check("viewer denied ungranted detail (403)", status == 403, f"status={status}")
+    check("secret not leaked pre-grant", SECRET not in body)
+
+    status, _ = _curl(sample_path, VIEWER)
+    check("viewer denied ungranted sample (403)", status == 403, f"status={status}")
+
+    # Viewer's own /groups must NOT include the owner's eval yet.
+    status, body = _curl("/api/compare/groups", VIEWER)
+    check("viewer groups excludes ungranted eval",
+          status == 200 and "shared-cfg" not in body, f"status={status}")
+
+    # --- Owner grants THIS group (run-abc123) to the viewer ---
+    grant_body = json.dumps({"principal_type": "user", "principal_id": VIEWER,
+                             "group_id": GROUP, "role": "viewer"})
+    status, body = _curl("/api/compare/shares", OWNER, method="POST", body=grant_body)
+    check("owner creates grant (200)", status == 200, f"status={status} body={body}")
+
+    # --- AFTER grant: viewer allowed the shared eval ---
+    status, body = _curl(detail_path, VIEWER)
+    check("viewer reads granted detail (200)", status == 200, f"status={status}")
+    check("granted detail returns secret", SECRET in body)
+
+    status, _ = _curl(sample_path, VIEWER)
+    # Sample read may 404 (no matching sample id in our minimal log) but must
+    # NOT be 403 — authorization passed. 403 would mean the grant didn't apply.
+    check("viewer sample read authorized (not 403)", status != 403, f"status={status}")
+
+    # Viewer's /groups now includes the shared eval, tagged shared.
+    status, body = _curl("/api/compare/groups", VIEWER)
+    check("viewer groups includes granted eval",
+          status == 200 and "shared-cfg" in body, f"status={status}")
+
+    # --- Scope: the grant on run-abc123 must NOT leak the un-shared group ---
+    status, body = _curl(
+        f"/api/compare/detail?group_id={OTHER_GROUP}&owner={OWNER}", VIEWER)
+    check("grant does NOT leak un-shared group (403)", status == 403,
+          f"status={status}")
+    check("viewer groups excludes un-shared group", "private-cfg" not in body)
+
+    # --- Revoke: viewer denied again ---
+    status, body = _curl("/api/compare/shares", OWNER)
+    shares = json.loads(body) if status == 200 else {"shares": []}
+    grant_id = shares["shares"][0]["id"] if shares["shares"] else ""
+    status, _ = _curl(f"/api/compare/shares/{grant_id}", OWNER, method="DELETE")
+    check("owner revokes grant (200)", status == 200, f"status={status}")
+
+    status, body = _curl(detail_path, VIEWER)
+    check("viewer denied after revoke (403)", status == 403, f"status={status}")
+    check("secret not leaked post-revoke", SECRET not in body)
+
+    # --- TEAM grant: create team as owner, add a 3rd user, share to team ---
+    TEAMMATE = "deploytest-dave"
+    ct = json.dumps({"name": "deploy-team"})
+    status, body = _curl("/api/teams", OWNER, method="POST", body=ct)
+    check("owner creates team (200)", status == 200, f"status={status} body={body}")
+    team_id = (json.loads(body).get("id") if status == 200 else "") or ""
+    # add teammate as member
+    am = json.dumps({"user_id": TEAMMATE, "role": "member"})
+    status, _ = _curl(f"/api/teams/{team_id}/members", OWNER, method="POST", body=am)
+    check("owner adds teammate (200)", status == 200, f"status={status}")
+    # teammate denied before team grant
+    status, _ = _curl(detail_path, TEAMMATE)
+    check("teammate denied before team grant (403)", status == 403, f"status={status}")
+    # share group to the team
+    tg = json.dumps({"principal_type": "team", "principal_id": team_id,
+                     "group_id": GROUP, "role": "viewer"})
+    status, _ = _curl("/api/compare/shares", OWNER, method="POST", body=tg)
+    check("owner shares to team (200)", status == 200, f"status={status}")
+    # teammate (member) now allowed
+    status, body = _curl(detail_path, TEAMMATE)
+    check("team member reads granted detail (200)", status == 200, f"status={status}")
+    # a non-member is still denied
+    status, _ = _curl(detail_path, "deploytest-stranger")
+    check("non-member denied team-shared eval (403)", status == 403, f"status={status}")
+
+    # --- ORG grant: share to everyone ---
+    og = json.dumps({"principal_type": "org", "principal_id": None,
+                     "group_id": GROUP, "role": "viewer"})
+    status, _ = _curl("/api/compare/shares", OWNER, method="POST", body=og)
+    check("owner shares to org (200)", status == 200, f"status={status}")
+    status, _ = _curl(detail_path, "deploytest-anyone")
+    check("any user reads org-shared eval (200)", status == 200, f"status={status}")
+
+    # --- editor/owner roles rejected (read-only v1) ---
+    bad = json.dumps({"principal_type": "user", "principal_id": VIEWER,
+                      "group_id": GROUP, "role": "editor"})
+    status, _ = _curl("/api/compare/shares", OWNER, method="POST", body=bad)
+    check("editor role rejected (400)", status == 400, f"status={status}")
+
+
+if __name__ == "__main__":
+    try:
+        plant_owner_data()
+        run()
+    finally:
+        cleanup()
+
+    print()
+    if failures:
+        print(f"GRANT-ISOLATION FAILED ({len(failures)}): {failures}")
+        sys.exit(1)
+    print("ALL GRANT-ISOLATION CHECKS PASSED")


### PR DESCRIPTION
## Summary

Read-only sharing of evaluation results in the EKS web app, scaling through one mechanism from user→user to team to whole-org. The standalone `eval_mcp` package stays DB-free — all grant resolution lives in `backend/`.

- **DB**: `eval_grants` / `teams` / `team_members` tables + `users.email` (idempotent migration); deny-by-default grant + membership queries.
- **Resolver** (`backend/core/sharing.py`): one `can_read(caller, owner, group)` composing the PR #106 path-boundary primitives + grant lookup. Grants key on composite `(owner_id, group_id)` — owner supplies the uniqueness Inspect's `run_id` lacks — so no eval-id registry refactor was needed.
- **API**: `/api/compare/*` gated via the resolver; share create/list/revoke; user search (email discovery); `/api/teams` CRUD with admin/member checks.
- **Inspect viewer**: grant-aware `can_read`/`can_list` (read-only — `can_delete`/`can_write` stay self-only); `map()` passes granted paths through. This is the PR #106 breach surface, so traversal resolves to the real owner before the grant check and the boundary primitives are reused verbatim.
- **Chat/MCP**: backend injects authorized `shared_scopes` into read tools; the model never controls access.
- **Frontend**: Share modal (per-eval/share-all, user picker, team, org + warning), owner/shared badges, Teams page + nav.
- **Security must-fix**: NetworkPolicy isolating backend `:8080` to oauth2-proxy (+ VPC CIDR for `/health`); pinned oauth2-proxy header-strip.
- **Docs**: `docs/EVAL_SHARING_DESIGN.md` (design + OWASP/NIST threat model); "How to really test the web app" in DEVELOPMENT.md + CLAUDE.md.

## Why

The web app scoped every read to one `user_id` with no way to share results. This adds progressive, read-only, revocable sharing under the owner's permission, built on the existing tenant-isolation primitives so the breach surface from PR #106 stays closed.

## Test plan

- [x] Unit: resolver + inspect_viewer suites, 25/25 (`tests/test_sharing_resolver.py`, `tests/test_inspect_viewer_sharing.py`)
- [x] Local E2E vs `make dev`: `verify_grant_isolation.py` 24/24 — user/team/org/scope/revoke/read-only-role
- [x] Chat E2E: real Bedrock chat turns — shared eval absent→present→absent across grant/revoke
- [x] Browser (Playwright/webapp-testing): share modal, Teams page, org warning
- [x] Deployed to us-east-2: schema migrated, NetworkPolicy live, endpoints auth-gated, forged-header rejected, in-pod prod RDS checks 12/12