### PR TITLE
fix(web): cross-pod chat_status via session_active DB table

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -770,10 +770,22 @@ async def chat(request: ChatRequest, user_id: str = Depends(get_current_user_id)
 
 @app.get("/api/chat/status/{session_id}")
 async def chat_status(session_id: str, user_id: str = Depends(get_current_user_id)):
-    """Check if a chat session is currently processing."""
+    """Check if a chat session is currently processing.
+
+    Checks in-memory first (fast path, same pod). If not found locally,
+    falls back to the session_active DB table so a reconnecting tab that
+    lands on a different pod still gets the correct answer.
+    """
     if session_id in active_tasks and not active_tasks[session_id].done():
         return {"running": True}
-    return {"running": False}
+    # Cross-pod fallback: the task may be running on another replica.
+    try:
+        running = await asyncio.wait_for(
+            db.get_session_active(session_id), timeout=1.0
+        )
+        return {"running": running}
+    except (asyncio.TimeoutError, Exception):
+        return {"running": False}
 
 
 async def _cancel_eval_subprocess_and_reconnect(user_id: str) -> None:
@@ -981,6 +993,17 @@ async def run_agent_background(
         except (asyncio.TimeoutError, Exception):
             pass
 
+        # Write the cross-pod "running" signal so chat_status returns
+        # True even when the reconnecting request lands on a different
+        # pod. Non-fatal — a miss just means the UI briefly shows idle.
+        pod_id = os.environ.get("POD_NAME", os.environ.get("HOSTNAME", ""))
+        try:
+            await asyncio.wait_for(
+                db.mark_session_active(session_id, pod_id), timeout=2.0
+            )
+        except (asyncio.TimeoutError, Exception):
+            pass
+
         logger.info(f"[AGENT START] Starting agent loop for session {session_id}")
 
         # Throttle the cross-pod cancellation poll so we don't hammer
@@ -1136,6 +1159,14 @@ async def run_agent_background(
         if session_id in event_queues:
             del event_queues[session_id]
         cancelled_sessions.pop(session_id, None)
+
+        # Clear the cross-pod "running" signal now that the task is done.
+        try:
+            await asyncio.wait_for(
+                db.clear_session_active(session_id), timeout=2.0
+            )
+        except (asyncio.TimeoutError, Exception):
+            pass
 
         logger.info(f"[BACKGROUND END] Session {session_id}, total events: {event_count}, cancelled: {was_cancelled}")
 

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -273,6 +273,20 @@ class Database:
                 )
             """)
 
+            # Cross-pod "session is running" signal. Backend runs as a
+            # multi-pod Deployment; chat_status checks in-memory first
+            # and falls back to this table so a tab that reconnects on a
+            # different pod can still tell the task is alive. Mirrors the
+            # session_cancellations pattern. Row written at task start,
+            # deleted in the finally block of run_agent_background.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS session_active (
+                    session_id TEXT PRIMARY KEY,
+                    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    pod_id TEXT
+                )
+            """)
+
             # Teams — a team is just another principal that grants can
             # target. Membership lives in team_members. See
             # docs/EVAL_SHARING_DESIGN.md.
@@ -547,6 +561,66 @@ class Database:
             # next poll catches it.
             logger.warning(f"Failed to check cancellation for {session_id}: {e}")
             return None
+
+    # ------------------------------------------------------------------
+    # Cross-pod session-active signals (mirrors session_cancellations).
+    # ------------------------------------------------------------------
+
+    async def mark_session_active(self, session_id: str, pod_id: str = "") -> None:
+        """Record that a chat session is running on this pod.
+
+        Written at task start so a tab that reconnects on a different pod
+        can still learn the session is live via get_session_active().
+        UPSERT so a retry within the same turn just refreshes started_at.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO session_active (session_id, started_at, pod_id)
+                    VALUES ($1, NOW(), $2)
+                    ON CONFLICT (session_id) DO UPDATE
+                      SET started_at = NOW(), pod_id = EXCLUDED.pod_id
+                    """,
+                    session_id, pod_id,
+                )
+        except asyncpg.PostgresError as e:
+            # Non-fatal — worst case the cross-pod status check misses
+            # this session and the UI treats it as idle. Log and move on.
+            logger.warning(f"Failed to mark session {session_id} active: {e}")
+
+    async def clear_session_active(self, session_id: str) -> None:
+        """Remove the active flag when the session finishes or is cancelled."""
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    "DELETE FROM session_active WHERE session_id = $1",
+                    session_id,
+                )
+        except asyncpg.PostgresError as e:
+            logger.warning(f"Failed to clear session_active for {session_id}: {e}")
+
+    async def get_session_active(self, session_id: str) -> bool:
+        """Return True if the session has an active row in session_active.
+
+        Used by chat_status as the cross-pod fallback when the session
+        is not found in the local in-memory active_tasks dict.
+        """
+        await self._ensure_pool_fresh()
+        try:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT 1 FROM session_active WHERE session_id = $1",
+                    session_id,
+                )
+                return row is not None
+        except asyncpg.PostgresError as e:
+            # On DB error default to False (idle) — better to briefly
+            # show idle than to hang the UI polling forever.
+            logger.warning(f"Failed to check session_active for {session_id}: {e}")
+            return False
 
     # ------------------------------------------------------------------
     # Eval sharing: grants + teams. See docs/EVAL_SHARING_DESIGN.md.

--- a/tests/test_xpod_status.py
+++ b/tests/test_xpod_status.py
@@ -1,0 +1,159 @@
+"""Cross-pod chat_status fix.
+
+chat_status used to check only in-memory active_tasks, so a tab that
+reconnects on a different pod always got {"running": false} even if the
+agent was still running on the original pod. The fix: fall back to the
+session_active DB table when the session isn't found locally.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import backend.api.main as main
+
+
+# ---------------------------------------------------------------------------
+# chat_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_local_task_running(monkeypatch):
+    """Same-pod fast path: in-memory task present and running → True,
+    no DB query issued."""
+    task = asyncio.create_task(asyncio.sleep(100))
+    monkeypatch.setattr(main, "active_tasks", {"sess-1": task})
+
+    fake_db = AsyncMock()
+    monkeypatch.setattr(main, "db", fake_db)
+
+    result = await main.chat_status("sess-1", user_id="u1")
+    assert result == {"running": True}
+    fake_db.get_session_active.assert_not_called()
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_status_not_local_hits_db_true(monkeypatch):
+    """Cross-pod: session not in active_tasks on this pod → DB says running."""
+    monkeypatch.setattr(main, "active_tasks", {})
+
+    fake_db = AsyncMock()
+    fake_db.get_session_active = AsyncMock(return_value=True)
+    monkeypatch.setattr(main, "db", fake_db)
+
+    result = await main.chat_status("sess-xpod", user_id="u1")
+    assert result == {"running": True}
+    fake_db.get_session_active.assert_awaited_once_with("sess-xpod")
+
+
+@pytest.mark.asyncio
+async def test_status_not_local_hits_db_false(monkeypatch):
+    """Cross-pod: session not in active_tasks, DB says not running → False."""
+    monkeypatch.setattr(main, "active_tasks", {})
+
+    fake_db = AsyncMock()
+    fake_db.get_session_active = AsyncMock(return_value=False)
+    monkeypatch.setattr(main, "db", fake_db)
+
+    result = await main.chat_status("sess-done", user_id="u1")
+    assert result == {"running": False}
+
+
+@pytest.mark.asyncio
+async def test_status_db_timeout_returns_false(monkeypatch):
+    """If the DB query times out the endpoint returns False, not an error."""
+    monkeypatch.setattr(main, "active_tasks", {})
+
+    async def slow_query(_sid):
+        await asyncio.sleep(10)
+
+    fake_db = AsyncMock()
+    fake_db.get_session_active = slow_query
+    monkeypatch.setattr(main, "db", fake_db)
+
+    # Patch the timeout down to something instant so the test is fast.
+    original_wait_for = asyncio.wait_for
+
+    async def fast_timeout(coro, timeout):
+        raise asyncio.TimeoutError
+
+    with patch("asyncio.wait_for", side_effect=fast_timeout):
+        result = await main.chat_status("sess-slow", user_id="u1")
+    assert result == {"running": False}
+
+
+@pytest.mark.asyncio
+async def test_status_done_task_not_running(monkeypatch):
+    """A task that has already completed should not count as running,
+    even if it's still in the active_tasks dict (cleanup is async)."""
+    task = asyncio.create_task(asyncio.sleep(0))
+    await task  # let it complete
+
+    monkeypatch.setattr(main, "active_tasks", {"sess-done": task})
+
+    fake_db = AsyncMock()
+    fake_db.get_session_active = AsyncMock(return_value=False)
+    monkeypatch.setattr(main, "db", fake_db)
+
+    result = await main.chat_status("sess-done", user_id="u1")
+    assert result == {"running": False}
+
+
+# ---------------------------------------------------------------------------
+# mark / clear session_active lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_marks_active_and_clears_on_finish(monkeypatch):
+    """run_agent_background must call mark_session_active at start and
+    clear_session_active in its finally block regardless of outcome."""
+    marked = []
+    cleared = []
+
+    async def fake_mark(sid, pod_id=""):
+        marked.append(sid)
+
+    async def fake_clear(sid):
+        cleared.append(sid)
+
+    fake_db = AsyncMock()
+    fake_db.mark_session_active = fake_mark
+    fake_db.clear_session_active = fake_clear
+    fake_db.save_message = AsyncMock()
+    fake_db.clear_session_cancellation = AsyncMock()
+    fake_db.get_session_cancellation = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(main, "db", fake_db)
+    monkeypatch.setattr(main, "active_tasks", {})
+    monkeypatch.setattr(main, "event_queues", {})
+    monkeypatch.setattr(main, "cancelled_sessions", {})
+
+    import logging
+
+    # Build a minimal fake agent that returns a single text chunk.
+    fake_agent = AsyncMock()
+
+    async def fake_run(message, stream=True):
+        yield {"type": "text", "text": "hello"}
+
+    fake_agent.run = fake_run
+
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await main.run_agent_background(
+        session_id="s1",
+        user_id="u1",
+        agent=fake_agent,
+        final_message="hi",
+        user_message_for_db="hi",
+        queue=queue,
+        logger=logging.getLogger("test"),
+    )
+
+    assert "s1" in marked, "mark_session_active not called"
+    assert "s1" in cleared, "clear_session_active not called in finally"


### PR DESCRIPTION
## Summary

- `chat_status` previously returned `{"running": false}` whenever the reconnecting request landed on a pod that didn't own the session's `active_tasks` entry — even with the agent actively running on another replica.
- Adds a `session_active` table (same pattern as `session_cancellations`) written at task start and cleared in the `run_agent_background` finally block.
- `chat_status` now checks in-memory first (same-pod, no DB hit), then falls back to `session_active` with a 1s timeout. DB error or timeout degrades to `false` (idle).

## Why

The backend runs 2–6 replicas with no reliable sticky routing through CloudFront → ALB. Cancel was already cross-pod-correct via `session_cancellations`. Status was the remaining gap — a refreshed tab would see the session as idle and stop polling, meaning the final assistant message never streamed live (it appeared only on the next manual reload, after it was written to DB).

## Test plan

- [x] 5 new unit tests: same-pod fast path (no DB call), cross-pod true, cross-pod false, DB timeout degrades to false, mark/clear lifecycle through `run_agent_background`
- [x] All 14 existing EKS/xpod tests still pass
- [x] `init_db` DDL is idempotent (`CREATE TABLE IF NOT EXISTS`) — safe to deploy against existing prod DB