### PR TITLE
fix(mcp): surface Mantle GPT-5.x under provider=openai filter

### DIFF
--- a/eval_mcp/tools/external_providers.py
+++ b/eval_mcp/tools/external_providers.py
@@ -107,6 +107,13 @@ EXTERNAL_PROVIDERS: dict[str, dict[str, Any]] = {
     "bedrock-mantle": {
         "env_var": None,
         "display_name": "OpenAI on Bedrock (Mantle)",
+        # match_aliases: a provider filter for any of these names ALSO returns
+        # this provider's models. GPT-5.4/5.5 are OpenAI models, so a caller (or
+        # the agent) filtering provider="openai" must find them here even though
+        # the canonical provider key is "bedrock-mantle". Without this, asking
+        # "is GPT-5.4 available?" filters to provider=openai and wrongly misses
+        # the Mantle models.
+        "match_aliases": ["openai"],
         "models": [
             {"id": "openai/bedrock/gpt-5.5", "name": "GPT-5.5 (Bedrock)"},
             {"id": "openai/bedrock/gpt-5.4", "name": "GPT-5.4 (Bedrock)"},
@@ -232,8 +239,10 @@ def get_external_models(provider: str = "all") -> list[dict[str, Any]]:
     _refresh_keys_from_file()
     models = []
     for name, config in EXTERNAL_PROVIDERS.items():
-        # Skip if provider filter doesn't match
-        if provider != "all" and provider != name:
+        # Skip if provider filter doesn't match the canonical name or any alias
+        # (e.g. provider="openai" also matches the "bedrock-mantle" provider,
+        # whose models are OpenAI models hosted on Bedrock).
+        if provider != "all" and provider != name and provider not in config.get("match_aliases", []):
             continue
 
         # Skip if the provider isn't usable (no API key, or no AWS creds for

--- a/tests/test_external_providers.py
+++ b/tests/test_external_providers.py
@@ -1,0 +1,44 @@
+"""Tests for external/Mantle provider discovery + filtering."""
+
+from unittest.mock import patch
+
+from eval_mcp.tools import external_providers as ep
+
+
+def _enabled(config):
+    """Treat every provider as enabled regardless of keys/AWS creds."""
+    return True
+
+
+def test_openai_filter_includes_mantle_gpt5():
+    """Filtering provider='openai' must surface the Bedrock Mantle GPT-5.x models.
+
+    They live under the 'bedrock-mantle' provider but ARE OpenAI models — the
+    match_aliases mechanism makes provider='openai' return them. This is the bug
+    that made the chat agent say "GPT-5.4 not available": it filtered to
+    provider=openai and missed the Mantle models."""
+    with patch.object(ep, "_provider_enabled", _enabled):
+        ids = [m["id"] for m in ep.get_external_models("openai")]
+    assert "openai/bedrock/gpt-5.4" in ids
+    assert "openai/bedrock/gpt-5.5" in ids
+
+
+def test_bedrock_mantle_canonical_name_still_works():
+    """The canonical provider name still returns its models."""
+    with patch.object(ep, "_provider_enabled", _enabled):
+        ids = [m["id"] for m in ep.get_external_models("bedrock-mantle")]
+    assert "openai/bedrock/gpt-5.4" in ids
+
+
+def test_provider_all_returns_everything():
+    with patch.object(ep, "_provider_enabled", _enabled):
+        ids = [m["id"] for m in ep.get_external_models("all")]
+    assert "openai/bedrock/gpt-5.4" in ids
+    assert any(m_id.startswith("openai/gpt-") for m_id in ids)  # direct-API openai too
+
+
+def test_unrelated_filter_excludes_mantle():
+    """A non-matching provider filter must NOT pull in Mantle models."""
+    with patch.object(ep, "_provider_enabled", _enabled):
+        ids = [m["id"] for m in ep.get_external_models("google")]
+    assert not any("bedrock/gpt-5" in m_id for m_id in ids)


### PR DESCRIPTION
## Summary

Fixes the real root cause of the chat agent reporting "GPT-5.4 not available."

## Root cause

The agent, asked about GPT models, calls `list_available_models(provider="openai")`. GPT-5.4/5.5 are registered under the `bedrock-mantle` provider, so the `openai` filter **excluded them** — the agent saw only the `gpt-oss` Bedrock models and concluded GPT-5.4 wasn't available.

The earlier nudges (#119 system prompt, #122 tool-note) didn't fix it because the **data itself** was filtered out before the agent ever saw it. I confirmed this by tracing the live pod's tool calls: the agent *did* call `list_available_models`, but with `provider="openai"`, which returned only gpt-oss.

## Fix

Add a `match_aliases` mechanism: `bedrock-mantle` declares `["openai"]`, so a `provider="openai"` filter also returns its OpenAI-family models. Minimal, and `provider="all"` / `provider="bedrock-mantle"` behavior is unchanged.

## Test plan

- [x] New `tests/test_external_providers.py` (4 tests) covering the openai-alias match, canonical name, all-filter, and that unrelated filters don't leak Mantle
- [x] `list_available_models(provider="openai")` now returns `openai/bedrock/gpt-5.4` (verified against live account)
- [x] pricing + bedrock_models + external_providers suites green (16 passed)
- [ ] Post-merge: redeploy + confirm the agent reliably answers "yes, GPT-5.4 available" on a terse question (3x)