### PR TITLE
feat(mcp): run code-execution benchmarks in the k8s sandbox

### DIFF
--- a/backend/core/agent.py
+++ b/backend/core/agent.py
@@ -88,13 +88,11 @@ Available Tools:
   of a generated dataset. When a user asks to run a named benchmark or "a standard
   benchmark", call list_benchmarks(search=...) to discover it (don't guess task
   names), get_benchmark_details to pick the exact task variant, then run_benchmark.
-  Some benchmarks need an extra dependency or a sandbox - the tools flag this via
-  needsSandbox / sandboxSupportsK8s. CHECK these before running: code-execution
-  benchmarks (HumanEval, MBPP, DS-1000, ...) need a Docker sandbox to verify
-  generated code and most have sandboxSupportsK8s=false, so they CANNOT run in
-  this hosted deployment. Don't attempt them here — instead proactively offer a
-  custom coding eval (generate_qa_pairs with coding tasks -> generate_judge ->
-  create_eval_config -> run_evaluation), which compares models without a sandbox.
+  Code-execution benchmarks (HumanEval, MBPP, DS-1000, ...) execute the model's
+  generated code in a sandbox to verify it; this is handled automatically (gVisor-
+  isolated inspect-k8s-sandbox on EKS, Docker locally) — just run them normally,
+  no special setup. Some benchmarks need an optional dependency group; the tool
+  flags that with an install hint.
 - list_evaluations: List completed evaluations
 - get_evaluation_details: Get detailed results for a specific eval
 - list_available_models: Discover ALL available models (standard Bedrock + Bedrock

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -240,20 +240,12 @@ async def handle_get_benchmark_details(args: Dict[str, Any]) -> List[TextContent
         sb = _sandbox_requirement(e)
         if sb["needs"]:
             phases = ", ".join(sb["phases"]) or "execution"
-            if sb["supportsK8s"]:
-                payload["sandboxNote"] = (
-                    f"This benchmark runs untrusted code in a sandbox (phase: {phases}). "
-                    f"Needs Docker locally, or inspect-k8s-sandbox on EKS (set "
-                    f"INSPECT_SANDBOX_TYPE=k8s)."
-                )
-            else:
-                payload["sandboxNote"] = (
-                    f"This benchmark runs untrusted code in a Docker sandbox (phase: "
-                    f"{phases}) and is NOT supported on Kubernetes (supports_k8s=false). "
-                    f"It can only run locally with Docker — it will fail in the EKS "
-                    f"deployment. Consider a custom coding eval (generate_qa_pairs + "
-                    f"generate_judge) instead."
-                )
+            payload["sandboxNote"] = (
+                f"This benchmark executes untrusted model-generated code in a "
+                f"sandbox (phase: {phases}) to verify it. run_benchmark handles "
+                f"this automatically: it runs in inspect-k8s-sandbox (gVisor-"
+                f"isolated) on EKS, or Docker locally. Just run it normally."
+            )
         return [TextContent(type="text", text=json.dumps(payload, indent=2))]
     except Exception as e:
         return [TextContent(type="text", text=json.dumps({
@@ -347,44 +339,25 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                     "error": f"Benchmark '{entry.id}' needs an optional dependency group.",
                     "extraInstall": f'pip install "inspect_evals[{extra_group}]"',
                 }))]
-        # Sandbox fail-fast. Use runtime_metadata.sandbox (authoritative: ~42
-        # benchmarks), NOT the unreliable `isolated` flag (only 7). Without this,
-        # a code-execution benchmark like HumanEval launches, downloads its
-        # dataset, generates completions, then dies at the scoring step when it
-        # tries to exec generated code in a sandbox that isn't there — exactly
-        # the "failed after downloading the dataset" symptom.
+        # Sandbox resolution. Code-execution benchmarks (HumanEval, MBPP, …) run
+        # untrusted model-generated code to verify it, which needs a sandbox.
+        # Detect the need via runtime_metadata.sandbox (authoritative: ~42
+        # benchmarks; the legacy `isolated` flag covers only 7) and INJECT the
+        # right sandbox type so the run actually works rather than dying at the
+        # scoring step.
+        #
+        # The benchmark's task hardcodes `sandbox="docker"`, but that's an
+        # overridable -T parameter and the verify scorer only needs *a* sandbox
+        # that can exec python. On EKS we have inspect-k8s-sandbox (default image
+        # python:3.12-bookworm, gVisor-isolated — see infra/platform/
+        # sandbox-security.tf), so we override to `sandbox=k8s`; locally we use
+        # Docker. INSPECT_SANDBOX_TYPE selects which (set to "k8s" in the EKS
+        # deployment, defaults to "docker" elsewhere).
         sb = _sandbox_requirement(entry)
-        if sb["needs"]:
-            sandbox_type = os.environ.get("INSPECT_SANDBOX_TYPE")
-            phases = ", ".join(sb["phases"]) or "execution"
-            # Docker-only benchmarks (supports_k8s=False) cannot run on the
-            # EKS k8s-sandbox at all — reject regardless of INSPECT_SANDBOX_TYPE.
-            if sb["supportsK8s"] is False and sandbox_type in (None, "k8s"):
-                return [TextContent(type="text", text=json.dumps({
-                    "success": False,
-                    "error": (
-                        f"Benchmark '{entry.id}' runs untrusted code in a Docker "
-                        f"sandbox (phase: {phases}) and does NOT support Kubernetes "
-                        f"(supports_k8s=false), so it cannot run in this deployment. "
-                        f"It only works locally with Docker. For a model comparison "
-                        f"here, use a custom coding eval instead: generate_qa_pairs "
-                        f"(coding tasks) -> generate_judge -> create_eval_config -> "
-                        f"run_evaluation."
-                    ),
-                    "needsSandbox": True,
-                    "sandboxSupportsK8s": False,
-                }))]
-            if not sandbox_type:
-                return [TextContent(type="text", text=json.dumps({
-                    "success": False,
-                    "error": (
-                        f"Benchmark '{entry.id}' runs untrusted code in a sandbox "
-                        f"(phase: {phases}) and no sandbox is configured. Needs Docker "
-                        f"locally, or inspect-k8s-sandbox on EKS (set "
-                        f"INSPECT_SANDBOX_TYPE=k8s)."
-                    ),
-                    "needsSandbox": True,
-                }))]
+        sandbox_override: Optional[str] = None
+        if sb["needs"] and "sandbox" not in task_args:
+            sandbox_type = os.environ.get("INSPECT_SANDBOX_TYPE", "docker")
+            sandbox_override = sandbox_type
 
         # Bedrock reachability: surface the multi-profile autodetect error here
         # rather than letting it fail deep in the subprocess.
@@ -415,6 +388,10 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
         ]
         if limit:
             cmd.extend(["--limit", str(int(limit))])
+        # Inject the resolved sandbox type for code-execution benchmarks (unless
+        # the caller already specified one via task_args).
+        if sandbox_override:
+            cmd.extend(["-T", f"sandbox={sandbox_override}"])
         for k, v in task_args.items():
             # -T key=value; inspect parses scalars/JSON on the far side.
             cmd.extend(["-T", f"{k}={v}"])

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -102,23 +102,71 @@ def test_no_sandbox_for_plain_qa_benchmark():
 
 
 @pytest.mark.asyncio
-async def test_run_benchmark_rejects_docker_only_on_k8s():
-    """A Docker-only (supports_k8s=False) code benchmark must fail fast with an
-    actionable message instead of launching and dying at the scorer."""
+async def test_run_benchmark_injects_sandbox_for_code_eval():
+    """A code-execution benchmark must get the resolved sandbox injected as
+    `-T sandbox=<type>` (k8s on EKS) so its verify scorer can run — instead of
+    being rejected. We intercept the subprocess to capture the launched cmd."""
     import os
-    from unittest.mock import patch
+    from unittest.mock import patch, AsyncMock
     from eval_mcp.tools import benchmarks as bm
+
     he = _Entry("humaneval", group="Coding", tasks=[_Task("humaneval")],
                 runtime_metadata={"sandbox": ["scorer"], "supports_k8s": False})
+
+    captured = {}
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.wait = AsyncMock(return_value=0)
+        proc.pid = 4242
+        return proc
+
     with patch.object(bm, "_load_evals", return_value=[he]), \
+         patch.object(bm, "raise_if_autodetect_error", lambda: None), \
+         patch.object(bm.asyncio, "create_subprocess_exec", side_effect=fake_exec), \
          patch.dict(os.environ, {"INSPECT_SANDBOX_TYPE": "k8s"}, clear=False):
-        r = await bm.handle_run_benchmark({
+        await bm.handle_run_benchmark({
             "task": "humaneval", "user_id": "t", "providers": ["bedrock/x"],
         })
-    d = json.loads(r[0].text)
-    assert d["success"] is False
-    assert "does NOT support Kubernetes" in d["error"]
-    assert d["sandboxSupportsK8s"] is False
+
+    cmd = captured.get("cmd", [])
+    # The launched inspect command must carry -T sandbox=k8s.
+    assert "-T" in cmd and "sandbox=k8s" in cmd, f"cmd missing sandbox inject: {cmd}"
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_no_sandbox_inject_for_plain_qa():
+    """A non-sandbox benchmark (gsm8k) must NOT get a sandbox -T arg."""
+    import os
+    from unittest.mock import patch, AsyncMock
+    from eval_mcp.tools import benchmarks as bm
+
+    g = _Entry("gsm8k", group="Mathematics", tasks=[_Task("gsm8k")],
+               runtime_metadata=None)
+    captured = {}
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.wait = AsyncMock(return_value=0)
+        proc.pid = 4243
+        return proc
+
+    with patch.object(bm, "_load_evals", return_value=[g]), \
+         patch.object(bm, "raise_if_autodetect_error", lambda: None), \
+         patch.object(bm.asyncio, "create_subprocess_exec", side_effect=fake_exec), \
+         patch.dict(os.environ, {"INSPECT_SANDBOX_TYPE": "k8s"}, clear=False):
+        await bm.handle_run_benchmark({
+            "task": "gsm8k", "user_id": "t", "providers": ["bedrock/x"],
+        })
+
+    cmd = captured.get("cmd", [])
+    assert not any(c.startswith("sandbox=") for c in cmd), f"unexpected sandbox inject: {cmd}"
 
 
 def test_resolve_task_by_exact_task_name():


### PR DESCRIPTION
## Summary

Makes code-execution benchmarks (HumanEval, MBPP, DS-1000, …) **actually run** in the hosted deployment instead of being declined.

## Background

#124 made these benchmarks fail fast with "can't run here" because the guard treated `supports_k8s=False` as a hard block. But that was overly conservative: the deployment already ships the full sandbox stack — `inspect-k8s-sandbox` with a default `python:3.12-bookworm` image on the gVisor `runtimeClass` (`infra/platform/sandbox-security.tf`) — and a benchmark's `sandbox` is an overridable `-T` parameter.

**Verified live before this change:** ran HumanEval on the k8s sandbox directly in the pod — it spun up a gVisor-isolated pod, executed + verified generated code, accuracy 1.0.

## Change

For any benchmark whose `runtime_metadata.sandbox` is set, inject the resolved sandbox type as `-T sandbox=<type>` (`k8s` on EKS via `INSPECT_SANDBOX_TYPE`, `docker` locally) — unless the caller passed an explicit `sandbox` in `task_args`. Updated `get_benchmark_details` note + agent prompt to say these run normally (no more "can't run / use custom eval").

## Test plan

- [x] 15 benchmark tests pass (incl. new: sandbox injected for code eval, NOT injected for plain QA)
- [x] **Verified in prod (REV 15) via the real chat path**: "evaluate gpt 5.4 against sonnet 4.6 using humaneval" → both ran on the k8s sandbox, status=success, accuracy 1.0/1.0 (GPT-5.4 Mantle + Sonnet 4.6)
- [x] Deploy-then-merge: deployed + verified live before opening this PR