### PR TITLE
fix(mcp): detect benchmark sandbox needs via runtime_metadata, fail fast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,16 @@ make clean                                # also wipe volumes
 
 `make dev` builds the static SPA into `frontend/dist`, which nginx serves directly while proxying the gated paths to the backend (no Node frontend container — nginx stands in for CloudFront+S3 serving static and the ALB/oauth2-proxy gating the API, mirroring the EKS split). The backend hot-reloads on Python edits. For frontend edits, rerun `make dev-spa` and refresh. Open http://127.0.0.1:4001. See [local/README.md](local/README.md).
 
+### Deploy-then-merge (web app changes)
+
+**Always deploy the feature branch to AWS and verify live BEFORE merging — never merge then deploy.** `./deploy.sh` zips the local working tree, so a deploy from inside the feature-branch worktree ships exactly that branch's code to EKS (us-east-2). The order is:
+
+1. Make the change on a feature-branch worktree, test locally (`pytest` + a real eval where it applies).
+2. **Deploy that worktree** to us-east-2 (`AWS_REGION=us-east-2 AWS_PROFILE=<profile> ./deploy.sh`) and verify against the live pod / chat endpoint — this is the only way to catch deployed-environment bugs (sandbox availability, IAM grants, dependency-resolution drift, agent tool-selection) that local tests and pytest greens miss.
+3. Only after prod verification passes: open/merge the PR.
+
+Rationale: several real bugs in this project only appeared in the deployed environment (openai version floor rejected at runtime, Mantle IAM, provider-filter excluding models, benchmark Docker-sandbox unavailable on k8s). Merging first means shipping unverified code to `main`; deploying the branch first lets us prove it in prod and merge with confidence. The deploy is non-destructive (idempotent DDL, rolling backend restart), so deploying an unmerged branch is safe.
+
 ### Release
 
 `make release` (patch) / `make release-minor` / `make release-major` from a clean `main`. Tags `vX.Y.Z`, pushes, GitHub Actions builds the wheel (frontend rebuilt in CI) and publishes to PyPI via trusted publishing. Version is derived from the tag by `setuptools-scm` — **never** add a static `version` to `pyproject.toml`. Full ship workflow in the [ship-it skill](./.claude/skills/ship-it/SKILL.md).

--- a/backend/core/agent.py
+++ b/backend/core/agent.py
@@ -88,7 +88,13 @@ Available Tools:
   of a generated dataset. When a user asks to run a named benchmark or "a standard
   benchmark", call list_benchmarks(search=...) to discover it (don't guess task
   names), get_benchmark_details to pick the exact task variant, then run_benchmark.
-  Some benchmarks need an extra dependency or a sandbox - the tools flag this.
+  Some benchmarks need an extra dependency or a sandbox - the tools flag this via
+  needsSandbox / sandboxSupportsK8s. CHECK these before running: code-execution
+  benchmarks (HumanEval, MBPP, DS-1000, ...) need a Docker sandbox to verify
+  generated code and most have sandboxSupportsK8s=false, so they CANNOT run in
+  this hosted deployment. Don't attempt them here — instead proactively offer a
+  custom coding eval (generate_qa_pairs with coding tasks -> generate_judge ->
+  create_eval_config -> run_evaluation), which compares models without a sandbox.
 - list_evaluations: List completed evaluations
 - get_evaluation_details: Get detailed results for a specific eval
 - list_available_models: Discover ALL available models (standard Bedrock + Bedrock

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -73,6 +73,37 @@ def _load_evals() -> List[Any]:
     return list(load_listing().evals)
 
 
+def _sandbox_requirement(e: Any) -> Dict[str, Any]:
+    """Detect whether a benchmark needs a code-execution sandbox, and where.
+
+    The ``isolated`` metadata flag is unreliable for this — only 7 of 129
+    benchmarks set it, yet ~42 actually run untrusted code (humaneval, mbpp,
+    ds1000, bigcodebench, swe_bench, …). The authoritative signal is
+    ``runtime_metadata.sandbox``, a list of the phases that need a sandbox
+    (e.g. ``["scorer"]`` for HumanEval, ``["solver"]`` for SWE-bench).
+
+    ``supports_k8s`` matters for our EKS deployment: code benchmarks that are
+    Docker-only (HumanEval/MBPP, ``supports_k8s=False``) cannot run on the
+    inspect-k8s-sandbox we provide in the cluster, so we must say so up front
+    rather than letting the run die at the scoring step.
+
+    Returns: {needs: bool, phases: list, supportsK8s: bool|None}.
+    """
+    rm = {}
+    try:
+        rm = e.model_dump().get("runtime_metadata") or {}
+    except Exception:
+        rm = {}
+    phases = rm.get("sandbox") or []
+    # Fall back to the legacy isolated flag if runtime_metadata is absent.
+    needs = bool(phases) or bool(getattr(e, "isolated", False))
+    return {
+        "needs": needs,
+        "phases": list(phases),
+        "supportsK8s": rm.get("supports_k8s"),
+    }
+
+
 def _entry_summary(e: Any) -> Dict[str, Any]:
     """Compact projection of one catalog entry — what ``list_benchmarks``
     returns per row. Deliberately small to keep agent context lean."""
@@ -83,6 +114,7 @@ def _entry_summary(e: Any) -> Dict[str, Any]:
         if s:
             samples = s
             break
+    sb = _sandbox_requirement(e)
     return {
         "id": e.id,
         "title": e.title,
@@ -90,7 +122,8 @@ def _entry_summary(e: Any) -> Dict[str, Any]:
         "tasks": tasks,
         "sampleCount": samples,
         "needsExtra": bool(e.dependency or e.dependency_group),
-        "needsSandbox": bool(getattr(e, "isolated", False)),
+        "needsSandbox": sb["needs"],
+        "sandboxSupportsK8s": sb["supportsK8s"],
     }
 
 
@@ -198,17 +231,29 @@ async def handle_get_benchmark_details(args: Dict[str, Any]) -> List[TextContent
             "datasets": datasets,
             "needsExtra": bool(extra_group),
             "extraInstall": f'pip install "inspect_evals[{extra_group}]"' if extra_group else None,
-            "needsSandbox": bool(getattr(e, "isolated", False)),
+            "needsSandbox": _sandbox_requirement(e)["needs"],
             "runHint": (
                 f"run_benchmark(task=\"{tasks[0]['name']}\", providers=[...]) "
                 if tasks else "No runnable task is registered for this entry."
             ),
         }
-        if payload["needsSandbox"]:
-            payload["sandboxNote"] = (
-                "This benchmark runs untrusted code in a sandbox: needs Docker "
-                "locally or inspect-k8s-sandbox on EKS."
-            )
+        sb = _sandbox_requirement(e)
+        if sb["needs"]:
+            phases = ", ".join(sb["phases"]) or "execution"
+            if sb["supportsK8s"]:
+                payload["sandboxNote"] = (
+                    f"This benchmark runs untrusted code in a sandbox (phase: {phases}). "
+                    f"Needs Docker locally, or inspect-k8s-sandbox on EKS (set "
+                    f"INSPECT_SANDBOX_TYPE=k8s)."
+                )
+            else:
+                payload["sandboxNote"] = (
+                    f"This benchmark runs untrusted code in a Docker sandbox (phase: "
+                    f"{phases}) and is NOT supported on Kubernetes (supports_k8s=false). "
+                    f"It can only run locally with Docker — it will fail in the EKS "
+                    f"deployment. Consider a custom coding eval (generate_qa_pairs + "
+                    f"generate_judge) instead."
+                )
         return [TextContent(type="text", text=json.dumps(payload, indent=2))]
     except Exception as e:
         return [TextContent(type="text", text=json.dumps({
@@ -302,15 +347,44 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                     "error": f"Benchmark '{entry.id}' needs an optional dependency group.",
                     "extraInstall": f'pip install "inspect_evals[{extra_group}]"',
                 }))]
-        if getattr(entry, "isolated", False) and not os.environ.get("INSPECT_SANDBOX_TYPE"):
-            return [TextContent(type="text", text=json.dumps({
-                "success": False,
-                "error": (
-                    f"Benchmark '{entry.id}' runs in a sandbox and no sandbox is "
-                    f"configured. Needs Docker locally or inspect-k8s-sandbox on EKS "
-                    f"(set INSPECT_SANDBOX_TYPE)."
-                ),
-            }))]
+        # Sandbox fail-fast. Use runtime_metadata.sandbox (authoritative: ~42
+        # benchmarks), NOT the unreliable `isolated` flag (only 7). Without this,
+        # a code-execution benchmark like HumanEval launches, downloads its
+        # dataset, generates completions, then dies at the scoring step when it
+        # tries to exec generated code in a sandbox that isn't there — exactly
+        # the "failed after downloading the dataset" symptom.
+        sb = _sandbox_requirement(entry)
+        if sb["needs"]:
+            sandbox_type = os.environ.get("INSPECT_SANDBOX_TYPE")
+            phases = ", ".join(sb["phases"]) or "execution"
+            # Docker-only benchmarks (supports_k8s=False) cannot run on the
+            # EKS k8s-sandbox at all — reject regardless of INSPECT_SANDBOX_TYPE.
+            if sb["supportsK8s"] is False and sandbox_type in (None, "k8s"):
+                return [TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Benchmark '{entry.id}' runs untrusted code in a Docker "
+                        f"sandbox (phase: {phases}) and does NOT support Kubernetes "
+                        f"(supports_k8s=false), so it cannot run in this deployment. "
+                        f"It only works locally with Docker. For a model comparison "
+                        f"here, use a custom coding eval instead: generate_qa_pairs "
+                        f"(coding tasks) -> generate_judge -> create_eval_config -> "
+                        f"run_evaluation."
+                    ),
+                    "needsSandbox": True,
+                    "sandboxSupportsK8s": False,
+                }))]
+            if not sandbox_type:
+                return [TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Benchmark '{entry.id}' runs untrusted code in a sandbox "
+                        f"(phase: {phases}) and no sandbox is configured. Needs Docker "
+                        f"locally, or inspect-k8s-sandbox on EKS (set "
+                        f"INSPECT_SANDBOX_TYPE=k8s)."
+                    ),
+                    "needsSandbox": True,
+                }))]
 
         # Bedrock reachability: surface the multi-profile autodetect error here
         # rather than letting it fail deep in the subprocess.

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -30,7 +30,7 @@ class _Entry:
 
     def __init__(self, id, title="", description="", group=None, tasks=None,
                  dependency=None, dependency_group=None, isolated=False,
-                 external_assets=None, arxiv=None):
+                 external_assets=None, arxiv=None, runtime_metadata=None):
         self.id = id
         self.title = title
         self.description = description
@@ -41,6 +41,12 @@ class _Entry:
         self.isolated = isolated
         self.external_assets = external_assets or []
         self.arxiv = arxiv
+        self.runtime_metadata = runtime_metadata
+
+    def model_dump(self):
+        # _sandbox_requirement reads runtime_metadata via model_dump(); mirror
+        # the real EvalListing entry's shape.
+        return {"isolated": self.isolated, "runtime_metadata": self.runtime_metadata}
 
 
 def test_matches_search_hits_id_title_and_tasks():
@@ -68,6 +74,51 @@ def test_entry_summary_flags_and_first_sample_count():
     assert s["needsSandbox"] is True
     assert s["sampleCount"] == 500  # skips the None, takes first real count
     assert s["tasks"] == ["swe", "swe_v"]
+
+
+def test_sandbox_detected_from_runtime_metadata_not_isolated():
+    """A code-execution benchmark flags needsSandbox via runtime_metadata.sandbox
+    even when the legacy `isolated` flag is False (the HumanEval bug)."""
+    from eval_mcp.tools.benchmarks import _sandbox_requirement
+    he = _Entry("humaneval", group="Coding", tasks=[_Task("humaneval")],
+                isolated=False,
+                runtime_metadata={"sandbox": ["scorer"], "supports_k8s": False})
+    sb = _sandbox_requirement(he)
+    assert sb["needs"] is True
+    assert sb["phases"] == ["scorer"]
+    assert sb["supportsK8s"] is False
+    # and the compact summary reflects it
+    s = _entry_summary(he)
+    assert s["needsSandbox"] is True
+    assert s["sandboxSupportsK8s"] is False
+
+
+def test_no_sandbox_for_plain_qa_benchmark():
+    from eval_mcp.tools.benchmarks import _sandbox_requirement
+    g = _Entry("gsm8k", group="Mathematics", tasks=[_Task("gsm8k")],
+               runtime_metadata=None)
+    assert _sandbox_requirement(g)["needs"] is False
+    assert _entry_summary(g)["needsSandbox"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_rejects_docker_only_on_k8s():
+    """A Docker-only (supports_k8s=False) code benchmark must fail fast with an
+    actionable message instead of launching and dying at the scorer."""
+    import os
+    from unittest.mock import patch
+    from eval_mcp.tools import benchmarks as bm
+    he = _Entry("humaneval", group="Coding", tasks=[_Task("humaneval")],
+                runtime_metadata={"sandbox": ["scorer"], "supports_k8s": False})
+    with patch.object(bm, "_load_evals", return_value=[he]), \
+         patch.dict(os.environ, {"INSPECT_SANDBOX_TYPE": "k8s"}, clear=False):
+        r = await bm.handle_run_benchmark({
+            "task": "humaneval", "user_id": "t", "providers": ["bedrock/x"],
+        })
+    d = json.loads(r[0].text)
+    assert d["success"] is False
+    assert "does NOT support Kubernetes" in d["error"]
+    assert d["sandboxSupportsK8s"] is False
 
 
 def test_resolve_task_by_exact_task_name():


### PR DESCRIPTION
## Summary

Fixes a confusing benchmark failure: asking the chat agent to run "humaneval, 5 samples" produced a post-hoc error (dataset downloaded, completions generated, then died at scoring) because the generated code needs a Docker sandbox that doesn't exist in the EKS pod.

## Root cause

The fail-fast guard keyed on the `isolated` metadata flag — set for only **7 of 129** benchmarks. HumanEval/MBPP/DS-1000/BigCodeBench all have `isolated=False` despite hardcoding `sandbox="docker"`, so the guard never fired and they launched anyway.

The authoritative signal is **`runtime_metadata.sandbox`** (the phases needing a sandbox — `["scorer"]` for HumanEval, `["solver"]` for SWE-bench; ~42 benchmarks) plus **`runtime_metadata.supports_k8s`** (whether it can run on our EKS k8s-sandbox vs Docker-only).

## Changes

- `_sandbox_requirement()` reads `runtime_metadata.sandbox`/`supports_k8s` (falls back to `isolated`). Used by `list_benchmarks`, `get_benchmark_details`, and the run guard.
- `run_benchmark` rejects Docker-only (`supports_k8s=false`) code benchmarks **up front** with an actionable message → points the user to the custom-coding-eval path, instead of launching a run that can't score.
- `list_benchmarks`/`get_benchmark_details` now report `needsSandbox` accurately + a new `sandboxSupportsK8s` field and a clearer `sandboxNote`.
- Agent prompt: check `needsSandbox`/`sandboxSupportsK8s` before running; proactively offer a custom coding eval for sandbox-only benchmarks.

## Test plan

- [x] +3 tests (runtime_metadata detection vs isolated, no-sandbox QA, docker-only rejection); `test_benchmarks.py` 14 passed
- [x] Verified against the live `inspect_evals` catalog: humaneval/mbpp/ds1000 → needsSandbox=True/supportsK8s=False; gsm8k/mmlu → False
- [x] `run_benchmark(task="humaneval")` now fails fast with the k8s-not-supported message (confirmed locally)
- [ ] Post-merge: redeploy + confirm the agent declines HumanEval cleanly and offers the custom eval