### PR TITLE
fix(mcp): point list_bedrock_models at Mantle for GPT-5.x discovery

### DIFF
--- a/eval_mcp/tools/bedrock_models.py
+++ b/eval_mcp/tools/bedrock_models.py
@@ -187,7 +187,14 @@ def list_bedrock_models(
             "limit": limit,
             "text_only": text_only,
         },
-        "note": "Shows inference profiles and foundation models. Use text_only=false to include image/embedding models.",
+        "note": (
+            "Shows standard Bedrock (Converse) inference profiles and foundation "
+            "models only. Use text_only=false to include image/embedding models. "
+            "IMPORTANT: this does NOT include OpenAI GPT-5.x models, which run on "
+            "the separate Bedrock Mantle endpoint — call list_available_models to "
+            "see those (e.g. openai/bedrock/gpt-5.4). Never tell a user a model is "
+            "unavailable based on this tool alone."
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Makes `list_bedrock_models`' output note explicitly state that OpenAI GPT-5.x models live on the **Bedrock Mantle** endpoint and that the agent should call `list_available_models` to see them.

## Why

After the Mantle support shipped (#118/#119), the chat agent still *intermittently* tells users "GPT-5.4 is not available" — because it sometimes reaches for `list_bedrock_models` (standard Converse, Mantle-excluded by design) instead of `list_available_models`. The #119 system-prompt nudge reduced this but isn't deterministic (model tool-choice varies on terse questions).

This closes the loop at the data layer: regardless of which discovery tool the model picks first, the response itself redirects it to the Mantle models. Verified in prod that `list_available_models` returns `openai/bedrock/gpt-5.4` correctly — this is purely about making the *narrow* tool self-correcting.

## Test plan

- [x] `pytest tests/test_bedrock_models.py` green (4 passed)
- [x] compiles
- [ ] Post-merge: redeploy + confirm the agent reliably reports GPT-5.4 available on a terse question