### PR TITLE
feat(infra): grant Bedrock Mantle IAM + lock token-generator dep

### DIFF
--- a/backend/core/agent.py
+++ b/backend/core/agent.py
@@ -91,8 +91,12 @@ Available Tools:
   Some benchmarks need an extra dependency or a sandbox - the tools flag this.
 - list_evaluations: List completed evaluations
 - get_evaluation_details: Get detailed results for a specific eval
-- list_available_models: Discover all available models (Bedrock + external providers)
-- list_bedrock_models: Discover available AWS Bedrock models only
+- list_available_models: Discover ALL available models (standard Bedrock + Bedrock
+  Mantle OpenAI models like GPT-5.4/5.5 + external API providers). PREFER THIS — it
+  is the only tool that surfaces the GPT-5.x-on-Bedrock (Mantle) models.
+- list_bedrock_models: Standard AWS Bedrock (Converse) models ONLY. Does NOT include
+  GPT-5.4/5.5, which run on the separate Bedrock Mantle endpoint — use
+  list_available_models for those.
 - get_viewer_url: Get URL to view evaluation results
 - test_provider: Test if a model is accessible (connectivity check only)
 
@@ -106,13 +110,23 @@ This system supports multiple model providers for evaluation:
      * Claude Opus 4.6: bedrock/us.anthropic.claude-opus-4-6
      * Claude Haiku 4.5: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
 
-2. External providers (available when API keys are configured):
-   - OpenAI: "openai/gpt-4o", "openai/gpt-4.1", "openai/o3"
+2. OpenAI on Bedrock Mantle (available when the AWS account is entitled — no API key):
+   - Model ID format: "openai/bedrock/gpt-5.4", "openai/bedrock/gpt-5.5"
+   - These OpenAI frontier models run on Bedrock's Mantle endpoint, NOT standard
+     Bedrock — so they appear in list_available_models but NOT list_bedrock_models.
+   - Use them exactly like any other model in a config (mix freely with Bedrock
+     Claude/Nova in one comparison eval).
+
+3. External providers (available when API keys are configured):
+   - OpenAI direct API: "openai/gpt-4o", "openai/gpt-4.1", "openai/o3"
    - Anthropic direct API: "anthropic/claude-sonnet-4-6"
    - Google Gemini: "google/gemini-2.5-pro", "google/gemini-2.5-flash"
    - Configure API keys via: make keys (local) or deploy.sh --keys (AWS)
 
-- ALWAYS call list_available_models() to discover which providers and models are available
+- ALWAYS call list_available_models() to discover which providers and models are
+  available — it is the authoritative list and the ONLY one that includes the
+  GPT-5.x Bedrock Mantle models. Never tell a user a model is unavailable based on
+  list_bedrock_models alone.
 - Users can compare models ACROSS providers (e.g., Bedrock Claude vs OpenAI GPT-4o)
 - Cost and latency are tracked per provider automatically
 

--- a/infra/platform/kubernetes.tf
+++ b/infra/platform/kubernetes.tf
@@ -193,6 +193,23 @@ resource "aws_iam_policy" "backend" {
         Resource = "*"
       },
       {
+        # Bedrock Mantle — OpenAI frontier models (GPT-5.4/5.5) are served on the
+        # bedrock-mantle endpoint (OpenAI-compatible Responses API), not
+        # bedrock-runtime. Inspect mints a short-lived bearer token from this
+        # role's credentials and calls Mantle (bedrock-mantle:CreateInference /
+        # CallWithBearerToken). Account must also be entitled
+        # (model access / C-score); run-time validation surfaces a clear error
+        # if not.
+        Effect = "Allow"
+        Action = [
+          "bedrock-mantle:CreateInference",
+          "bedrock-mantle:Get*",
+          "bedrock-mantle:List*",
+          "bedrock-mantle:CallWithBearerToken",
+        ]
+        Resource = "*"
+      },
+      {
         # IAM database authentication - pods connect to RDS using IAM tokens instead of passwords
         Effect   = "Allow"
         Action   = ["rds-db:connect"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ dependencies = [
     # natively; we just need the OpenAI SDK plus the token generator, which
     # mints short-lived Bedrock bearer tokens from the ambient AWS credential
     # chain (IAM role / SSO / profile) so no static API key is required.
-    "openai>=1.99.0",
+    # Floor is >=2.40.0: inspect-ai enforces that minimum at runtime for its
+    # OpenAI provider (MIN_VERSION = "2.40.0") but only declares it in a dev
+    # extra, so a lower floor here lets the resolver pick an incompatible wheel.
+    "openai>=2.40.0",
     "aws-bedrock-token-generator>=1.1.0",
     "click>=8.1.7",
     "rich>=13.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "azure-ai-inference"
 version = "1.0.0b9"
 source = { registry = "https://pypi.org/simple" }
@@ -1601,6 +1613,7 @@ name = "llm-evaluation-system"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "aws-bedrock-token-generator" },
     { name = "boto3" },
     { name = "click" },
     { name = "fastapi" },
@@ -1609,6 +1622,7 @@ dependencies = [
     { name = "inspect-ai" },
     { name = "inspect-evals" },
     { name = "mcp" },
+    { name = "openai" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-botocore" },
@@ -1651,6 +1665,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.80.0" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "asyncpg", marker = "extra == 'backend'", specifier = ">=0.30.0" },
+    { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },
     { name = "azure-ai-inference", marker = "extra == 'providers'" },
     { name = "azure-identity", marker = "extra == 'providers'" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
@@ -1666,6 +1681,7 @@ requires-dist = [
     { name = "inspect-k8s-sandbox", marker = "extra == 'k8s-sandbox'", specifier = ">=0.4.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "openai", specifier = ">=1.99.0" },
     { name = "openai", marker = "extra == 'providers'", specifier = ">=2.26.0" },
     { name = "opentelemetry-distro", specifier = ">=0.50b0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
@@ -3993,7 +4009,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1681,7 +1681,7 @@ requires-dist = [
     { name = "inspect-k8s-sandbox", marker = "extra == 'k8s-sandbox'", specifier = ">=0.4.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
-    { name = "openai", specifier = ">=1.99.0" },
+    { name = "openai", specifier = ">=2.40.0" },
     { name = "openai", marker = "extra == 'providers'", specifier = ">=2.26.0" },
     { name = "opentelemetry-distro", specifier = ">=0.50b0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
@@ -2185,7 +2185,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.36.0"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2197,9 +2197,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires up the deployment side of the Bedrock Mantle support added in #118, closing two gaps that block GPT-5.4/5.5 from working in the EKS web app:

- **IAM**: grant the backend pod `bedrock-mantle:CreateInference / Get* / List* / CallWithBearerToken`. Mantle is a separate service from `bedrock-runtime`; the prior policy only covered standard Bedrock. Inspect mints a short-lived bearer token from the pod's ambient credentials — no static key needed.
- **Lockfile**: `aws-bedrock-token-generator` was declared in `pyproject.toml` (#118) but never locked, so the sidecar image build (`uv sync --locked`) would fail. Regenerated `uv.lock`.

## Why

#118 merged the Mantle *application* code (provider entry, validation branch, pricing matcher, deps) but not the infra grants. Without these two changes, a GPT-5.4 eval in the deployed app would fail — either the image build breaks (`--locked`) or the Mantle API call is denied (no IAM).

## Test plan

- [x] `uv lock --check` passes (lock in sync with pyproject)
- [x] GPT-5.4 verified end-to-end locally via the MCP pipeline against the live Mantle endpoint (dataset → judge → config → run → scored, cost resolved at the Mantle-specific rate $2.75/$16.5)
- [x] `terraform fmt -check` passes on the edited file (HCL is a minimal addition to an existing `jsonencode` policy block); full `terraform plan` not run in-sandbox (provider download blocked) — will confirm via the CodeBuild deploy
- [x] CodeQL / Analyze checks green
- [ ] Post-merge: redeploy to us-east-2 and confirm GPT-5.4 runs in the web app