### PR TITLE
feat(mcp): GPT-5.6 (sol/terra/luna) + GPT-5.5 support on Bedrock Mantle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,19 @@ and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
 
 - Region resolution goes through `bedrock_client.resolve_region()`:
   `AWS_REGION` → `AWS_DEFAULT_REGION` → **the resolved profile's region** →
-  `us-west-2`. Never re-add a bare `os.environ.get("AWS_REGION", "us-west-2")` —
-  that ignores the user's profile and silently hides the us-east-only models.
+  `DEFAULT_REGION` (**us-east-2**). Never re-add a bare
+  `os.environ.get("AWS_REGION", ...)` for a Bedrock call — that ignores the
+  user's profile and silently hides the us-east-only models.
+- **`DEFAULT_REGION` is us-east-2, not us-west-2**, because that's the region
+  carrying the full model set: the Mantle frontier models are us-east-only, and
+  every current-generation Converse model (Claude Opus 5 / Sonnet 5 / Haiku 4.5 /
+  Sonnet 4.6, Nova, gpt-oss) is in us-east-2 too. Pinned by a test — don't
+  "tidy" it back to us-west-2.
+- **Storage regions are separate on purpose.** `core/user_storage.py`,
+  `core/s3_client.py` and `backend/core/database.py` keep their own
+  `AWS_REGION` fallback and must NOT use `resolve_region()` — they address S3
+  buckets and RDS whose location is fixed at deploy time. Pointing them at the
+  Bedrock region would send requests to resources that don't exist there.
 - Before concluding a model doesn't exist, check another region. `list_*` output
   is region-scoped, and a "not available" from one region is not evidence of
   absence. `run_eval` already reports this for you: a Mantle validation failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,27 @@ fails fast with an actionable message if a chosen model doesn't work with the ev
 pipeline. If you ever need the offline fallback prices to be more current, run
 `make sync-pricing` and review the diff.
 
+The same applies to the OpenAI frontier models on **Bedrock Mantle**
+(`openai/bedrock/<id>` — GPT-5.x, served on a separate OpenAI-compatible endpoint,
+NOT Converse, so they never appear in `list_foundation_models`). Those come from
+Mantle's live `/v1/models` catalog via `external_providers.list_mantle_models()`
+(10-min cache); the list in `EXTERNAL_PROVIDERS["bedrock-mantle"]` is only an
+offline fallback.
+
+**Region matters for these.** Mantle models launch region-by-region, so
+availability is per-region, not global — as of 2026-07-27 `gpt-5.5` and
+`gpt-5.6-sol` are us-east-1/us-east-2 only, while `gpt-5.6-terra`, `gpt-5.6-luna`
+and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
+
+- Region resolution goes through `bedrock_client.resolve_region()`:
+  `AWS_REGION` → `AWS_DEFAULT_REGION` → **the resolved profile's region** →
+  `us-west-2`. Never re-add a bare `os.environ.get("AWS_REGION", "us-west-2")` —
+  that ignores the user's profile and silently hides the us-east-only models.
+- Before concluding a model doesn't exist, check another region. `list_*` output
+  is region-scoped, and a "not available" from one region is not evidence of
+  absence. `run_eval` already reports this for you: a Mantle validation failure
+  probes the other regions and names the ones that do serve the model.
+
 ### Adding a tool
 
 1. Async handler in `eval_mcp/tools/<name>.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,10 +163,23 @@ and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
   an opaque IAM-auth failure instead of an honest error. A bucket/database is
   only ever configured together with an explicit `AWS_REGION` (both come from
   Helm/Terraform), and with no bucket set those modules never touch S3.
+- **Mantle models are auto-routed cross-region**, so GPT-5.x works for any user
+  regardless of where they are. Credentials are global and only the endpoint is
+  regional, so `external_providers.resolve_mantle_region()` sends a model the
+  caller's region doesn't serve to one that does; the decision is baked into the
+  config's `mantle_regions` map at creation time. Judges apply it per-model in
+  the generated task file; targets arrive via `--model` on the CLI, so
+  `run_eval._region_for_run()` moves the whole subprocess instead — the two
+  alternatives are dead ends (`-M aws_region=` is global and errors on Converse
+  models; `BEDROCK_OPENAI_BASE_URL` alone gives "Credential should be scoped to
+  a valid region" because the bearer token is still minted for the ambient
+  region). Only `openai/bedrock/*` inference moves — storage, logs and Converse
+  models stay put. `EVAL_MCP_MANTLE_REGION` pins a region;
+  `EVAL_MCP_NO_CROSS_REGION=1` disables the hop for data-residency constraints.
 - Before concluding a model doesn't exist, check another region. `list_*` output
   is region-scoped, and a "not available" from one region is not evidence of
-  absence. `run_eval` already reports this for you: a Mantle validation failure
-  probes the other regions and names the ones that do serve the model.
+  absence. `run_eval` also reports this: a Mantle validation failure probes the
+  other regions and names the ones that do serve the model.
 
 ### Adding a tool
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,11 +154,15 @@ and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
   every current-generation Converse model (Claude Opus 5 / Sonnet 5 / Haiku 4.5 /
   Sonnet 4.6, Nova, gpt-oss) is in us-east-2 too. Pinned by a test — don't
   "tidy" it back to us-west-2.
-- **Storage regions are separate on purpose.** `core/user_storage.py`,
-  `core/s3_client.py` and `backend/core/database.py` keep their own
-  `AWS_REGION` fallback and must NOT use `resolve_region()` — they address S3
-  buckets and RDS whose location is fixed at deploy time. Pointing them at the
-  Bedrock region would send requests to resources that don't exist there.
+- **There is exactly one default region, and it is Bedrock-only.**
+  `core/user_storage.py`, `core/s3_client.py` and `backend/core/database.py`
+  read `AWS_REGION` with **no fallback at all** (empty string) and must NOT use
+  `resolve_region()`. They address S3 buckets and RDS whose location is fixed
+  when created; the Bedrock region would point at resources that don't exist
+  there, and a guessed default would mean silently hitting the wrong bucket or
+  an opaque IAM-auth failure instead of an honest error. A bucket/database is
+  only ever configured together with an explicit `AWS_REGION` (both come from
+  Helm/Terraform), and with no bucket set those modules never touch S3.
 - Before concluding a model doesn't exist, check another region. `list_*` output
   is region-scoped, and a "not available" from one region is not evidence of
   absence. `run_eval` already reports this for you: a Mantle validation failure

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -206,8 +206,11 @@ async def lifespan(app: FastAPI):
     print("🚀 Initializing backend...")
 
     try:
-        # Get AWS region from environment
-        region = os.getenv("AWS_REGION", "us-west-2")
+        # Bedrock region — resolve_region() also honours the profile and
+        # defaults to us-east-2, where the full model set (incl. the
+        # us-east-only GPT-5.x models) is available.
+        from eval_mcp.core.bedrock_client import resolve_region
+        region = resolve_region()
 
         # Initialize database
         db = Database()

--- a/backend/core/chat.py
+++ b/backend/core/chat.py
@@ -1,6 +1,8 @@
 """Interactive chat/REPL interface."""
 
 
+from typing import Optional
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import InMemoryHistory
 from rich.console import Console
@@ -16,7 +18,7 @@ console = Console()
 class ChatInterface:
     """Interactive chat interface for eval MCP."""
 
-    def __init__(self, mcp_client: MultiMCPClient, debug: bool = False, region: str = "us-west-2") -> None:
+    def __init__(self, mcp_client: MultiMCPClient, debug: bool = False, region: Optional[str] = None) -> None:
         """Initialize chat interface."""
         self.mcp_client = mcp_client
         self.debug = debug

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -48,7 +48,13 @@ class Database:
         self.database = self._validate_db_name(_require_env("POSTGRES_DB"))
         self.user = _require_env("POSTGRES_USER")
         self.use_iam_auth = os.getenv("POSTGRES_USE_IAM_AUTH", "").lower() == "true"
-        self.region = os.getenv("AWS_REGION", "us-west-2")
+        # RDS region — no guessed default. This signs IAM auth tokens, and a
+        # token signed for the wrong region fails as an opaque auth error rather
+        # than a clear misconfiguration. Every sibling connection parameter above
+        # uses _require_env for the same reason. Unrelated to the Bedrock region
+        # (bedrock_client.DEFAULT_REGION = us-east-2): RDS lives where it was
+        # deployed, and Helm always sets AWS_REGION in the pod.
+        self.region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or ""
 
         # For IAM auth, track token generation time
         self._token_generated_at: float = 0

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -48,13 +48,26 @@ class Database:
         self.database = self._validate_db_name(_require_env("POSTGRES_DB"))
         self.user = _require_env("POSTGRES_USER")
         self.use_iam_auth = os.getenv("POSTGRES_USE_IAM_AUTH", "").lower() == "true"
-        # RDS region — no guessed default. This signs IAM auth tokens, and a
-        # token signed for the wrong region fails as an opaque auth error rather
-        # than a clear misconfiguration. Every sibling connection parameter above
-        # uses _require_env for the same reason. Unrelated to the Bedrock region
-        # (bedrock_client.DEFAULT_REGION = us-east-2): RDS lives where it was
-        # deployed, and Helm always sets AWS_REGION in the pod.
+        # RDS region — no guessed default, but required when it is actually used.
+        #
+        # Deliberately NOT the Bedrock region (bedrock_client.DEFAULT_REGION is
+        # us-east-2 so the us-east-only GPT-5.x models are reachable): RDS lives
+        # wherever it was deployed, and a token signed for the wrong region fails
+        # as an opaque auth error. Helm always sets AWS_REGION in the pod, so this
+        # only bites locally.
+        #
+        # Required only under IAM auth, which is the sole consumer. Left
+        # unvalidated it produced `Invalid endpoint: https://rds..amazonaws.com`
+        # — the cryptic failure this whole approach was meant to avoid.
         self.region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or ""
+        if self.use_iam_auth and not self.region:
+            raise RuntimeError(
+                "POSTGRES_USE_IAM_AUTH is enabled but no AWS region is set. "
+                "RDS IAM tokens must be signed for the region the database lives "
+                "in — set AWS_REGION (or AWS_DEFAULT_REGION) to that region. "
+                "Note this is the *database* region, which need not match the "
+                "Bedrock region used for model calls."
+            )
 
         # For IAM auth, track token generation time
         self._token_generated_at: float = 0

--- a/backend/core/mcp_client.py
+++ b/backend/core/mcp_client.py
@@ -45,7 +45,7 @@ def setup_mcp_logging(log_dir: str = "backend/logs") -> logging.Logger:
 class MultiMCPClient:
     """Client for interacting with multiple MCP servers with auto-reconnection."""
 
-    def __init__(self, working_dir: Optional[str] = None, region: str = "us-west-2") -> None:
+    def __init__(self, working_dir: Optional[str] = None, region: Optional[str] = None) -> None:
         """Initialize the MCP client with multiple servers.
 
         Args:
@@ -64,7 +64,12 @@ class MultiMCPClient:
         # Get current environment and merge with custom vars
         env = os.environ.copy()
         env["INSPECT_LOG_DIR"] = cwd
-        env["AWS_REGION"] = region
+        # resolve_region() honours AWS_REGION / AWS_DEFAULT_REGION / the
+        # profile, then falls back to us-east-2 (the region with the full
+        # model set, incl. the us-east-only GPT-5.x models). Passing None
+        # through to the subprocess env would set the literal "None".
+        from eval_mcp.core.bedrock_client import resolve_region
+        env["AWS_REGION"] = resolve_region(region)
 
         # Single unified MCP server
         self._server_configs = {

--- a/eval_mcp/core/bedrock_client.py
+++ b/eval_mcp/core/bedrock_client.py
@@ -173,7 +173,56 @@ def raise_if_autodetect_error() -> None:
         raise err
 
 
-def create_boto3_bedrock_client(service: str = "bedrock-runtime", region: str = "us-west-2", **extra_config):
+DEFAULT_REGION = "us-west-2"
+
+# Model-id fragments identifying reasoning models that reject a `temperature`
+# parameter outright (HTTP 400 unsupported_parameter, not a soft warning).
+# Verified live against Bedrock Mantle: openai.gpt-5.6-{sol,luna,terra} and
+# openai.gpt-5.5 all fail with `'temperature' is not supported with this model`.
+_NO_TEMPERATURE_FRAGMENTS = ("gpt-5", "o1-", "o3-", "o4-")
+
+
+def model_rejects_temperature(model_id: str) -> bool:
+    """True when a model refuses a `temperature` parameter.
+
+    Matched on id fragments rather than an exhaustive list so a future gpt-5.7
+    is handled without a code change — the failure mode of guessing wrong is
+    only a lost determinism hint, whereas sending the field to a model that
+    forbids it is a hard 400.
+    """
+    lowered = model_id.lower()
+    return any(frag in lowered for frag in _NO_TEMPERATURE_FRAGMENTS)
+
+
+def resolve_region(explicit: Optional[str] = None) -> str:
+    """Resolve which AWS region to use for Bedrock calls.
+
+    Precedence: explicit argument, then ``AWS_REGION``, then
+    ``AWS_DEFAULT_REGION``, then the **resolved profile's** region from
+    ``~/.aws/config``, then ``DEFAULT_REGION``.
+
+    The profile step matters: models are not launched in every region at once
+    (e.g. OpenAI's gpt-5.5 and gpt-5.6-sol are us-east-1/us-east-2 only). A user
+    whose profile says ``region = us-east-2`` used to still get us-west-2
+    because every call site read ``os.environ`` directly and ignored the
+    profile, making those models unreachable with no way to say otherwise short
+    of exporting AWS_REGION. Honouring the profile is also what every other AWS
+    tool does, so this just stops us being the odd one out.
+    """
+    if explicit:
+        return explicit
+    env_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    if env_region:
+        return env_region
+    _autodetect_aws_profile()
+    try:
+        session_region = boto3.Session().region_name
+    except Exception:
+        session_region = None
+    return session_region or DEFAULT_REGION
+
+
+def create_boto3_bedrock_client(service: str = "bedrock-runtime", region: Optional[str] = None, **extra_config):
     """Create a boto3 Bedrock client with API key support if configured.
 
     When AWS_BEARER_TOKEN_BEDROCK is set, creates a client that uses bearer token
@@ -182,7 +231,7 @@ def create_boto3_bedrock_client(service: str = "bedrock-runtime", region: str = 
     _autodetect_aws_profile()
     bearer_token = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
     config_kwargs = {
-        "region_name": region,
+        "region_name": resolve_region(region),
         "retries": {"max_attempts": 10, "mode": "adaptive"},
         **extra_config,
     }
@@ -212,31 +261,60 @@ class BedrockClient:
 
     _instances: Dict[str, "BedrockClient"] = {}
 
-    def __new__(cls, region: str = "us-west-2") -> "BedrockClient":
+    def __new__(cls, region: Optional[str] = None) -> "BedrockClient":
         """Singleton: Return existing instance for this region if it exists."""
+        # Resolve before keying the cache so `BedrockClient()` and
+        # `BedrockClient("us-east-2")` share one instance when the environment
+        # already points at us-east-2.
+        region = resolve_region(region)
         if region not in cls._instances:
             instance = super().__new__(cls)
             cls._instances[region] = instance
             instance._initialized = False
         return cls._instances[region]
 
-    def __init__(self, region: str = "us-west-2") -> None:
+    def __init__(self, region: Optional[str] = None) -> None:
         """Initialize Bedrock client (only once per region)."""
         if self._initialized:
             return
 
-        self.region = region
+        self.region = resolve_region(region)
         self.model_id = os.environ.get(
             "BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-6"
         )
 
         self.client = create_boto3_bedrock_client(
-            "bedrock-runtime", region,
+            "bedrock-runtime", self.region,
             max_pool_connections=100,
             read_timeout=300,  # 5 minutes for PDF processing
             connect_timeout=30,
         )
         self._initialized = True
+
+    def _build_request_body(
+        self,
+        messages: List[Dict[str, Any]],
+        max_tokens: int,
+        temperature: Optional[float],
+    ) -> Dict[str, Any]:
+        """Assemble the Anthropic Messages request body.
+
+        ``temperature`` is omitted when None **or** when the configured model is
+        a reasoning model that rejects the field. Reasoning models (OpenAI's
+        gpt-5.6 family on Mantle, and Bedrock reasoning variants) return
+        ``400 unsupported_parameter`` if `temperature` is present at all — not a
+        warning, a hard failure. Callers pass a temperature for reproducibility,
+        which is right for Claude; dropping it for models that forbid it keeps a
+        BEDROCK_MODEL_ID override from breaking every synthesis call.
+        """
+        body: Dict[str, Any] = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": max_tokens,
+            "messages": messages,
+        }
+        if temperature is not None and not model_rejects_temperature(self.model_id):
+            body["temperature"] = temperature
+        return body
 
     def convert_mcp_tools_to_claude(self, mcp_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
@@ -269,7 +347,7 @@ class BedrockClient:
         tool_choice: Optional[Dict[str, Any]] = None,
         system: Optional[str] = None,
         max_tokens: int = 8192,
-        temperature: float = 0.0,
+        temperature: Optional[float] = 0.0,
     ) -> Dict[str, Any]:
         """
         Send a message to Claude and get response.
@@ -283,18 +361,15 @@ class BedrockClient:
                 - {"type": "tool", "name": "tool_name"} - force specific tool
             system: Optional system prompt
             max_tokens: Maximum tokens in response
-            temperature: Sampling temperature (0.0 = deterministic, default for reproducibility)
+            temperature: Sampling temperature (0.0 = deterministic, default for
+                reproducibility). Pass None to omit the field entirely — some
+                reasoning models reject `temperature` outright.
 
         Returns:
             Response dict from Claude
         """
         raise_if_autodetect_error()
-        request_body = {
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "messages": messages,
-        }
+        request_body = self._build_request_body(messages, max_tokens, temperature)
 
         if system:
             request_body["system"] = system
@@ -332,7 +407,7 @@ class BedrockClient:
         tool_choice: Optional[Dict[str, Any]] = None,
         system: Optional[str] = None,
         max_tokens: int = 8192,
-        temperature: float = 0.0,
+        temperature: Optional[float] = 0.0,
     ):
         """
         Stream a message response from Claude token-by-token.
@@ -344,12 +419,7 @@ class BedrockClient:
         raise_if_autodetect_error()
         import asyncio
 
-        request_body = {
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "messages": messages,
-        }
+        request_body = self._build_request_body(messages, max_tokens, temperature)
 
         if system:
             request_body["system"] = system
@@ -431,11 +501,30 @@ class BedrockClient:
                 }
 
     def extract_text_from_response(self, response: Dict[str, Any]) -> str:
-        """Extract text content from Claude response."""
-        content = response.get("content", [])
+        """Extract text content from a Claude (Anthropic Messages) response.
+
+        Raises ValueError when handed a response that isn't in Anthropic shape —
+        which in practice means BEDROCK_MODEL_ID points at a non-Anthropic model.
+        This path builds a native Anthropic Messages body, so an OpenAI-shaped
+        model (gpt-oss, which Bedrock happily serves) returns HTTP 200 with a
+        `choices` array and no `content` key. Returning "" there was the worst
+        outcome available: callers took the empty string as a legitimate answer
+        and downstream JSON parsing failed somewhere unrelated, with nothing
+        pointing back at the real cause. Failing loudly names the actual problem.
+        """
+        if "content" not in response:
+            raise ValueError(
+                "Bedrock response is not in Anthropic Messages format "
+                f"(got keys: {sorted(response)}). The internal synthesis client "
+                f"only speaks the Anthropic Messages API, but BEDROCK_MODEL_ID is "
+                f"'{self.model_id}'. Set BEDROCK_MODEL_ID to an Anthropic model "
+                "(e.g. us.anthropic.claude-sonnet-4-6). Non-Anthropic models are "
+                "fully supported as evaluation targets and judges — this limit "
+                "applies only to the MCP's own synthesis calls."
+            )
 
         text_parts = []
-        for block in content:
+        for block in response.get("content", []):
             if block.get("type") == "text":
                 text_parts.append(block.get("text", ""))
 

--- a/eval_mcp/core/bedrock_client.py
+++ b/eval_mcp/core/bedrock_client.py
@@ -173,7 +173,21 @@ def raise_if_autodetect_error() -> None:
         raise err
 
 
-DEFAULT_REGION = "us-west-2"
+# Fallback region when nothing else specifies one (no AWS_REGION, no
+# AWS_DEFAULT_REGION, no region in the resolved profile).
+#
+# us-east-2 rather than us-west-2 because it is the only tier that carries the
+# FULL model set we care about: OpenAI's frontier models on Bedrock Mantle
+# (gpt-5.5, gpt-5.6-sol) launched in us-east-1/us-east-2 ONLY, while every
+# current-generation Converse model — Claude Opus 5, Sonnet 5, Haiku 4.5,
+# Sonnet 4.6, Nova, gpt-oss — is present in us-east-2 exactly as in us-west-2
+# (verified 2026-07-27: 81 vs 86 models, the difference being retired Llama 3.0
+# and Mistral 2402/2407 variants). Defaulting to us-west-2 made two frontier
+# models unreachable and had us report they did not exist.
+#
+# This is only a last resort: an explicit AWS_REGION or a profile region always
+# wins, so nobody's existing setup moves.
+DEFAULT_REGION = "us-east-2"
 
 # Model-id fragments identifying reasoning models that reject a `temperature`
 # parameter outright (HTTP 400 unsupported_parameter, not a soft warning).

--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -659,7 +659,15 @@ def _build_detail_from_logs(
         if task_file:
             config_filename = Path(task_file).with_suffix(".json").name
         else:
-            config_filename = f"{config_name}.json"
+            # No task_file in the log metadata — this is the benchmark path,
+            # where the task is a package reference ("inspect_evals/humaneval")
+            # rather than a generated config in configs/. `config_name` was
+            # never defined in this function, so this branch raised NameError
+            # and killed the whole pre-compute: benchmark runs succeeded but
+            # their results never reached the viewer. Derive the name from
+            # task_name instead; there won't be a matching config JSON for a
+            # benchmark, and the os.path.isfile check below handles that.
+            config_filename = f"{task_name}.json"
         # Filename is user-derived (from log metadata / config name); strip any
         # path components via basename before joining so the result stays under
         # configs_real.

--- a/eval_mcp/core/litellm_pricing_snapshot.json
+++ b/eval_mcp/core/litellm_pricing_snapshot.json
@@ -251,6 +251,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.5e-05
 },
+"anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.5e-05
+},
 "anthropic.claude-sonnet-4-20250514-v1:0": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -271,6 +278,13 @@
 "input_cost_per_token": 3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.5e-05
+},
+"anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1e-05
 },
 "anthropic.claude-v1": {
 "cache_creation_input_token_cost": null,
@@ -475,6 +489,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.75e-05
 },
+"au.anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.75e-05
+},
 "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 "cache_creation_input_token_cost": 4.125e-06,
 "cache_read_input_token_cost": 3.3e-07,
@@ -488,6 +509,13 @@
 "input_cost_per_token": 3.3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.65e-05
+},
+"au.anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.75e-06,
+"cache_read_input_token_cost": 2.2e-07,
+"input_cost_per_token": 2.2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1.1e-05
 },
 "azure/codex-mini": {
 "cache_creation_input_token_cost": null,
@@ -530,27 +558,6 @@
 "input_cost_per_token": 1.65e-07,
 "litellm_provider": "azure",
 "output_cost_per_token": 6.6e-07
-},
-"azure/eu/gpt-4o-mini-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 3.3e-07,
-"input_cost_per_token": 6.6e-07,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.64e-06
-},
-"azure/eu/gpt-4o-realtime-preview-2024-10-01": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.75e-06,
-"input_cost_per_token": 5.5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.2e-05
-},
-"azure/eu/gpt-4o-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.75e-06,
-"input_cost_per_token": 5.5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.2e-05
 },
 "azure/eu/gpt-5-2025-08-07": {
 "cache_creation_input_token_cost": null,
@@ -600,6 +607,62 @@
 "input_cost_per_token": 2.75e-07,
 "litellm_provider": "azure",
 "output_cost_per_token": 2.2e-06
+},
+"azure/eu/gpt-5.4": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.8e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
+},
+"azure/eu/gpt-5.4-2026-03-05": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.8e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
+},
+"azure/eu/gpt-5.5": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/eu/gpt-5.5-2026-04-23": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/eu/gpt-5.6": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/eu/gpt-5.6-luna": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.1e-07,
+"input_cost_per_token": 1.1e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 6.6e-06
+},
+"azure/eu/gpt-5.6-sol": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/eu/gpt-5.6-terra": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.75e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
 },
 "azure/eu/o1-2024-12-17": {
 "cache_creation_input_token_cost": null,
@@ -930,27 +993,6 @@
 "litellm_provider": "azure",
 "output_cost_per_token": 1e-05
 },
-"azure/gpt-4o-mini-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 3e-07,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.4e-06
-},
-"azure/gpt-4o-realtime-preview-2024-10-01": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.5e-06,
-"input_cost_per_token": 5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2e-05
-},
-"azure/gpt-4o-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.5e-06,
-"input_cost_per_token": 5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2e-05
-},
 "azure/gpt-5": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": 1.25e-07,
@@ -1231,6 +1273,34 @@
 "litellm_provider": "azure",
 "output_cost_per_token": 0.00018
 },
+"azure/gpt-5.6": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3e-05
+},
+"azure/gpt-5.6-luna": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1e-07,
+"input_cost_per_token": 1e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 6e-06
+},
+"azure/gpt-5.6-sol": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3e-05
+},
+"azure/gpt-5.6-terra": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.5e-07,
+"input_cost_per_token": 2.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.5e-05
+},
 "azure/gpt-audio-1.5-2026-02-23": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -1248,27 +1318,6 @@
 "azure/gpt-audio-mini-2025-10-06": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.4e-06
-},
-"azure/gpt-realtime-1.5-2026-02-23": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-06,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 1.6e-05
-},
-"azure/gpt-realtime-2025-08-28": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-06,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 1.6e-05
-},
-"azure/gpt-realtime-mini-2025-10-06": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 6e-08,
 "input_cost_per_token": 6e-07,
 "litellm_provider": "azure",
 "output_cost_per_token": 2.4e-06
@@ -1434,27 +1483,6 @@
 "litellm_provider": "azure",
 "output_cost_per_token": 6.6e-07
 },
-"azure/us/gpt-4o-mini-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 3.3e-07,
-"input_cost_per_token": 6.6e-07,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.64e-06
-},
-"azure/us/gpt-4o-realtime-preview-2024-10-01": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.75e-06,
-"input_cost_per_token": 5.5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.2e-05
-},
-"azure/us/gpt-4o-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.75e-06,
-"input_cost_per_token": 5.5e-06,
-"litellm_provider": "azure",
-"output_cost_per_token": 2.2e-05
-},
 "azure/us/gpt-5-2025-08-07": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": 1.375e-07,
@@ -1503,6 +1531,62 @@
 "input_cost_per_token": 2.75e-07,
 "litellm_provider": "azure",
 "output_cost_per_token": 2.2e-06
+},
+"azure/us/gpt-5.4": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.8e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
+},
+"azure/us/gpt-5.4-2026-03-05": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.8e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
+},
+"azure/us/gpt-5.5": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/us/gpt-5.5-2026-04-23": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/us/gpt-5.6": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/us/gpt-5.6-luna": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.1e-07,
+"input_cost_per_token": 1.1e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 6.6e-06
+},
+"azure/us/gpt-5.6-sol": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 3.3e-05
+},
+"azure/us/gpt-5.6-terra": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.75e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "azure",
+"output_cost_per_token": 1.65e-05
 },
 "azure/us/o1-2024-12-17": {
 "cache_creation_input_token_cost": null,
@@ -1763,6 +1847,13 @@
 "litellm_provider": "azure_ai",
 "output_cost_per_token": 2.5e-05
 },
+"azure_ai/claude-opus-5": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "azure_ai",
+"output_cost_per_token": 2.5e-05
+},
 "azure_ai/claude-sonnet-4-5": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -1776,6 +1867,13 @@
 "input_cost_per_token": 3e-06,
 "litellm_provider": "azure_ai",
 "output_cost_per_token": 1.5e-05
+},
+"azure_ai/claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "azure_ai",
+"output_cost_per_token": 1e-05
 },
 "azure_ai/deepseek-r1": {
 "cache_creation_input_token_cost": null,
@@ -3051,6 +3149,27 @@
 "litellm_provider": "bedrock_mantle",
 "output_cost_per_token": 3.3e-05
 },
+"bedrock_mantle/openai.gpt-5.6-luna": {
+"cache_creation_input_token_cost": 1.375e-06,
+"cache_read_input_token_cost": 1.1e-07,
+"input_cost_per_token": 1.1e-06,
+"litellm_provider": "bedrock_mantle",
+"output_cost_per_token": 6.6e-06
+},
+"bedrock_mantle/openai.gpt-5.6-sol": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_mantle",
+"output_cost_per_token": 3.3e-05
+},
+"bedrock_mantle/openai.gpt-5.6-terra": {
+"cache_creation_input_token_cost": 3.4375e-06,
+"cache_read_input_token_cost": 2.75e-07,
+"input_cost_per_token": 2.75e-06,
+"litellm_provider": "bedrock_mantle",
+"output_cost_per_token": 1.65e-05
+},
 "bedrock_mantle/openai.gpt-oss-120b": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -3078,6 +3197,13 @@
 "input_cost_per_token": 7.5e-08,
 "litellm_provider": "bedrock_mantle",
 "output_cost_per_token": 3e-07
+},
+"bedrock_mantle/xai.grok-4.3": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 1.25e-06,
+"litellm_provider": "bedrock_mantle",
+"output_cost_per_token": 2.5e-06
 },
 "cerebras/gpt-oss-120b": {
 "cache_creation_input_token_cost": null,
@@ -3268,6 +3394,13 @@
 "litellm_provider": "anthropic",
 "output_cost_per_token": 2.5e-05
 },
+"claude-opus-5": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "anthropic",
+"output_cost_per_token": 2.5e-05
+},
 "claude-sonnet-4-20250514": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -3303,6 +3436,62 @@
 "litellm_provider": "anthropic",
 "output_cost_per_token": 1.5e-05
 },
+"claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "anthropic",
+"output_cost_per_token": 1e-05
+},
+"cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3.51e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 5.55e-07
+},
+"cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 4.97e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 4.881e-06
+},
+"cloudflare/@cf/google/gemma-2b-it-lora": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 0.0,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 0.0
+},
+"cloudflare/@cf/google/gemma-4-26b-a4b-it": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 3e-07
+},
+"cloudflare/@cf/google/gemma-7b-it-lora": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 0.0,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 0.0
+},
+"cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.7e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 1.12e-07
+},
+"cloudflare/@cf/meta-llama/llama-2-7b-chat-hf-lora": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 0.0,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 0.0
+},
 "cloudflare/@cf/meta/llama-2-7b-chat-fp16": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -3317,12 +3506,145 @@
 "litellm_provider": "cloudflare",
 "output_cost_per_token": 1.923e-06
 },
+"cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.52e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 2.87e-07
+},
+"cloudflare/@cf/meta/llama-3.2-11b-vision-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 4.85e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 6.76e-07
+},
+"cloudflare/@cf/meta/llama-3.2-1b-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 2.7e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 2.01e-07
+},
+"cloudflare/@cf/meta/llama-3.2-3b-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 5.09e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 3.35e-07
+},
+"cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 2.93e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 2.253e-06
+},
+"cloudflare/@cf/meta/llama-4-scout-17b-16e-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 2.7e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 8.5e-07
+},
+"cloudflare/@cf/meta/llama-guard-3-8b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 4.84e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 3e-08
+},
 "cloudflare/@cf/mistral/mistral-7b-instruct-v0.1": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
 "input_cost_per_token": 1.923e-06,
 "litellm_provider": "cloudflare",
 "output_cost_per_token": 1.923e-06
+},
+"cloudflare/@cf/mistral/mistral-7b-instruct-v0.2-lora": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 0.0,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 0.0
+},
+"cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3.51e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 5.55e-07
+},
+"cloudflare/@cf/moonshotai/kimi-k2.6": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.6e-07,
+"input_cost_per_token": 9.5e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 4e-06
+},
+"cloudflare/@cf/moonshotai/kimi-k2.7-code": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.9e-07,
+"input_cost_per_token": 9.5e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 4e-06
+},
+"cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 5e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 1.5e-06
+},
+"cloudflare/@cf/openai/gpt-oss-120b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3.5e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 7.5e-07
+},
+"cloudflare/@cf/openai/gpt-oss-20b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 2e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 3e-07
+},
+"cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 6.6e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 1e-06
+},
+"cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 5.09e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 3.35e-07
+},
+"cloudflare/@cf/qwen/qwq-32b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 6.6e-07,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 1e-06
+},
+"cloudflare/@cf/zai-org/glm-4.7-flash": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 6.05e-08,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 4e-07
+},
+"cloudflare/@cf/zai-org/glm-5.2": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 2.6e-07,
+"input_cost_per_token": 1.4e-06,
+"litellm_provider": "cloudflare",
+"output_cost_per_token": 4.4e-06
 },
 "cloudflare/@hf/thebloke/codellama-7b-instruct-awq": {
 "cache_creation_input_token_cost": null,
@@ -3498,6 +3820,20 @@
 "input_cost_per_token": 8e-07,
 "litellm_provider": "crusoe",
 "output_cost_per_token": 8e-07
+},
+"darkbloom/gemma-4-26b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3e-08,
+"litellm_provider": "darkbloom",
+"output_cost_per_token": 1.65e-07
+},
+"darkbloom/gpt-oss-20b": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.45e-08,
+"litellm_provider": "darkbloom",
+"output_cost_per_token": 7e-08
 },
 "dashscope/qwen-coder": {
 "cache_creation_input_token_cost": null,
@@ -4528,6 +4864,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.75e-05
 },
+"eu.anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.75e-05
+},
 "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -4548,6 +4891,13 @@
 "input_cost_per_token": 3.3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.65e-05
+},
+"eu.anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.75e-06,
+"cache_read_input_token_cost": 2.2e-07,
+"input_cost_per_token": 2.2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1.1e-05
 },
 "eu.deepseek.v3.2": {
 "cache_creation_input_token_cost": null,
@@ -5174,7 +5524,7 @@
 },
 "fireworks_ai/accounts/fireworks/models/glm-5p2": {
 "cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.6e-07,
+"cache_read_input_token_cost": 1.4e-07,
 "input_cost_per_token": 1.4e-06,
 "litellm_provider": "fireworks_ai",
 "output_cost_per_token": 4.4e-06
@@ -6441,7 +6791,7 @@
 },
 "fireworks_ai/glm-5p2": {
 "cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.6e-07,
+"cache_read_input_token_cost": 1.4e-07,
 "input_cost_per_token": 1.4e-06,
 "litellm_provider": "fireworks_ai",
 "output_cost_per_token": 4.4e-06
@@ -6796,6 +7146,20 @@
 "litellm_provider": "vertex_ai-language-models",
 "output_cost_per_token": 9e-06
 },
+"gemini-3.5-flash-lite": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 3e-08,
+"input_cost_per_token": 3e-07,
+"litellm_provider": "vertex_ai-language-models",
+"output_cost_per_token": 2.5e-06
+},
+"gemini-3.6-flash": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.5e-07,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "vertex_ai-language-models",
+"output_cost_per_token": 7.5e-06
+},
 "gemini-exp-1206": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": 3e-08,
@@ -6816,6 +7180,13 @@
 "input_cost_per_token": 1e-07,
 "litellm_provider": "gemini",
 "output_cost_per_token": 4e-07
+},
+"gemini-omni-flash-preview": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "vertex_ai-language-models",
+"output_cost_per_token": 9e-06
 },
 "gemini-pro-latest": {
 "cache_creation_input_token_cost": null,
@@ -6992,6 +7363,20 @@
 "litellm_provider": "gemini",
 "output_cost_per_token": 9e-06
 },
+"gemini/gemini-3.5-flash-lite": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 3e-08,
+"input_cost_per_token": 3e-07,
+"litellm_provider": "gemini",
+"output_cost_per_token": 2.5e-06
+},
+"gemini/gemini-3.6-flash": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.5e-07,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "gemini",
+"output_cost_per_token": 7.5e-06
+},
 "gemini/gemini-exp-1114": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -7033,6 +7418,13 @@
 "input_cost_per_token": 3.5e-07,
 "litellm_provider": "gemini",
 "output_cost_per_token": 1.05e-06
+},
+"gemini/gemini-omni-flash-preview": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "gemini",
+"output_cost_per_token": 9e-06
 },
 "gemini/gemini-pro-latest": {
 "cache_creation_input_token_cost": null,
@@ -7167,6 +7559,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.5e-05
 },
+"global.anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.5e-05
+},
 "global.anthropic.claude-sonnet-4-20250514-v1:0": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -7187,6 +7586,13 @@
 "input_cost_per_token": 3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.5e-05
+},
+"global.anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1e-05
 },
 "gmi/MiniMaxAI/MiniMax-M2.1": {
 "cache_creation_input_token_cost": null,
@@ -7545,20 +7951,6 @@
 "litellm_provider": "openai",
 "output_cost_per_token": 6e-07
 },
-"gpt-4o-mini-realtime-preview": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 3e-07,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "openai",
-"output_cost_per_token": 2.4e-06
-},
-"gpt-4o-mini-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 3e-07,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "openai",
-"output_cost_per_token": 2.4e-06
-},
 "gpt-4o-mini-search-preview": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": 7.5e-08,
@@ -7572,27 +7964,6 @@
 "input_cost_per_token": 1.5e-07,
 "litellm_provider": "openai",
 "output_cost_per_token": 6e-07
-},
-"gpt-4o-realtime-preview": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.5e-06,
-"input_cost_per_token": 5e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 2e-05
-},
-"gpt-4o-realtime-preview-2024-12-17": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.5e-06,
-"input_cost_per_token": 5e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 2e-05
-},
-"gpt-4o-realtime-preview-2025-06-03": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 2.5e-06,
-"input_cost_per_token": 5e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 2e-05
 },
 "gpt-4o-search-preview": {
 "cache_creation_input_token_cost": null,
@@ -7881,6 +8252,34 @@
 "litellm_provider": "openai",
 "output_cost_per_token": 0.00018
 },
+"gpt-5.6": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "openai",
+"output_cost_per_token": 3e-05
+},
+"gpt-5.6-luna": {
+"cache_creation_input_token_cost": 1.25e-06,
+"cache_read_input_token_cost": 1e-07,
+"input_cost_per_token": 1e-06,
+"litellm_provider": "openai",
+"output_cost_per_token": 6e-06
+},
+"gpt-5.6-sol": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "openai",
+"output_cost_per_token": 3e-05
+},
+"gpt-5.6-terra": {
+"cache_creation_input_token_cost": 3.125e-06,
+"cache_read_input_token_cost": 2.5e-07,
+"input_cost_per_token": 2.5e-06,
+"litellm_provider": "openai",
+"output_cost_per_token": 1.5e-05
+},
 "gpt-audio": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -7919,55 +8318,6 @@
 "gpt-audio-mini-2025-12-15": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "openai",
-"output_cost_per_token": 2.4e-06
-},
-"gpt-realtime": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-07,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 1.6e-05
-},
-"gpt-realtime-1.5": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-07,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 1.6e-05
-},
-"gpt-realtime-2": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-07,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 1.6e-05
-},
-"gpt-realtime-2025-08-28": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 4e-07,
-"input_cost_per_token": 4e-06,
-"litellm_provider": "openai",
-"output_cost_per_token": 1.6e-05
-},
-"gpt-realtime-mini": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": null,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "openai",
-"output_cost_per_token": 2.4e-06
-},
-"gpt-realtime-mini-2025-10-06": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 6e-08,
-"input_cost_per_token": 6e-07,
-"litellm_provider": "openai",
-"output_cost_per_token": 2.4e-06
-},
-"gpt-realtime-mini-2025-12-15": {
-"cache_creation_input_token_cost": null,
-"cache_read_input_token_cost": 6e-08,
 "input_cost_per_token": 6e-07,
 "litellm_provider": "openai",
 "output_cost_per_token": 2.4e-06
@@ -8336,6 +8686,20 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.75e-05
 },
+"jp.anthropic.claude-opus-4-8": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.75e-05
+},
+"jp.anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.75e-05
+},
 "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 "cache_creation_input_token_cost": 4.125e-06,
 "cache_read_input_token_cost": 3.3e-07,
@@ -8349,6 +8713,13 @@
 "input_cost_per_token": 3.3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.65e-05
+},
+"jp.anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.75e-06,
+"cache_read_input_token_cost": 2.2e-07,
+"input_cost_per_token": 2.2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1.1e-05
 },
 "kimi-k2-thinking-251104": {
 "cache_creation_input_token_cost": null,
@@ -8805,6 +9176,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 6.6e-07
 },
+"meta/muse-spark-1.1": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.5e-07,
+"input_cost_per_token": 1.25e-06,
+"litellm_provider": "meta",
+"output_cost_per_token": 4.25e-06
+},
 "minimax.minimax-m2": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -9190,6 +9568,20 @@
 "litellm_provider": "mistral",
 "output_cost_per_token": 2e-06
 },
+"mistral/mistral-medium-2508": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 4e-07,
+"litellm_provider": "mistral",
+"output_cost_per_token": 2e-06
+},
+"mistral/mistral-medium-2604": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "mistral",
+"output_cost_per_token": 7.5e-06
+},
 "mistral/mistral-medium-3-1-2508": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -9207,9 +9599,9 @@
 "mistral/mistral-medium-latest": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
-"input_cost_per_token": 4e-07,
+"input_cost_per_token": 1.5e-06,
 "litellm_provider": "mistral",
-"output_cost_per_token": 2e-06
+"output_cost_per_token": 7.5e-06
 },
 "mistral/mistral-small": {
 "cache_creation_input_token_cost": null,
@@ -11612,6 +12004,13 @@
 "litellm_provider": "openrouter",
 "output_cost_per_token": 2.56e-06
 },
+"openrouter/z-ai/glm-5.1": {
+"cache_creation_input_token_cost": 0.0,
+"cache_read_input_token_cost": 5.25e-07,
+"input_cost_per_token": 1.05e-06,
+"litellm_provider": "openrouter",
+"output_cost_per_token": 3.5e-06
+},
 "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -12403,6 +12802,13 @@
 "litellm_provider": "sambanova",
 "output_cost_per_token": 4.5e-06
 },
+"sambanova/DeepSeek-V3.2": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3e-06,
+"litellm_provider": "sambanova",
+"output_cost_per_token": 4.5e-06
+},
 "sambanova/Llama-4-Maverick-17B-128E-Instruct": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -12462,9 +12868,9 @@
 "sambanova/MiniMax-M2.7": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
-"input_cost_per_token": 3e-07,
+"input_cost_per_token": 6e-07,
 "litellm_provider": "sambanova",
-"output_cost_per_token": 1.2e-06
+"output_cost_per_token": 2.4e-06
 },
 "sambanova/QwQ-32B": {
 "cache_creation_input_token_cost": null,
@@ -12487,12 +12893,19 @@
 "litellm_provider": "sambanova",
 "output_cost_per_token": 8e-07
 },
+"sambanova/gemma-4-31B-it": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": null,
+"input_cost_per_token": 3.8e-07,
+"litellm_provider": "sambanova",
+"output_cost_per_token": 1.15e-06
+},
 "sambanova/gpt-oss-120b": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
-"input_cost_per_token": 3e-06,
+"input_cost_per_token": 2.2e-07,
 "litellm_provider": "sambanova",
-"output_cost_per_token": 4.5e-06
+"output_cost_per_token": 5.9e-07
 },
 "sarvam/sarvam-m": {
 "cache_creation_input_token_cost": 0,
@@ -12731,6 +13144,20 @@
 "input_cost_per_token": 7.2e-07,
 "litellm_provider": "snowflake",
 "output_cost_per_token": 7.2e-07
+},
+"tencent/deepseek-v4-flash": {
+"cache_creation_input_token_cost": 0.0,
+"cache_read_input_token_cost": 2.8e-09,
+"input_cost_per_token": 1.4e-07,
+"litellm_provider": "tencent",
+"output_cost_per_token": 2.8e-07
+},
+"tencent/deepseek-v4-pro": {
+"cache_creation_input_token_cost": 0.0,
+"cache_read_input_token_cost": 3.625e-09,
+"input_cost_per_token": 4.35e-07,
+"litellm_provider": "tencent",
+"output_cost_per_token": 8.7e-07
 },
 "tensormesh/MiniMaxAI/MiniMax-M2.5": {
 "cache_creation_input_token_cost": null,
@@ -13222,6 +13649,13 @@
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 2.75e-05
 },
+"us.anthropic.claude-opus-5": {
+"cache_creation_input_token_cost": 6.875e-06,
+"cache_read_input_token_cost": 5.5e-07,
+"input_cost_per_token": 5.5e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 2.75e-05
+},
 "us.anthropic.claude-sonnet-4-20250514-v1:0": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -13242,6 +13676,13 @@
 "input_cost_per_token": 3.3e-06,
 "litellm_provider": "bedrock_converse",
 "output_cost_per_token": 1.65e-05
+},
+"us.anthropic.claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.75e-06,
+"cache_read_input_token_cost": 2.2e-07,
+"input_cost_per_token": 2.2e-06,
+"litellm_provider": "bedrock_converse",
+"output_cost_per_token": 1.1e-05
 },
 "us.deepseek.r1-v1:0": {
 "cache_creation_input_token_cost": null,
@@ -14223,6 +14664,20 @@
 "litellm_provider": "vertex_ai-anthropic_models",
 "output_cost_per_token": 7.5e-05
 },
+"vertex_ai/claude-opus-5": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "vertex_ai-anthropic_models",
+"output_cost_per_token": 2.5e-05
+},
+"vertex_ai/claude-opus-5@default": {
+"cache_creation_input_token_cost": 6.25e-06,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 5e-06,
+"litellm_provider": "vertex_ai-anthropic_models",
+"output_cost_per_token": 2.5e-05
+},
 "vertex_ai/claude-sonnet-4": {
 "cache_creation_input_token_cost": 3.75e-06,
 "cache_read_input_token_cost": 3e-07,
@@ -14264,6 +14719,20 @@
 "input_cost_per_token": 3e-06,
 "litellm_provider": "vertex_ai-anthropic_models",
 "output_cost_per_token": 1.5e-05
+},
+"vertex_ai/claude-sonnet-5": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "vertex_ai-anthropic_models",
+"output_cost_per_token": 1e-05
+},
+"vertex_ai/claude-sonnet-5@default": {
+"cache_creation_input_token_cost": 2.5e-06,
+"cache_read_input_token_cost": 2e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "vertex_ai-anthropic_models",
+"output_cost_per_token": 1e-05
 },
 "vertex_ai/codestral-2": {
 "cache_creation_input_token_cost": null,
@@ -14369,6 +14838,20 @@
 "input_cost_per_token": 1.5e-06,
 "litellm_provider": "vertex_ai",
 "output_cost_per_token": 9e-06
+},
+"vertex_ai/gemini-3.5-flash-lite": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 3e-08,
+"input_cost_per_token": 3e-07,
+"litellm_provider": "vertex_ai-language-models",
+"output_cost_per_token": 2.5e-06
+},
+"vertex_ai/gemini-3.6-flash": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 1.5e-07,
+"input_cost_per_token": 1.5e-06,
+"litellm_provider": "vertex_ai",
+"output_cost_per_token": 7.5e-06
 },
 "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
 "cache_creation_input_token_cost": null,
@@ -15238,6 +15721,20 @@
 "litellm_provider": "xai",
 "output_cost_per_token": 2.5e-06
 },
+"xai/grok-4.5": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "xai",
+"output_cost_per_token": 6e-06
+},
+"xai/grok-4.5-latest": {
+"cache_creation_input_token_cost": null,
+"cache_read_input_token_cost": 5e-07,
+"input_cost_per_token": 2e-06,
+"litellm_provider": "xai",
+"output_cost_per_token": 6e-06
+},
 "xai/grok-beta": {
 "cache_creation_input_token_cost": null,
 "cache_read_input_token_cost": null,
@@ -15357,6 +15854,13 @@
 "litellm_provider": "zai",
 "output_cost_per_token": 2.2e-06
 },
+"zai/glm-4.7-flash": {
+"cache_creation_input_token_cost": 0,
+"cache_read_input_token_cost": 0,
+"input_cost_per_token": 0,
+"litellm_provider": "zai",
+"output_cost_per_token": 0
+},
 "zai/glm-5": {
 "cache_creation_input_token_cost": 0,
 "cache_read_input_token_cost": 2e-07,
@@ -15370,5 +15874,12 @@
 "input_cost_per_token": 1.2e-06,
 "litellm_provider": "zai",
 "output_cost_per_token": 5e-06
+},
+"zai/glm-5.1": {
+"cache_creation_input_token_cost": 0,
+"cache_read_input_token_cost": 2.6e-07,
+"input_cost_per_token": 1.4e-06,
+"litellm_provider": "zai",
+"output_cost_per_token": 4.4e-06
 }
 }

--- a/eval_mcp/core/pdf_report.py
+++ b/eval_mcp/core/pdf_report.py
@@ -345,7 +345,7 @@ def _build_code_snippet(recommended_model: str) -> str:
     """Build a code snippet showing how to switch to the recommended model."""
     if "bedrock" in recommended_model.lower() or "anthropic" in recommended_model.lower():
         return f'''import boto3
-client = boto3.client("bedrock-runtime", region_name="us-west-2")
+client = boto3.client("bedrock-runtime", region_name="us-east-2")
 response = client.invoke_model(modelId="{recommended_model}")'''
     elif "openai" in recommended_model.lower() or "gpt" in recommended_model.lower():
         model_name = recommended_model.split("/")[-1]

--- a/eval_mcp/core/pricing.py
+++ b/eval_mcp/core/pricing.py
@@ -184,6 +184,14 @@ def _candidates(model_id: str) -> list[str]:
         if not mantle_id.startswith("openai."):
             mantle_id = f"openai.{mantle_id}"
         out.append(f"bedrock_mantle/{mantle_id}")
+        # Mantle also serves pinned date snapshots ("openai.gpt-5.5-2026-04-23")
+        # that LiteLLM doesn't key separately — it prices only the floating
+        # alias. Fall back to the alias rather than reporting cost unknown for a
+        # model that is priced identically and is the *better* choice for a
+        # reproducible eval.
+        dated = re.match(r"^(?P<base>.+)-\d{4}-\d{2}-\d{2}$", mantle_id)
+        if dated:
+            out.append(f"bedrock_mantle/{dated['base']}")
 
     bare = model_id
     for pfx in _PROVIDER_PREFIXES:

--- a/eval_mcp/core/s3_client.py
+++ b/eval_mcp/core/s3_client.py
@@ -21,7 +21,14 @@ DOCUMENTS_BUCKET = os.environ.get("S3_BUCKET", "") or os.environ.get("DOCUMENTS_
 # Pre-signed URL expiration (1 hour)
 PRESIGN_EXPIRATION = 3600
 
-# AWS region
+# AWS region for the S3 data bucket.
+#
+# Deliberately NOT bedrock_client.resolve_region(): this addresses a *storage*
+# bucket, whose location is fixed at deploy time and has nothing to do with
+# where Bedrock models live. The Bedrock default moved to us-east-2 (for the
+# us-east-only GPT-5.x models); pointing S3 there too would send requests to a
+# bucket that does not exist in that region. In deployment AWS_REGION is always
+# set explicitly, so this fallback only matters for local runs with no bucket.
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 
 

--- a/eval_mcp/core/s3_client.py
+++ b/eval_mcp/core/s3_client.py
@@ -21,15 +21,21 @@ DOCUMENTS_BUCKET = os.environ.get("S3_BUCKET", "") or os.environ.get("DOCUMENTS_
 # Pre-signed URL expiration (1 hour)
 PRESIGN_EXPIRATION = 3600
 
-# AWS region for the S3 data bucket.
+# AWS region for the S3 bucket. NO fallback on purpose.
 #
-# Deliberately NOT bedrock_client.resolve_region(): this addresses a *storage*
-# bucket, whose location is fixed at deploy time and has nothing to do with
-# where Bedrock models live. The Bedrock default moved to us-east-2 (for the
-# us-east-only GPT-5.x models); pointing S3 there too would send requests to a
-# bucket that does not exist in that region. In deployment AWS_REGION is always
-# set explicitly, so this fallback only matters for local runs with no bucket.
-AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
+# This addresses a *storage* bucket, whose location is fixed when it is created —
+# unrelated to where Bedrock models live (see bedrock_client.DEFAULT_REGION,
+# which is us-east-2 for the us-east-only GPT-5.x models). Using that region
+# here would address a bucket that does not exist.
+#
+# Left empty rather than given a guessed default: a bucket is only ever
+# configured together with an explicit AWS_REGION (both come from Helm/Terraform
+# in deployment), and with no bucket set these modules never touch S3 at all.
+# A plausible-but-wrong region here would mean silently reading the wrong
+# bucket, or a confusing 301 PermanentRedirect, instead of an honest failure.
+# boto3 raises NoRegionError if this is somehow reached unset, which is the
+# correct outcome.
+AWS_REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or ""
 
 
 def get_s3_client():

--- a/eval_mcp/core/user_storage.py
+++ b/eval_mcp/core/user_storage.py
@@ -29,7 +29,14 @@ from eval_mcp.core.s3_client import (
 # S3 data bucket for persistent user data (judges, datasets, configs, logs)
 DATA_BUCKET = os.environ.get("DATA_BUCKET", "")
 
-# AWS region
+# AWS region for the S3 data bucket.
+#
+# Deliberately NOT bedrock_client.resolve_region(): this addresses a *storage*
+# bucket, whose location is fixed at deploy time and has nothing to do with
+# where Bedrock models live. The Bedrock default moved to us-east-2 (for the
+# us-east-only GPT-5.x models); pointing S3 there too would send requests to a
+# bucket that does not exist in that region. In deployment AWS_REGION is always
+# set explicitly, so this fallback only matters for local runs with no bucket.
 _AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 
 

--- a/eval_mcp/core/user_storage.py
+++ b/eval_mcp/core/user_storage.py
@@ -29,15 +29,21 @@ from eval_mcp.core.s3_client import (
 # S3 data bucket for persistent user data (judges, datasets, configs, logs)
 DATA_BUCKET = os.environ.get("DATA_BUCKET", "")
 
-# AWS region for the S3 data bucket.
+# AWS region for the S3 bucket. NO fallback on purpose.
 #
-# Deliberately NOT bedrock_client.resolve_region(): this addresses a *storage*
-# bucket, whose location is fixed at deploy time and has nothing to do with
-# where Bedrock models live. The Bedrock default moved to us-east-2 (for the
-# us-east-only GPT-5.x models); pointing S3 there too would send requests to a
-# bucket that does not exist in that region. In deployment AWS_REGION is always
-# set explicitly, so this fallback only matters for local runs with no bucket.
-_AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
+# This addresses a *storage* bucket, whose location is fixed when it is created —
+# unrelated to where Bedrock models live (see bedrock_client.DEFAULT_REGION,
+# which is us-east-2 for the us-east-only GPT-5.x models). Using that region
+# here would address a bucket that does not exist.
+#
+# Left empty rather than given a guessed default: a bucket is only ever
+# configured together with an explicit AWS_REGION (both come from Helm/Terraform
+# in deployment), and with no bucket set these modules never touch S3 at all.
+# A plausible-but-wrong region here would mean silently reading the wrong
+# bucket, or a confusing 301 PermanentRedirect, instead of an honest failure.
+# boto3 raises NoRegionError if this is somehow reached unset, which is the
+# correct outcome.
+_AWS_REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or ""
 
 
 def _get_s3_client():

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -50,7 +50,6 @@ from eval_mcp.tools.benchmarks import (
 )
 
 # Configuration
-region = os.environ.get("AWS_REGION", "us-west-2")
 port = int(os.environ.get("EVAL_MCP_PORT", "8002"))
 host = os.environ.get("HOST", "127.0.0.1")
 
@@ -65,7 +64,7 @@ if "USER_STORAGE_BASE" not in os.environ:
 mcp = FastMCP("eval-server", port=port, host=host)
 
 # Shared clients
-bedrock = BedrockClient(region=region)
+bedrock = BedrockClient()
 
 
 # Tool annotation presets. These are hints (not security boundaries) that

--- a/eval_mcp/tools/analyze_agent_image.py
+++ b/eval_mcp/tools/analyze_agent_image.py
@@ -393,7 +393,7 @@ async def handle_analyze_agent_image(args: Dict[str, Any]) -> List[TextContent]:
             return [TextContent(type="text", text=json.dumps({"success": False, "error": "No Python files found in image working directory"}))]
 
         # Step 2: Analyze the code
-        bedrock = BedrockClient(region=os.environ.get("AWS_REGION", "us-west-2"))
+        bedrock = BedrockClient()
         analysis = await analyze_agent_deep(bedrock, code_files, num_samples, user_context)
 
         test_cases = analysis.get("test_cases", [])

--- a/eval_mcp/tools/analyze_agent_path.py
+++ b/eval_mcp/tools/analyze_agent_path.py
@@ -93,7 +93,7 @@ async def handle_analyze_agent_path(args: Dict[str, Any]) -> List[TextContent]:
         except Exception as e:
             return [TextContent(type="text", text=json.dumps({"success": False, "error": f"Failed to read agent: {str(e)}"}))]
 
-        bedrock = BedrockClient(region=os.environ.get("AWS_REGION", "us-west-2"))
+        bedrock = BedrockClient()
         analysis = await analyze_agent_deep(bedrock, code_files, num_samples, user_context)
 
         test_cases = analysis.get("test_cases", [])

--- a/eval_mcp/tools/bedrock_models.py
+++ b/eval_mcp/tools/bedrock_models.py
@@ -16,7 +16,7 @@ unpriced model is caught at run time with a clear error rather than silently
 hidden — and the maintenance burden is gone.
 """
 
-import os
+import re
 from typing import Optional
 from eval_mcp.core.bedrock_client import (
     create_boto3_bedrock_client,
@@ -27,7 +27,39 @@ from eval_mcp.tools.external_providers import (
     get_external_models,
 )
 
-region = os.environ.get("AWS_REGION", "us-west-2")
+# Regional prefixes AWS uses on cross-region inference profile IDs
+# (e.g. "us.anthropic.claude-...", "jp.anthropic.claude-..."). Stripping these
+# is how we dedupe a profile against its base foundation model and how we read
+# the provider out of an ID — miss one and the model shows up twice with
+# "jp" as its provider.
+_REGIONAL_PREFIXES = (
+    "us", "us-gov", "eu", "apac", "jp", "au", "ca", "global",
+)
+
+
+def strip_regional_prefix(model_id: str) -> str:
+    """Strip a regional prefix ('us.anthropic.claude-…' -> 'anthropic.claude-…')."""
+    parts = model_id.split('.', 1)
+    if len(parts) >= 2 and parts[0] in _REGIONAL_PREFIXES:
+        return parts[1]
+    return model_id
+
+
+def extract_provider_name(model_id: str) -> str:
+    """Extract the provider from a model ID ('us.anthropic.claude-…' -> 'anthropic')."""
+    parts = strip_regional_prefix(model_id).split('.')
+    return parts[0] if parts and parts[0] else "unknown"
+
+
+# Trailing Bedrock version suffix on a foundation-model ID, e.g. the "-1:0" in
+# "openai.gpt-oss-120b-1:0". Mantle omits it ("openai.gpt-oss-120b"), so it has
+# to be stripped before the two catalogs can be compared for duplicates.
+_VERSION_SUFFIX_RE = re.compile(r"-\d+:\d+$")
+
+
+def normalize_model_id(model_id: str) -> str:
+    """Strip regional prefix and version suffix, for cross-catalog comparison."""
+    return _VERSION_SUFFIX_RE.sub("", strip_regional_prefix(model_id))
 
 
 def list_bedrock_models(
@@ -46,7 +78,11 @@ def list_bedrock_models(
     err = get_autodetect_error()
     if err is not None:
         return {"models": [], "count": 0, "error": str(err)}
-    bedrock_client = create_boto3_bedrock_client('bedrock', region)
+    # Region resolved per call (not at import) so a profile/env change is picked
+    # up without restarting the long-lived MCP process — and so the resolved
+    # profile's own region counts, which is what makes region-limited models
+    # (e.g. OpenAI's us-east-only frontier models) discoverable.
+    bedrock_client = create_boto3_bedrock_client('bedrock')
 
     # Patterns to exclude for text_only mode — non-text modalities and
     # task-specific models that aren't chat/generation endpoints.
@@ -60,23 +96,6 @@ def list_bedrock_models(
     # so foundation model anthropic.claude-* won't be added (it requires inference profile)
     seen_base_ids = set()
     models = []
-
-    def strip_regional_prefix(model_id: str) -> str:
-        """Strip regional prefix (e.g., 'us.anthropic.claude-...' -> 'anthropic.claude-...')."""
-        parts = model_id.split('.', 1)
-        if len(parts) >= 2 and parts[0] in ('us', 'eu', 'apac', 'global', 'us-gov'):
-            return parts[1]
-        return model_id
-
-    def extract_provider_name(model_id: str) -> str:
-        """Extract provider from model ID (e.g., 'us.anthropic.claude-...' -> 'anthropic')."""
-        parts = model_id.split('.')
-        if len(parts) >= 2:
-            # Skip regional prefix if present (us., eu., apac., global.)
-            if parts[0] in ('us', 'eu', 'apac', 'global', 'us-gov'):
-                return parts[1]
-            return parts[0]
-        return "unknown"
 
     def should_include(model_id: str, model_name: str, provider_filter: str) -> bool:
         """Check if model should be included based on filters.
@@ -227,11 +246,21 @@ def list_available_models(
             pass
 
     if source in ("all", "external"):
-        external = get_external_models(provider=provider)
-        for m in external:
+        # Some open-weight models (notably openai.gpt-oss-*) are served on BOTH
+        # Converse and Mantle, so they'd otherwise be listed twice under two
+        # different IDs for the same weights. Prefer the Converse entry: it's
+        # what validate_providers smoke-tests and what pricing resolves against.
+        converse_base_ids = {
+            normalize_model_id(m.get("modelId", "")) for m in all_models
+        }
+        for m in get_external_models(provider=provider):
             m["source"] = "external"
             m["type"] = "external"
-        all_models.extend(external)
+            if m["id"].startswith("openai/bedrock/"):
+                short_id = m["id"].rsplit("/", 1)[1]
+                if f"openai.{short_id}" in converse_base_ids:
+                    continue
+            all_models.append(m)
 
     available_providers = detect_available_providers()
 

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -461,11 +461,25 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                 if log.results and log.results.scores:
                     for s in log.results.scores:
                         scores.append({"scorer": s.name, "metrics": {n: m.value for n, m in s.metrics.items()}})
+                # Report what actually RAN, not the dataset size. `--limit N`
+                # leaves dataset.samples at the full count (e.g. 164 for
+                # HumanEval) while only N samples are scored, so reporting the
+                # dataset size overstates the evidence behind the score — a
+                # 3-sample smoke test looked like a full 164-sample benchmark.
+                ran = getattr(log.results, "total_samples", None) if log.results else None
+                dataset_total = log.eval.dataset.samples if log.eval.dataset else 0
                 results_summary = {
-                    "totalTests": log.eval.dataset.samples if log.eval.dataset else 0,
+                    "totalTests": ran if ran else dataset_total,
                     "scores": scores,
                     "logFile": latest.name,
                 }
+                if ran and dataset_total and ran < dataset_total:
+                    results_summary["datasetTotal"] = dataset_total
+                    results_summary["limited"] = (
+                        f"Ran {ran} of {dataset_total} samples (--limit). Scores are "
+                        f"from that subset only and are not comparable to published "
+                        f"full-benchmark numbers."
+                    )
                 run_id = log.eval.run_id
                 all_samples_errored = is_catastrophic_eval_failure(scores, log.results)
         except Exception as e:

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -283,6 +283,27 @@ def _resolve_task(task: str, evals: List[Any]) -> Dict[str, Any]:
     return {"ok": False, "error": f"Unknown benchmark/task '{task}'. Use list_benchmarks to discover names."}
 
 
+async def _count_truncated_samples(log_name: str) -> int:
+    """Number of samples cut off by the max_tokens limit.
+
+    Requires the full log (stop_reason is per-sample, not in the header), so it
+    is called only once per run when building the summary. Best-effort: returns
+    0 on any read failure rather than breaking an otherwise-successful run.
+    """
+    try:
+        from inspect_ai.log import read_eval_log_async
+
+        log = await read_eval_log_async(log_name)
+        return sum(
+            1
+            for s in (log.samples or [])
+            if s.output and s.output.stop_reason == "max_tokens"
+        )
+    except Exception as e:  # pragma: no cover - diagnostics must not break runs
+        logger.warning("Could not count truncated samples for %s: %s", log_name, e)
+        return 0
+
+
 async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
     """Run a premade ``inspect_evals`` benchmark via subprocess.
 
@@ -482,6 +503,25 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                     )
                 run_id = log.eval.run_id
                 all_samples_errored = is_catastrophic_eval_failure(scores, log.results)
+
+                # Surface truncation. A reasoning model that runs out of tokens
+                # mid-thought scores 0 on that sample, so a high truncation rate
+                # means the score measures the token budget, not the model.
+                # Observed: gpt-oss-20b truncated on 12/30 AIME 2025 problems at
+                # max_tokens=8192 and ALL 12 scored 0 — its reported 0.467 was a
+                # floor, not an ability. Benchmarks are the headline numbers
+                # people quote, so this cannot be left implicit.
+                truncated = await _count_truncated_samples(latest.name)
+                if truncated:
+                    results_summary["truncatedSamples"] = truncated
+                    pct = round(100 * truncated / ran) if ran else 0
+                    results_summary["truncationWarning"] = (
+                        f"{truncated} of {ran} samples ({pct}%) hit the max_tokens "
+                        f"limit and were cut off mid-answer — those score 0 "
+                        f"regardless of ability. This score is a LOWER BOUND. "
+                        f"Re-run with a higher --max-tokens before comparing "
+                        f"this model against others or against published numbers."
+                    )
         except Exception as e:
             results_summary = {"error": f"Could not parse results: {e}"}
 

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -42,6 +42,7 @@ from eval_mcp.core.bedrock_client import raise_if_autodetect_error, resolve_regi
 from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
+    _DEFAULT_MAX_TOKENS,
     _INSPECT_CMD,
     _running_evaluations,
     _terminate_process_gracefully,
@@ -385,6 +386,8 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
             "--no-log-images",
             "--no-fail-on-error",
             "--log-shared", "10",
+            # Same reasoning-model truncation guard as run_eval.
+            "--max-tokens", str(_DEFAULT_MAX_TOKENS),
         ]
         if limit:
             cmd.extend(["--limit", str(int(limit))])

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -511,6 +511,25 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                 # max_tokens=8192 and ALL 12 scored 0 — its reported 0.467 was a
                 # floor, not an ability. Benchmarks are the headline numbers
                 # people quote, so this cannot be left implicit.
+                # Errored samples are dropped from the accuracy DENOMINATOR, not
+                # scored 0 — so a model whose requests time out gets graded only
+                # on the ones that came back. Observed: gpt-oss-20b hit 3 Bedrock
+                # read timeouts on AIME 2025 and its 0.519 was 14/27, while
+                # haiku and luna were graded on all 30. That flatters whichever
+                # model fails most, which is the opposite of what you want.
+                completed = getattr(log.results, "completed_samples", None) if log.results else None
+                if ran and completed is not None and completed < ran:
+                    errored = ran - completed
+                    results_summary["erroredSamples"] = errored
+                    results_summary["scoredSamples"] = completed
+                    results_summary["errorWarning"] = (
+                        f"{errored} of {ran} samples errored (e.g. timeout) and are "
+                        f"EXCLUDED from the accuracy denominator — this score is "
+                        f"{completed} samples, not {ran}. Cross-model comparison is "
+                        f"skewed unless every model was scored on the same set; "
+                        f"treat errors as unsolved for a like-for-like number."
+                    )
+
                 truncated = await _count_truncated_samples(latest.name)
                 if truncated:
                     results_summary["truncatedSamples"] = truncated

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, List, Optional
 
 from mcp.types import TextContent
 
-from eval_mcp.core.bedrock_client import raise_if_autodetect_error
+from eval_mcp.core.bedrock_client import raise_if_autodetect_error, resolve_region
 from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
@@ -373,7 +373,7 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
         _refresh_keys_from_file()
         env = os.environ.copy()
         env["INSPECT_LOG_DIR"] = log_dir_str
-        region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
+        region = resolve_region()
         env["AWS_REGION"] = region
         env["AWS_DEFAULT_REGION"] = region
 

--- a/eval_mcp/tools/create_config.py
+++ b/eval_mcp/tools/create_config.py
@@ -327,6 +327,27 @@ def jury_scorer():
     async def score(state, target):
         output = state.output.completion if state.output else ""
         if not output:
+            # Distinguish "the model produced a bad answer" from "the model
+            # never got to answer". A reasoning model (gpt-5.6-*, gpt-oss-*)
+            # can spend its entire token budget on the reasoning channel and
+            # emit zero visible tokens: stop_reason == "max_tokens" with an
+            # empty completion. Scoring that a plain 0 is a measurement error
+            # masquerading as a quality signal — it silently penalises exactly
+            # the models that think hardest, and the run still reports success.
+            stop_reason = getattr(state.output, "stop_reason", None) if state.output else None
+            if stop_reason == "max_tokens":
+                return Score(
+                    value=0.0,
+                    answer="",
+                    explanation=(
+                        "TRUNCATED: the model hit its max_tokens limit before emitting "
+                        "any answer (all output tokens went to the reasoning channel). "
+                        "This is a token-budget problem, NOT a quality result — raise "
+                        "max_tokens (e.g. --max-tokens 8192) and re-run before comparing "
+                        "this model against others."
+                    ),
+                    metadata={"truncated_no_output": True, "stop_reason": stop_reason},
+                )
             return Score(value=0.0, answer="", explanation="No output generated")
 
         question = str(state.input)

--- a/eval_mcp/tools/create_config.py
+++ b/eval_mcp/tools/create_config.py
@@ -11,6 +11,7 @@ argument — alone or composed with the jury.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -23,6 +24,8 @@ from eval_mcp.core.user_storage import (
     get_dataset_by_name,
     get_user_dir,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +216,38 @@ def build_config_json(
         config["prompts"] = prompts
     if score_only:
         config["score_only"] = True
+
+    # Resolve region routing for any Bedrock Mantle model (target or judge) that
+    # the caller's own region doesn't serve. Done HERE, at config-creation time,
+    # rather than inside the eval: it costs a cached HTTP lookup per distinct
+    # model, and the eval subprocess would otherwise repeat it for every sample.
+    mantle_regions = _resolve_mantle_regions(
+        [m for m in list(providers or []) + list(judge_config.judges.values())
+         if isinstance(m, str) and m.startswith("openai/bedrock/")]
+    )
+    if mantle_regions:
+        config["mantle_regions"] = mantle_regions
     return config
+
+
+def _resolve_mantle_regions(model_ids: list) -> dict:
+    """Map each Mantle model to a region that serves it, where a hop is needed.
+
+    Omits models the caller's own region already serves, so the common case adds
+    nothing to the config. Best-effort: a probe failure just means no override,
+    and the model fails later with the actionable region hint from run_eval.
+    """
+    out = {}
+    for model_id in dict.fromkeys(model_ids):
+        try:
+            from eval_mcp.tools.external_providers import resolve_mantle_region
+
+            region = resolve_mantle_region(model_id)
+            if region:
+                out[model_id] = region
+        except Exception as e:  # pragma: no cover - never block config creation
+            logger.warning("Could not resolve Mantle region for %s: %s", model_id, e)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +287,20 @@ from inspect_ai.tool._tool_params import ToolParams
 JUDGE_MODELS = CONFIG["judge_models"]
 CRITERIA = CONFIG["criteria"]
 SYSTEM_PROMPT = CONFIG["system_prompt"]
+
+# Region routing for Bedrock Mantle judges, baked in at config-creation time by
+# create_eval_config. Mantle model availability is per-region (gpt-5.5 and
+# gpt-5.6-sol are us-east-1/us-east-2 only) while AWS credentials are global, so
+# a judge that isn't served in the user's own region is invoked against one that
+# does serve it. Only openai/bedrock/* inference is affected — Converse judges,
+# storage and logs all stay in the user's region.
+MANTLE_REGIONS = CONFIG.get("mantle_regions") or {}
+
+
+def _judge_model_args(model_id):
+    """Extra get_model() kwargs for a judge — an aws_region override, if needed."""
+    region = MANTLE_REGIONS.get(model_id)
+    return {"aws_region": region} if region else {}
 
 
 def _build_scoring_tool():
@@ -366,7 +414,7 @@ def jury_scorer():
 
         for label, model_id in JUDGE_MODELS.items():
             try:
-                judge = get_model(model_id)
+                judge = get_model(model_id, **_judge_model_args(model_id))
                 result = await judge.generate(
                     [
                         ChatMessageSystem(content=SYSTEM_PROMPT),

--- a/eval_mcp/tools/external_providers.py
+++ b/eval_mcp/tools/external_providers.py
@@ -338,6 +338,56 @@ def list_mantle_models(region: str | None = None) -> list[dict[str, Any]] | None
 _MANTLE_PROBE_REGIONS = ("us-east-1", "us-east-2", "us-west-2", "eu-west-1")
 
 
+def resolve_mantle_region(model_id: str) -> str | None:
+    """Region to send this Mantle model's request to, or None to use the default.
+
+    Bedrock Mantle model availability is per-region and AWS rolls models out
+    region by region (as of 2026-07-27, gpt-5.5 and gpt-5.6-sol are
+    us-east-1/us-east-2 only). Credentials, though, are global — only the
+    endpoint is regional — so a user in eu-west-1 or us-west-2 CAN invoke a
+    us-east-only model by pointing that one request at us-east-2. Verified live:
+    with AWS_REGION=us-west-2, `get_model("openai/bedrock/gpt-5.5",
+    aws_region="us-east-2")` succeeds where the un-overridden call 404s.
+
+    Without this, the MCP only worked for users who happened to be in a us-east
+    region, and told everyone else the model did not exist.
+
+    Returns None when the caller's own region already serves the model (the
+    common case — no cross-region hop, no probing cost) or when we can't tell.
+    Scope is deliberately narrow: ONLY ``openai/bedrock/*`` inference is
+    redirected. Converse models, S3, RDS and logs all stay in the user's region.
+
+    Override with EVAL_MCP_MANTLE_REGION to pin a region explicitly, or set
+    EVAL_MCP_NO_CROSS_REGION=1 to disable redirection entirely (for callers with
+    data-residency constraints who would rather see a clear failure).
+    """
+    from eval_mcp.core.bedrock_client import resolve_region
+
+    pinned = os.environ.get("EVAL_MCP_MANTLE_REGION", "").strip()
+    if pinned:
+        return pinned
+    if os.environ.get("EVAL_MCP_NO_CROSS_REGION", "").lower() in ("1", "true", "yes"):
+        return None
+
+    home = resolve_region()
+    short_id = model_id.rsplit("/", 1)[-1].removeprefix("openai.")
+
+    # Fast path: the user's own region serves it. Uses the same 10-min cache as
+    # discovery, so this is normally free.
+    local = list_mantle_models(region=home)
+    if local and any(m["id"] == f"openai/bedrock/{short_id}" for m in local):
+        return None
+
+    for candidate in find_mantle_regions_for_model(model_id):
+        if candidate != home:
+            logger.info(
+                "Routing Mantle model %s to %s (not available in %s)",
+                short_id, candidate, home,
+            )
+            return candidate
+    return None
+
+
 def find_mantle_regions_for_model(model_id: str) -> list[str]:
     """Regions whose Mantle catalog lists ``model_id`` as available.
 

--- a/eval_mcp/tools/external_providers.py
+++ b/eval_mcp/tools/external_providers.py
@@ -9,9 +9,14 @@ To add a new provider:
   2. Add the env var name to scripts/parse-env-keys.sh ALLOWED_KEY_NAMES
 """
 
+import logging
 import os
+import re
+import time
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +119,16 @@ EXTERNAL_PROVIDERS: dict[str, dict[str, Any]] = {
         # "is GPT-5.4 available?" filters to provider=openai and wrongly misses
         # the Mantle models.
         "match_aliases": ["openai"],
+        # Fallback list, used only when the live Mantle catalog can't be reached
+        # (no network / no creds / endpoint error). The real list comes from
+        # list_mantle_models() below — Mantle exposes a genuine `/v1/models`
+        # catalog, so hard-coding IDs here would repeat the mistake this repo
+        # already avoids for Converse models: a stale allowlist that hides
+        # newly launched models and advertises ones the region doesn't have.
         "models": [
+            {"id": "openai/bedrock/gpt-5.6-sol", "name": "GPT-5.6 Sol (Bedrock)"},
+            {"id": "openai/bedrock/gpt-5.6-terra", "name": "GPT-5.6 Terra (Bedrock)"},
+            {"id": "openai/bedrock/gpt-5.6-luna", "name": "GPT-5.6 Luna (Bedrock)"},
             {"id": "openai/bedrock/gpt-5.5", "name": "GPT-5.5 (Bedrock)"},
             {"id": "openai/bedrock/gpt-5.4", "name": "GPT-5.4 (Bedrock)"},
         ],
@@ -199,6 +213,153 @@ EXTERNAL_PROVIDERS: dict[str, dict[str, Any]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Live Bedrock Mantle catalog
+#
+# Mantle serves an OpenAI-compatible `/v1/models` catalog per region, so the set
+# of OpenAI models available to this account is discoverable rather than
+# guessed. This matters because model availability is region-specific: as of
+# this writing gpt-5.5 and gpt-5.6-sol are us-east-1/us-east-2 only, while
+# gpt-5.6-terra/luna and gpt-5.4 are also in us-west-2. A static list either
+# hides models (a newer release) or advertises ones the caller's region can't
+# invoke — both of which we hit in practice.
+#
+# Cached for 10 minutes: the catalog changes on AWS launch timescales, and the
+# MCP process is long-lived, so per-call HTTP would add latency for nothing.
+# ---------------------------------------------------------------------------
+
+_MANTLE_CACHE_TTL_SECONDS = 600
+# Keyed by region: the failure path probes several regions to report where a
+# model does live, and a single-slot cache would evict on every probe.
+_MANTLE_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+# Display names for the model families we know about. Anything not listed falls
+# back to a title-cased ID, so an unrecognized new model still surfaces.
+_MANTLE_DISPLAY_NAMES = {
+    "gpt-5.6-sol": "GPT-5.6 Sol",
+    "gpt-5.6-terra": "GPT-5.6 Terra",
+    "gpt-5.6-luna": "GPT-5.6 Luna",
+    "gpt-5.5": "GPT-5.5",
+    "gpt-5.4": "GPT-5.4",
+    "gpt-oss-120b": "GPT-OSS 120B",
+    "gpt-oss-20b": "GPT-OSS 20B",
+    "gpt-oss-safeguard-120b": "GPT-OSS Safeguard 120B",
+    "gpt-oss-safeguard-20b": "GPT-OSS Safeguard 20B",
+}
+
+
+_DATED_SNAPSHOT_RE = re.compile(r"^(?P<base>.+)-(?P<date>\d{4}-\d{2}-\d{2})$")
+
+
+def _mantle_display_name(short_id: str) -> str:
+    """Human label for a Mantle model ID, handling pinned date snapshots.
+
+    Mantle lists both a floating alias (`gpt-5.5`) and pinned snapshots
+    (`gpt-5.5-2026-04-23`). Both are invokable and the pinned one is what you
+    want for a reproducible eval, so we surface both and label the snapshot
+    'GPT-5.5 (2026-04-23)' rather than dumping the raw ID.
+    """
+    if short_id in _MANTLE_DISPLAY_NAMES:
+        return _MANTLE_DISPLAY_NAMES[short_id]
+    dated = _DATED_SNAPSHOT_RE.match(short_id)
+    if dated:
+        base = _MANTLE_DISPLAY_NAMES.get(dated["base"], dated["base"])
+        return f"{base} ({dated['date']})"
+    return short_id
+
+
+def list_mantle_models(region: str | None = None) -> list[dict[str, Any]] | None:
+    """Query the live Bedrock Mantle model catalog for OpenAI models.
+
+    Returns Inspect-format entries (``openai/bedrock/<short-id>``) for every
+    OpenAI model the endpoint reports as ``available`` in ``region``, or None if
+    the catalog can't be reached — callers then fall back to the static list in
+    EXTERNAL_PROVIDERS rather than reporting "no models".
+
+    Only ``openai.*`` IDs are returned. Mantle also hosts Anthropic, Qwen,
+    Mistral and others, but Inspect's ``openai/bedrock/`` provider prefix routes
+    through the OpenAI client, so a non-OpenAI ID listed under it wouldn't be
+    invokable the way callers expect. Those models are reachable on Converse via
+    ``list_bedrock_models`` instead.
+    """
+    from eval_mcp.core.bedrock_client import resolve_region
+
+    region = resolve_region(region)
+    now = time.monotonic()
+    cached = _MANTLE_CACHE.get(region)
+    if cached is not None and now - cached[0] < _MANTLE_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    try:
+        import httpx
+        from aws_bedrock_token_generator import provide_token
+
+        token = provide_token(region=region)
+        # The frontier models are served under /openai/v1 for *inference*, but
+        # the catalog itself lives at /v1/models (a GET on /openai/v1/models is
+        # a 404). Verified live in us-east-1/2, us-west-2 and eu-west-1.
+        response = httpx.get(
+            f"https://bedrock-mantle.{region}.api.aws/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as e:
+        logger.debug("Mantle catalog unavailable in %s: %s", region, e)
+        return None
+
+    models: list[dict[str, Any]] = []
+    for entry in payload.get("data", []):
+        model_id = entry.get("id", "")
+        if not model_id.startswith("openai.") or entry.get("status") != "available":
+            continue
+        short_id = model_id.split(".", 1)[1]
+        models.append({
+            "id": f"openai/bedrock/{short_id}",
+            "name": f"{_mantle_display_name(short_id)} (Bedrock {region})",
+        })
+
+    if not models:
+        # An empty OpenAI section is more likely a response-shape change than a
+        # region with genuinely zero OpenAI models. Treat it as "unknown" and
+        # let the static fallback answer.
+        return None
+
+    models.sort(key=lambda m: m["id"], reverse=True)
+    _MANTLE_CACHE[region] = (now, models)
+    return models
+
+
+# Regions where AWS serves Bedrock Mantle. Probed (only on the failure path) to
+# tell a user *where* a model they asked for actually lives, instead of a bare
+# "not available" — the answer that had us wrongly conclude gpt-5.5 and
+# gpt-5.6-sol didn't exist when they were simply us-east-only.
+_MANTLE_PROBE_REGIONS = ("us-east-1", "us-east-2", "us-west-2", "eu-west-1")
+
+
+def find_mantle_regions_for_model(model_id: str) -> list[str]:
+    """Regions whose Mantle catalog lists ``model_id`` as available.
+
+    ``model_id`` may be an Inspect ID (``openai/bedrock/gpt-5.5``) or a bare
+    Mantle ID (``openai.gpt-5.5``). Returns [] if the model is found nowhere or
+    no region could be reached — callers treat that as "no extra information",
+    never as proof of absence.
+
+    Intended for error messages only: it issues one HTTP call per region, so it
+    must not sit on a hot path.
+    """
+    short_id = model_id.rsplit("/", 1)[-1].removeprefix("openai.")
+    found = []
+    for probe_region in _MANTLE_PROBE_REGIONS:
+        models = list_mantle_models(region=probe_region)
+        if not models:
+            continue
+        if any(m["id"] == f"openai/bedrock/{short_id}" for m in models):
+            found.append(probe_region)
+    return found
+
+
 def detect_available_providers() -> list[dict[str, Any]]:
     """
     Detect which external providers are available based on environment variables.
@@ -212,7 +373,7 @@ def detect_available_providers() -> list[dict[str, Any]]:
             available.append({
                 "name": name,
                 "display_name": config["display_name"],
-                "model_count": len(config["models"]),
+                "model_count": len(_models_for_provider(name, config)),
             })
     return available
 
@@ -250,7 +411,7 @@ def get_external_models(provider: str = "all") -> list[dict[str, Any]]:
         if not _provider_enabled(config):
             continue
 
-        for model in config["models"]:
+        for model in _models_for_provider(name, config):
             models.append({
                 "id": model["id"],
                 "name": model["name"],
@@ -258,3 +419,12 @@ def get_external_models(provider: str = "all") -> list[dict[str, Any]]:
             })
 
     return models
+
+
+def _models_for_provider(name: str, config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Models for a provider — live catalog where one exists, else the static list."""
+    if name == "bedrock-mantle":
+        live = list_mantle_models()
+        if live is not None:
+            return live
+    return config["models"]

--- a/eval_mcp/tools/optimize_prompt.py
+++ b/eval_mcp/tools/optimize_prompt.py
@@ -64,7 +64,7 @@ from mcp.types import TextContent
 from inspect_ai._view.common import list_eval_logs_async
 from inspect_ai.log import read_eval_log_async
 
-from eval_mcp.core.bedrock_client import BedrockClient
+from eval_mcp.core.bedrock_client import BedrockClient, resolve_region
 from eval_mcp.core.judge_config import JUDGE_MODELS, JudgeConfig
 from eval_mcp.core.user_storage import (
     get_dataset_by_name,
@@ -382,7 +382,7 @@ async def _spawn_inspect_eval(
     _refresh_keys_from_file()
     env = os.environ.copy()
     env["INSPECT_LOG_DIR"] = log_dir
-    region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
+    region = resolve_region()
     env["AWS_REGION"] = region
     env["AWS_DEFAULT_REGION"] = region
 

--- a/eval_mcp/tools/optimize_prompt.py
+++ b/eval_mcp/tools/optimize_prompt.py
@@ -81,6 +81,7 @@ from eval_mcp.tools.create_config import (
 )
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
+    _DEFAULT_MAX_TOKENS,
     _running_evaluations,
     _terminate_process_gracefully,
 )
@@ -394,6 +395,8 @@ async def _spawn_inspect_eval(
         "--no-log-images",
         "--no-fail-on-error",
         "--log-shared", "10",
+        # Same reasoning-model truncation guard as run_eval.
+        "--max-tokens", str(_DEFAULT_MAX_TOKENS),
     ]
     if providers:
         cmd.extend(["--model", ",".join(providers)])

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -36,6 +36,21 @@ _VALID_CONFIG_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
 # Pattern for valid eval IDs: alphanumeric, underscore, dash, colon only
 _VALID_EVAL_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_:-]+$')
 
+# Output-token ceiling for every eval we launch.
+#
+# Inspect's Bedrock provider defaults to 2048, which is too low for reasoning
+# models and biases comparisons in a way that is easy to miss: gpt-5.6-luna,
+# gpt-5.6-sol and gpt-oss-20b can spend the WHOLE budget on their reasoning
+# channel and return an empty completion (stop_reason="max_tokens"). The sample
+# still "completes", so it scores 0 and the run reports success — the model that
+# reasoned hardest looks like the worst model. Measured on a hard proof task:
+# luna and sol both consumed 2048/2048 reasoning tokens with 0 visible output.
+#
+# 8192 clears the observed worst case with headroom. It's a ceiling, not a
+# target — models that answer briefly are unaffected and cost nothing extra,
+# since Bedrock bills actual tokens generated.
+_DEFAULT_MAX_TOKENS = 8192
+
 # Model IDs to pull out of a config for pre-flight validation. Covers both
 # Bedrock endpoints: `bedrock/<id>` (Converse) and `openai/bedrock/<id>`
 # (Mantle / OpenAI frontier models). The optional `openai/` group is what makes
@@ -582,6 +597,7 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             "--no-log-images",
             "--no-fail-on-error",
             "--log-shared", "10",
+            "--max-tokens", str(_DEFAULT_MAX_TOKENS),
         ]
 
         # Pass models to inspect eval (comma-separated for multiple).

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -10,12 +10,14 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import boto3
-from botocore.config import Config
 from inspect_ai.log import read_eval_log_async
 from mcp.types import TextContent
 
-from eval_mcp.core.bedrock_client import raise_if_autodetect_error
+from eval_mcp.core.bedrock_client import (
+    create_boto3_bedrock_client,
+    raise_if_autodetect_error,
+    resolve_region,
+)
 from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 
@@ -33,6 +35,12 @@ _VALID_CONFIG_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
 
 # Pattern for valid eval IDs: alphanumeric, underscore, dash, colon only
 _VALID_EVAL_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_:-]+$')
+
+# Model IDs to pull out of a config for pre-flight validation. Covers both
+# Bedrock endpoints: `bedrock/<id>` (Converse) and `openai/bedrock/<id>`
+# (Mantle / OpenAI frontier models). The optional `openai/` group is what makes
+# the Mantle models validate — without it they were skipped entirely.
+_PROVIDER_PATTERN = re.compile(r'"((?:openai/)?bedrock/[^"]+)"')
 
 
 def is_catastrophic_eval_failure(scores: list, log_results: Any) -> bool:
@@ -58,6 +66,89 @@ def is_catastrophic_eval_failure(scores: list, log_results: Any) -> bool:
     total = getattr(log_results, "total_samples", 0) or 0
     completed = getattr(log_results, "completed_samples", 0) or 0
     return total > 0 and completed == 0
+
+
+async def _read_stream(stream: Any, label: str, timeout: float = 5.0) -> str:
+    """Drain a subprocess pipe, returning "" rather than raising.
+
+    Used for post-mortem output capture on a failed eval, where losing the
+    diagnostic is worse than any error this could raise.
+    """
+    if stream is None:
+        return ""
+    try:
+        data = await asyncio.wait_for(stream.read(), timeout=timeout)
+    except (asyncio.TimeoutError, Exception):
+        return f"({label} unavailable)"
+    return data.decode("utf-8", errors="replace") if data else ""
+
+
+# Lines that carry the actual cause of an Inspect failure. Ordered by
+# specificity — the first match wins, so a concrete exception beats a generic
+# "Task failed" banner.
+_ERROR_LINE_MARKERS = (
+    "ModuleNotFoundError",
+    "ImportError",
+    "PrerequisiteError",
+    "NotImplementedError",
+    "ValidationException",
+    "AccessDenied",
+    "ResourceNotFound",
+    "Error:",
+    "error:",
+    "Exception",
+    "Traceback",
+)
+
+
+def _summarize_failure(stderr_str: str, stdout_str: str) -> str:
+    """Extract the most informative single line from a failed eval's output.
+
+    Inspect writes fatal errors to stdout via its Rich console, so a caller that
+    only reads stderr gets an empty string and no way to diagnose the run. We
+    scan stderr first (a genuine crash lands there) and fall back to stdout.
+
+    Pure function so the marker matching is unit-testable without spawning
+    Inspect. Returns "" when nothing recognisable is found — the caller keeps
+    its generic exit-code message in that case.
+    """
+    for source in (stderr_str, stdout_str):
+        if not source:
+            continue
+        for marker in _ERROR_LINE_MARKERS:
+            for raw_line in source.splitlines():
+                # Inspect's Rich console box-draws its output, in either Unicode
+                # or ASCII depending on terminal detection. Strip both framing
+                # styles so the message reads cleanly instead of "| ValueError…".
+                line = raw_line.strip().strip("│|").strip()
+                if marker in line and line:
+                    return line[:500]
+    return ""
+
+
+def _mantle_region_hint(model_id: str, current_region: str) -> str:
+    """Build the 'not available here' message, naming regions that do serve it.
+
+    Pure string assembly around the region probe so the wording is testable
+    without network access.
+    """
+    try:
+        from eval_mcp.tools.external_providers import find_mantle_regions_for_model
+
+        regions = [r for r in find_mantle_regions_for_model(model_id) if r != current_region]
+    except Exception:  # pragma: no cover - hint must never break validation
+        regions = []
+
+    base = f"Model not available on Bedrock Mantle in {current_region}"
+    if regions:
+        return (
+            f"{base}. It IS available in: {', '.join(regions)} — "
+            f"set AWS_REGION={regions[0]} and re-run."
+        )
+    return (
+        f"{base}, and it wasn't found in any other region we checked. "
+        "Verify the model ID, or that your account has Bedrock Mantle model access."
+    )
 
 
 def _validate_config_name(config_name: str) -> str:
@@ -119,14 +210,17 @@ async def _validate_providers(providers: List[str]) -> Dict[str, Any]:
 
     # --- Standard Bedrock runtime (Converse) ---
     if runtime_models:
-        region = os.environ.get("AWS_REGION", "us-west-2")
-        config = Config(
-            region_name=region,
+        # Go through create_boto3_bedrock_client, not raw boto3: it honours
+        # AWS_BEARER_TOKEN_BEDROCK (API-key auth) and the resolved profile's
+        # region. A raw client made validation fail for API-key users whose
+        # evals would then have run fine, and pinned the smoke test to
+        # us-west-2 even when the profile pointed elsewhere.
+        runtime_client = create_boto3_bedrock_client(
+            "bedrock-runtime",
             read_timeout=15,
             connect_timeout=10,
             retries={"max_attempts": 1},
         )
-        runtime_client = boto3.client("bedrock-runtime", config=config)
 
         for model_id in runtime_models:
             actual_model_id = model_id.replace("bedrock/", "", 1)
@@ -165,7 +259,13 @@ async def _validate_providers(providers: List[str]) -> Dict[str, Any]:
             if "AccessDenied" in error_msg or "Forbidden" in error_msg or "403" in error_msg:
                 hint = "Bedrock Mantle access not enabled for this account (needs model access / sufficient C-score)"
             elif "not_found" in error_msg or "does not exist" in error_msg or "404" in error_msg:
-                hint = "Model not available on Bedrock Mantle (check the model ID / region)"
+                # "Not found" on Mantle almost always means wrong *region*, not
+                # a nonexistent model — OpenAI's frontier models launch
+                # region-by-region (gpt-5.5 and gpt-5.6-sol were us-east-only
+                # for weeks). Naming the regions that do serve it turns a dead
+                # end into a one-line fix, and stops us telling a user a model
+                # doesn't exist when it merely isn't here.
+                hint = _mantle_region_hint(model_id, resolve_region())
             elif "aws-bedrock-token-generator" in error_msg:
                 hint = "Missing aws-bedrock-token-generator package"
             elif "credential" in error_msg.lower():
@@ -339,9 +439,15 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             if json_config.exists():
                 sources.append(json_config.read_text())
 
-            import re as _re
-            provider_pattern = _re.compile(r'"(bedrock/[^"]+)"')
-            providers = list({m for src in sources for m in provider_pattern.findall(src)})
+            # Match BOTH endpoints. `"(bedrock/...)"` alone could never match
+            # "openai/bedrock/gpt-5.5" — the `"` anchor requires bedrock/ to
+            # start the string — so every GPT-5.x config skipped validation
+            # silently and failed later with an opaque non-zero exit instead of
+            # the actionable region/access message _validate_providers produces.
+            providers = list({
+                m for src in sources
+                for m in _PROVIDER_PATTERN.findall(src)
+            })
 
             if providers:
                 validation = await _validate_providers(providers)
@@ -373,7 +479,11 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         env = os.environ.copy()
         env["INSPECT_LOG_DIR"] = log_dir_str
         # Ensure AWS region is set for Bedrock
-        region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
+        # Pin the child's region explicitly. resolve_region() also consults the
+        # resolved profile's configured region, so a user on a us-east-2 profile
+        # reaches the models that only launched there (gpt-5.5, gpt-5.6-sol)
+        # without having to export AWS_REGION by hand.
+        region = resolve_region()
         env["AWS_REGION"] = region
         env["AWS_DEFAULT_REGION"] = region
 
@@ -522,14 +632,15 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         finally:
             _running_evaluations.pop(user_id, None)
 
-        # Read stderr only on failure
-        stderr_str = ""
-        if process.returncode != 0 and process.stderr:
-            try:
-                stderr_bytes = await asyncio.wait_for(process.stderr.read(), timeout=5)
-                stderr_str = stderr_bytes.decode("utf-8") if stderr_bytes else ""
-            except (asyncio.TimeoutError, Exception):
-                stderr_str = "(stderr unavailable)"
+        # Read the child's output only on failure.
+        #
+        # Both streams, not just stderr: Inspect's CLI renders fatal errors
+        # through its Rich console, which writes to **stdout**. Reading stderr
+        # alone produced the worst possible failure report — `success: false,
+        # exit code 1, stderr: ""` — with the actual cause (e.g. a missing
+        # `openai` package for openai/bedrock/* models) sitting unread in stdout.
+        stderr_str = await _read_stream(process.stderr, "stderr") if process.returncode != 0 else ""
+        stdout_str = await _read_stream(process.stdout, "stdout") if process.returncode != 0 else ""
 
         # Retry failed/incomplete samples from this run
         try:
@@ -589,18 +700,23 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             logger.warning(f"S3 log sync failed: {e}")
 
         if process.returncode != 0:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({
-                        "success": False,
-                        "evalId": eval_id,
-                        "configName": config_name,
-                        "error": f"Evaluation failed with exit code {process.returncode}",
-                        "stderr": stderr_str[:2000],
-                    }),
+            payload = {
+                "success": False,
+                "evalId": eval_id,
+                "configName": config_name,
+                "error": f"Evaluation failed with exit code {process.returncode}",
+                "stderr": stderr_str[:2000],
+                "stdout": stdout_str[:4000],
+            }
+            # Inspect prints the traceback to stdout, so that's usually where
+            # the real cause is. Hoist it into `error` when stderr is empty —
+            # otherwise the agent reads "exit code 1" and has nothing to act on.
+            detail = _summarize_failure(stderr_str, stdout_str)
+            if detail:
+                payload["error"] = (
+                    f"Evaluation failed with exit code {process.returncode}: {detail}"
                 )
-            ]
+            return [TextContent(type="text", text=json.dumps(payload))]
 
         # Read results from the latest .eval log file
         results_summary = None
@@ -802,7 +918,11 @@ async def handle_retry_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         _refresh_keys_from_file()
         env = os.environ.copy()
         env["INSPECT_LOG_DIR"] = log_dir_str
-        region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
+        # Pin the child's region explicitly. resolve_region() also consults the
+        # resolved profile's configured region, so a user on a us-east-2 profile
+        # reaches the models that only launched there (gpt-5.5, gpt-5.6-sol)
+        # without having to export AWS_REGION by hand.
+        region = resolve_region()
         env["AWS_REGION"] = region
         env["AWS_DEFAULT_REGION"] = region
 

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -141,6 +141,32 @@ def _summarize_failure(stderr_str: str, stdout_str: str) -> str:
     return ""
 
 
+def _region_for_run(config_data: Optional[Dict[str, Any]], models: List[str]) -> str:
+    """Region to run the eval subprocess in.
+
+    Defaults to the ambient/resolved region. If the config recorded a Mantle
+    region override for any model in this run (meaning the caller's own region
+    doesn't serve it), use that instead so those models are reachable. Ties are
+    broken deterministically by sorting, so the same config always picks the same
+    region.
+
+    Pure apart from resolve_region(), so the selection logic is unit-testable.
+    """
+    home = resolve_region()
+    overrides = (config_data or {}).get("mantle_regions") or {}
+    needed = sorted({overrides[m] for m in models if m in overrides})
+    if not needed:
+        return home
+    if len(needed) > 1:
+        logger.info(
+            "Models in this run want different Mantle regions %s; using %s.",
+            needed, needed[0],
+        )
+    logger.info("Running eval in %s (ambient region %s lacks a chosen model).",
+                needed[0], home)
+    return needed[0]
+
+
 def _mantle_region_hint(model_id: str, current_region: str) -> str:
     """Build the 'not available here' message, naming regions that do serve it.
 
@@ -267,7 +293,17 @@ async def _validate_providers(providers: List[str]) -> Dict[str, Any]:
         try:
             from inspect_ai.model import get_model, GenerateConfig
 
-            model = get_model(model_id)
+            from eval_mcp.tools.external_providers import resolve_mantle_region
+
+            # Route to a region that actually serves this model. Mantle rolls out
+            # region by region, but credentials are global — so validate against
+            # the same region the eval will use, or this check would reject a
+            # model that is about to work fine.
+            model_args = {}
+            routed = resolve_mantle_region(model_id)
+            if routed:
+                model_args["aws_region"] = routed
+            model = get_model(model_id, **model_args)
             await model.generate("Hi", config=GenerateConfig(max_tokens=16))
         except Exception as e:
             error_msg = str(e)
@@ -489,16 +525,56 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         if not log_dir_str.startswith("s3://"):
             Path(log_dir_str).mkdir(parents=True, exist_ok=True)
 
+        # Extract model providers from the JSON config file
+        models = []
+        config_data = None
+        score_only = False
+        config_json_path = user_dir / "configs" / f"{config_name}.json"
+        if config_json_path.exists():
+            config_data = json.loads(config_json_path.read_text())
+            score_only = bool(config_data.get("score_only"))
+            # Agent evals use single "model" field; standard evals use "providers" list
+            if config_data.get("model"):
+                models = [config_data["model"]]
+            else:
+                models = config_data.get("providers", [])
+        else:
+            # Fallback: scan the task .py for provider strings when there's no
+            # sibling JSON config. `task_content` was never defined here — this
+            # branch raised NameError instead of falling back, so a config
+            # without its JSON got "no models" rather than a scan. Read the file.
+            try:
+                task_content = Path(task_file).read_text()
+            except OSError as e:
+                logger.warning("Could not read task file for provider scan: %s", e)
+                task_content = ""
+            for line in task_content.split("\n"):
+                if '"bedrock/' in line or '"openai/' in line or '"anthropic/' in line or '"google/' in line:
+                    matches = re.findall(r'"([^"]+/[^"]+)"', line)
+                    models.extend(matches)
+
         # Set up environment
         _refresh_keys_from_file()
         env = os.environ.copy()
         env["INSPECT_LOG_DIR"] = log_dir_str
-        # Ensure AWS region is set for Bedrock
         # Pin the child's region explicitly. resolve_region() also consults the
         # resolved profile's configured region, so a user on a us-east-2 profile
         # reaches the models that only launched there (gpt-5.5, gpt-5.6-sol)
         # without having to export AWS_REGION by hand.
-        region = resolve_region()
+        #
+        # When the run includes a Mantle model the ambient region doesn't serve,
+        # move the WHOLE subprocess to a region that does. That is the only lever
+        # available for target models: they arrive via `--model` on the CLI, and
+        # both alternatives are dead ends — Inspect's `-M aws_region=` applies
+        # globally and is a hard error on Converse models, while
+        # BEDROCK_OPENAI_BASE_URL alone yields "Credential should be scoped to a
+        # valid region" because the bearer token is still minted for the ambient
+        # region (both verified live). Since every current-generation Converse
+        # model is available in us-east-1/us-east-2 too, relocating the whole
+        # subprocess costs nothing in model coverage. Judges are routed
+        # per-model inside the task file via the config's mantle_regions map, so
+        # they work regardless.
+        region = _region_for_run(config_data, models)
         env["AWS_REGION"] = region
         env["AWS_DEFAULT_REGION"] = region
 
@@ -519,26 +595,6 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
         # Build inspect eval command with relative path (Inspect requires non-absolute paths)
         relative_task = f"configs/{config_name}.py"
 
-        # Extract model providers from the JSON config file
-        models = []
-        config_data = None
-        score_only = False
-        config_json_path = user_dir / "configs" / f"{config_name}.json"
-        if config_json_path.exists():
-            config_data = json.loads(config_json_path.read_text())
-            score_only = bool(config_data.get("score_only"))
-            # Agent evals use single "model" field; standard evals use "providers" list
-            if config_data.get("model"):
-                models = [config_data["model"]]
-            else:
-                models = config_data.get("providers", [])
-        else:
-            # Fallback: scan task file for provider strings
-            for line in task_content.split("\n"):
-                if '"bedrock/' in line or '"openai/' in line or '"anthropic/' in line or '"google/' in line:
-                    import re as _re
-                    matches = _re.findall(r'"([^"]+/[^"]+)"', line)
-                    models.extend(matches)
 
         # Pre-flight capture check for agent evals: spawn the agent once
         # with a trivial prompt and verify ≥1 Bedrock span lands in our

--- a/infra/data/variables.tf
+++ b/infra/data/variables.tf
@@ -7,5 +7,11 @@ variable "project_name" {
 variable "region" {
   description = "Primary AWS region for all core infrastructure"
   type        = string
-  default     = "us-west-2"
+  # deploy.sh always writes an explicit `region = ...` into the tfvars (it errors
+  # out if AWS_REGION is unset), so this default is a fallback for direct
+  # terraform invocation only. us-east-2 matches the Bedrock default in
+  # eval_mcp/core/bedrock_client.py: it is the region carrying the full model
+  # set, including the OpenAI frontier models (gpt-5.5, gpt-5.6-sol) that AWS
+  # serves only in us-east-1/us-east-2.
+  default = "us-east-2"
 }

--- a/infra/platform/variables.tf
+++ b/infra/platform/variables.tf
@@ -7,7 +7,13 @@ variable "project_name" {
 variable "region" {
   description = "Primary AWS region for EKS and all core infrastructure"
   type        = string
-  default     = "us-west-2"
+  # deploy.sh always writes an explicit `region = ...` into the tfvars (it errors
+  # out if AWS_REGION is unset), so this default is a fallback for direct
+  # terraform invocation only. us-east-2 matches the Bedrock default in
+  # eval_mcp/core/bedrock_client.py: it is the region carrying the full model
+  # set, including the OpenAI frontier models (gpt-5.5, gpt-5.6-sol) that AWS
+  # serves only in us-east-1/us-east-2.
+  default = "us-east-2"
 }
 
 #------------------------------------------------------------------------------

--- a/tests/test_bedrock_client_region.py
+++ b/tests/test_bedrock_client_region.py
@@ -234,3 +234,22 @@ def test_empty_content_list_is_not_an_error():
     """A model that legitimately returned only tool_use blocks yields ""."""
     client = _StubClient("us.anthropic.claude-sonnet-4-6")
     assert client.extract_text_from_response({"content": []}) == ""
+
+
+def test_default_region_serves_the_us_east_only_models():
+    """The fallback region must be one where the full model set exists.
+
+    OpenAI's frontier models on Bedrock Mantle (gpt-5.5, gpt-5.6-sol) are served
+    in us-east-1/us-east-2 ONLY. Defaulting anywhere else makes them unreachable
+    and — as actually happened — has the tool report they do not exist. Every
+    current-generation Converse model (Claude Opus 5 / Sonnet 5 / Haiku 4.5 /
+    Sonnet 4.6, Nova, gpt-oss) is present in us-east-2 as well, so this costs
+    nothing.
+
+    Pinned as a test because the failure mode is silent: a well-meaning revert
+    to us-west-2 breaks two models with no error until someone tries to use them.
+    """
+    assert bc.DEFAULT_REGION in ("us-east-1", "us-east-2"), (
+        "DEFAULT_REGION must be a region that serves the Bedrock Mantle "
+        "frontier models; see the comment on DEFAULT_REGION."
+    )

--- a/tests/test_bedrock_client_region.py
+++ b/tests/test_bedrock_client_region.py
@@ -1,0 +1,236 @@
+"""Tests for region resolution and reasoning-model temperature handling.
+
+Both behaviors exist because model availability on Bedrock is region-specific
+and model *parameter* support is model-specific:
+
+  - OpenAI's frontier models launched region-by-region: as of 2026-07-27
+    gpt-5.5 and gpt-5.6-sol are us-east-1/us-east-2 only, while gpt-5.6-terra,
+    gpt-5.6-luna and gpt-5.4 are also in us-west-2. Every call site used to read
+    `os.environ.get("AWS_REGION", "us-west-2")` directly, which ignored the
+    user's configured profile region and made the us-east-only models
+    unreachable — the tool would report they didn't exist.
+
+  - Reasoning models reject `temperature` outright with HTTP 400
+    `unsupported_parameter`, not a warning. Sending it is a hard failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eval_mcp.core import bedrock_client as bc
+
+
+@pytest.fixture(autouse=True)
+def _clean_region_env(monkeypatch):
+    """Start each test with no region env vars and autodetect already done.
+
+    Marking autodetect done keeps resolve_region() from touching ~/.aws/config
+    on the machine running the tests.
+    """
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.setattr(bc, "_autodetect_done", True)
+    monkeypatch.setattr(bc, "_autodetect_error", None)
+
+
+def _no_profile_region(monkeypatch):
+    """Make boto3's session report no configured region."""
+
+    class _Session:
+        region_name = None
+
+    monkeypatch.setattr(bc.boto3, "Session", lambda *a, **k: _Session())
+
+
+# ---------------------------------------------------------------------------
+# resolve_region precedence
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_argument_wins(monkeypatch):
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    assert bc.resolve_region("eu-central-1") == "eu-central-1"
+
+
+def test_aws_region_beats_aws_default_region(monkeypatch):
+    monkeypatch.setenv("AWS_REGION", "us-east-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    assert bc.resolve_region() == "us-east-2"
+
+
+def test_aws_default_region_used_when_aws_region_absent(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    assert bc.resolve_region() == "us-east-1"
+
+
+def test_profile_region_used_when_env_is_empty(monkeypatch):
+    """The fix: honour the resolved profile's region.
+
+    A user whose profile says `region = us-east-2` previously still got
+    us-west-2, putting gpt-5.5 and gpt-5.6-sol permanently out of reach with no
+    recourse short of exporting AWS_REGION by hand.
+    """
+
+    class _Session:
+        region_name = "us-east-2"
+
+    monkeypatch.setattr(bc.boto3, "Session", lambda *a, **k: _Session())
+    assert bc.resolve_region() == "us-east-2"
+
+
+def test_falls_back_to_default_when_nothing_configured(monkeypatch):
+    _no_profile_region(monkeypatch)
+    assert bc.resolve_region() == bc.DEFAULT_REGION
+
+
+def test_never_raises_when_session_construction_fails(monkeypatch):
+    """A broken AWS config must not take down region resolution.
+
+    resolve_region() is called on import-adjacent paths; raising here would
+    surface as "MCP failed to connect" rather than a credential error.
+    """
+
+    def _boom(*a, **k):
+        raise RuntimeError("no config for you")
+
+    monkeypatch.setattr(bc.boto3, "Session", _boom)
+    assert bc.resolve_region() == bc.DEFAULT_REGION
+
+
+def test_empty_string_env_does_not_shadow_profile(monkeypatch):
+    """AWS_REGION="" is unset, not a region.
+
+    Docker/Helm templating routinely produces empty env values; treating "" as
+    a region would send requests to a nonsense endpoint.
+    """
+    monkeypatch.setenv("AWS_REGION", "")
+
+    class _Session:
+        region_name = "us-east-1"
+
+    monkeypatch.setattr(bc.boto3, "Session", lambda *a, **k: _Session())
+    assert bc.resolve_region() == "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Reasoning models and the temperature parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "openai.gpt-5.6-sol",
+        "openai.gpt-5.6-luna",
+        "openai.gpt-5.6-terra",
+        "openai.gpt-5.5",
+        "openai/bedrock/gpt-5.4",
+        "openai.gpt-5.7-hypothetical-future",  # forward-compatible by design
+        "o3-mini",
+        "o4-mini",
+    ],
+)
+def test_reasoning_models_reject_temperature(model_id):
+    assert bc.model_rejects_temperature(model_id) is True
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "us.anthropic.claude-sonnet-4-6",
+        "anthropic.claude-haiku-4-5",
+        "openai.gpt-oss-120b",  # open-weight, accepts temperature
+        "meta.llama3-3-70b-instruct-v1:0",
+    ],
+)
+def test_standard_models_accept_temperature(model_id):
+    assert bc.model_rejects_temperature(model_id) is False
+
+
+class _StubClient(bc.BedrockClient):
+    """BedrockClient with the boto3 client and singleton machinery bypassed."""
+
+    def __init__(self, model_id):  # noqa: D107 - test double
+        self.model_id = model_id
+        self.region = "us-east-2"
+        self._initialized = True
+
+    def __new__(cls, *a, **k):  # bypass the per-region singleton cache
+        return object.__new__(cls)
+
+
+def test_request_body_omits_temperature_for_reasoning_model():
+    """The 400 this prevents: 'temperature' is not supported with this model."""
+    body = _StubClient("openai.gpt-5.6-luna")._build_request_body(
+        [{"role": "user", "content": "hi"}], max_tokens=64, temperature=0.0
+    )
+    assert "temperature" not in body
+
+
+def test_request_body_keeps_temperature_for_claude():
+    """Claude callers still get the determinism they asked for."""
+    body = _StubClient("us.anthropic.claude-sonnet-4-6")._build_request_body(
+        [{"role": "user", "content": "hi"}], max_tokens=64, temperature=0.0
+    )
+    assert body["temperature"] == 0.0
+
+
+def test_explicit_none_temperature_is_omitted():
+    """Callers can opt out explicitly regardless of model."""
+    body = _StubClient("us.anthropic.claude-sonnet-4-6")._build_request_body(
+        [{"role": "user", "content": "hi"}], max_tokens=64, temperature=None
+    )
+    assert "temperature" not in body
+
+
+def test_request_body_always_has_required_anthropic_fields():
+    body = _StubClient("us.anthropic.claude-sonnet-4-6")._build_request_body(
+        [{"role": "user", "content": "hi"}], max_tokens=128, temperature=0.3
+    )
+    assert body["anthropic_version"] == "bedrock-2023-05-31"
+    assert body["max_tokens"] == 128
+    assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# Non-Anthropic response bodies must fail loudly
+# ---------------------------------------------------------------------------
+
+
+def test_openai_shaped_response_raises_with_actionable_message():
+    """The silent-data-loss case: HTTP 200 but no `content` key.
+
+    Bedrock happily serves gpt-oss via invoke_model, returning an OpenAI-shaped
+    body with `choices`. Returning "" there meant callers treated an empty
+    string as a real answer and failed later somewhere unrelated.
+    """
+    client = _StubClient("openai.gpt-oss-120b")
+    openai_body = {"choices": [{"message": {"content": "hello"}}]}
+
+    with pytest.raises(ValueError) as excinfo:
+        client.extract_text_from_response(openai_body)
+
+    message = str(excinfo.value)
+    assert "BEDROCK_MODEL_ID" in message
+    assert "openai.gpt-oss-120b" in message
+    # Must not imply non-Anthropic models are unusable for evals — they aren't.
+    assert "evaluation targets and judges" in message
+
+
+def test_anthropic_response_still_extracts_text():
+    client = _StubClient("us.anthropic.claude-sonnet-4-6")
+    body = {
+        "content": [
+            {"type": "text", "text": "line one"},
+            {"type": "tool_use", "name": "t", "input": {}},
+            {"type": "text", "text": "line two"},
+        ]
+    }
+    assert client.extract_text_from_response(body) == "line one\nline two"
+
+
+def test_empty_content_list_is_not_an_error():
+    """A model that legitimately returned only tool_use blocks yields ""."""
+    client = _StubClient("us.anthropic.claude-sonnet-4-6")
+    assert client.extract_text_from_response({"content": []}) == ""

--- a/tests/test_bedrock_models.py
+++ b/tests/test_bedrock_models.py
@@ -110,3 +110,86 @@ def test_foundation_model_dedup_against_inference_profile():
     ids = [m["modelId"] for m in result["models"]]
     assert ids.count("us.anthropic.claude-sonnet-4-6") == 1
     assert "anthropic.claude-sonnet-4-6" not in ids
+
+
+# ---------------------------------------------------------------------------
+# ID normalization
+#
+# These were nested closures inside list_bedrock_models, so they couldn't be
+# tested at all. They're module-level now — and the regional-prefix tuple was
+# missing jp/au/ca, which meant a Japanese or Australian inference profile got
+# "jp" reported as its provider and failed to dedupe against its base model.
+# ---------------------------------------------------------------------------
+
+
+def test_strip_regional_prefix_covers_all_aws_regions():
+    cases = {
+        "us.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "eu.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "apac.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "jp.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "au.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "ca.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "us-gov.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        "global.anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+        # Already bare — unchanged.
+        "anthropic.claude-sonnet-4-6": "anthropic.claude-sonnet-4-6",
+    }
+    for raw, expected in cases.items():
+        assert bedrock_models.strip_regional_prefix(raw) == expected, raw
+
+
+def test_strip_regional_prefix_does_not_eat_vendor_names():
+    """A vendor whose name isn't a region prefix must survive untouched."""
+    assert bedrock_models.strip_regional_prefix("amazon.nova-pro-v1:0") == "amazon.nova-pro-v1:0"
+    assert bedrock_models.strip_regional_prefix("writer.palmyra-x5") == "writer.palmyra-x5"
+
+
+def test_extract_provider_name_skips_regional_prefix():
+    assert bedrock_models.extract_provider_name("jp.anthropic.claude-sonnet-4-6") == "anthropic"
+    assert bedrock_models.extract_provider_name("openai.gpt-oss-120b-1:0") == "openai"
+    assert bedrock_models.extract_provider_name("nonsense") == "nonsense"
+    assert bedrock_models.extract_provider_name("") == "unknown"
+
+
+def test_normalize_model_id_strips_version_suffix():
+    """Converse IDs carry a '-N:M' version that Mantle IDs omit.
+
+    Without stripping it, `openai.gpt-oss-120b-1:0` (Converse) and
+    `openai.gpt-oss-120b` (Mantle) look like different models and the same
+    weights get listed twice under two different provider prefixes.
+    """
+    assert bedrock_models.normalize_model_id("openai.gpt-oss-120b-1:0") == "openai.gpt-oss-120b"
+    assert (
+        bedrock_models.normalize_model_id("us.meta.llama3-3-70b-instruct-v1:0")
+        == "meta.llama3-3-70b-instruct-v1:0"
+    )
+    # No version suffix — unchanged.
+    assert bedrock_models.normalize_model_id("openai.gpt-oss-120b") == "openai.gpt-oss-120b"
+
+
+def test_mantle_duplicate_of_converse_model_is_dropped():
+    """gpt-oss is on BOTH endpoints; only the Converse entry should be listed.
+
+    Converse is what validate_providers smoke-tests and what pricing resolves
+    against, so it's the entry that should win.
+    """
+    foundation = [("openai.gpt-oss-120b-1:0", "gpt-oss-120b")]
+    mantle = [
+        {"id": "openai/bedrock/gpt-oss-120b", "name": "GPT-OSS 120B"},
+        {"id": "openai/bedrock/gpt-5.6-sol", "name": "GPT-5.6 Sol"},
+    ]
+    with patch.object(
+        bedrock_models,
+        "create_boto3_bedrock_client",
+        return_value=_fake_client([], foundation_models=foundation),
+    ), patch.object(bedrock_models, "get_external_models", return_value=mantle), patch.object(
+        bedrock_models, "detect_available_providers", return_value=[]
+    ):
+        result = bedrock_models.list_available_models()
+
+    ids = [m["id"] for m in result["models"]]
+    assert "bedrock/openai.gpt-oss-120b-1:0" in ids
+    assert "openai/bedrock/gpt-oss-120b" not in ids, "duplicate of a Converse model"
+    # A Mantle-only model must still come through.
+    assert "openai/bedrock/gpt-5.6-sol" in ids

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -261,3 +261,72 @@ def test_limit_warning_explains_incomparability():
 
     src = _inspect.getsource(benchmarks.handle_run_benchmark)
     assert "not comparable" in src
+
+
+# ---------------------------------------------------------------------------
+# Truncation must be visible on benchmark results
+#
+# A reasoning model that runs out of tokens mid-thought scores 0 on that sample.
+# Observed: gpt-oss-20b truncated on 12/30 AIME 2025 problems at
+# max_tokens=8192, and ALL 12 scored 0 — the reported 0.467 was a floor, not an
+# ability. Benchmark numbers are what people quote, so a score depressed by the
+# token budget cannot be reported as if it measured the model.
+# ---------------------------------------------------------------------------
+
+
+def test_truncation_is_surfaced_as_lower_bound():
+    import inspect as _inspect
+
+    from eval_mcp.tools import benchmarks
+
+    src = _inspect.getsource(benchmarks.handle_run_benchmark)
+    assert "truncatedSamples" in src
+    assert "truncationWarning" in src
+    assert "LOWER BOUND" in src
+
+
+async def _fake_log(samples):
+    class _O:
+        def __init__(self, sr):
+            self.stop_reason = sr
+
+    class _S:
+        def __init__(self, sr):
+            self.output = _O(sr)
+
+    class _L:
+        pass
+
+    log = _L()
+    log.samples = [_S(sr) for sr in samples]
+    return log
+
+
+def test_count_truncated_samples_counts_only_max_tokens(monkeypatch):
+    import asyncio
+
+    from eval_mcp.tools import benchmarks
+
+    async def run():
+        import sys
+        import types
+
+        fake = types.ModuleType("inspect_ai.log")
+
+        async def read_eval_log_async(name, **kw):
+            return await _fake_log(["stop", "max_tokens", "stop", "max_tokens", "tool_calls"])
+
+        fake.read_eval_log_async = read_eval_log_async
+        monkeypatch.setitem(sys.modules, "inspect_ai.log", fake)
+        return await benchmarks._count_truncated_samples("x.eval")
+
+    assert asyncio.run(run()) == 2
+
+
+def test_count_truncated_samples_degrades_to_zero_on_error():
+    """A diagnostics helper must never break an otherwise-successful run."""
+    import asyncio
+
+    from eval_mcp.tools import benchmarks
+
+    assert asyncio.run(benchmarks._count_truncated_samples("/definitely/not/a/log.eval")) == 0

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -330,3 +330,21 @@ def test_count_truncated_samples_degrades_to_zero_on_error():
     from eval_mcp.tools import benchmarks
 
     assert asyncio.run(benchmarks._count_truncated_samples("/definitely/not/a/log.eval")) == 0
+
+
+def test_errored_samples_shrink_denominator_and_are_reported():
+    """Errored samples are excluded from accuracy, which flatters failing models.
+
+    Observed on AIME 2025: gpt-oss-20b hit 3 Bedrock read timeouts, so its
+    reported 0.519 was 14/27 while haiku and luna were graded on all 30. Treating
+    the errors as unsolved gives 0.467 — a materially different comparison. The
+    report must say which denominator was used.
+    """
+    import inspect as _inspect
+
+    from eval_mcp.tools import benchmarks
+
+    src = _inspect.getsource(benchmarks.handle_run_benchmark)
+    assert "erroredSamples" in src
+    assert "scoredSamples" in src
+    assert "EXCLUDED from the accuracy denominator" in src

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -224,3 +224,40 @@ async def test_get_benchmark_details_unknown_suggests_near_matches():
     d = json.loads(out[0].text)
     assert d["success"] is False
     assert "gsm8k" in d["didYouMean"]
+
+
+# ---------------------------------------------------------------------------
+# --limit reporting
+#
+# `--limit N` leaves eval.dataset.samples at the FULL dataset size while only N
+# samples are actually scored. Reporting the dataset size made a 3-sample smoke
+# test look like a complete 164-sample HumanEval run — overstating the evidence
+# behind a score, which is the one thing an eval tool must never do.
+# ---------------------------------------------------------------------------
+
+
+def test_limited_run_reports_samples_actually_run():
+    """totalTests must be what ran; the dataset size goes in datasetTotal."""
+    import inspect as _inspect
+
+    from eval_mcp.tools import benchmarks
+
+    src = _inspect.getsource(benchmarks.handle_run_benchmark)
+    # The summary must prefer results.total_samples over dataset.samples.
+    assert "total_samples" in src
+    assert "datasetTotal" in src
+    assert "limited" in src
+
+
+def test_limit_warning_explains_incomparability():
+    """A subset score is not comparable to published full-benchmark numbers.
+
+    Without saying so, a 20-sample HumanEval score gets quoted next to a
+    published pass@1 as though they measured the same thing.
+    """
+    import inspect as _inspect
+
+    from eval_mcp.tools import benchmarks
+
+    src = _inspect.getsource(benchmarks.handle_run_benchmark)
+    assert "not comparable" in src

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -293,3 +293,46 @@ def test_non_score_only_unchanged(jc: JudgeConfig) -> None:
     assert "static_output_solver" not in code
     assert 'metadata=["actual_output"]' not in code
     assert "score_only" not in cfg
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-model truncation
+#
+# Inspect's Bedrock provider defaults to max_tokens=2048. Reasoning models
+# (gpt-5.6-luna/sol/terra, gpt-oss-*) can spend that ENTIRE budget on their
+# reasoning channel and return an empty completion with
+# stop_reason="max_tokens". Verified live: luna and sol both burned 2048/2048
+# reasoning tokens with zero visible output on a hard proof task.
+#
+# The sample still "completes", so it used to score a plain 0.0 — a measurement
+# error indistinguishable from a wrong answer. In a real comparison this cost
+# gpt-oss-20b 3 samples and flipped it from 1st to last place.
+# ---------------------------------------------------------------------------
+
+
+def test_jury_scorer_block_flags_truncation_not_quality():
+    """The emitted scorer must distinguish truncation from a bad answer."""
+    from eval_mcp.tools.create_config import JURY_SCORER_BLOCK
+
+    assert "TRUNCATED" in JURY_SCORER_BLOCK
+    assert "truncated_no_output" in JURY_SCORER_BLOCK
+    # It must key off stop_reason, not just the empty string.
+    assert "stop_reason" in JURY_SCORER_BLOCK
+    # And still handle plain no-output separately.
+    assert "No output generated" in JURY_SCORER_BLOCK
+
+
+def test_generated_config_contains_truncation_guard(tmp_path, monkeypatch):
+    """A freshly generated config carries the guard.
+
+    The scorer reaches the eval as *source text* inside the generated task file,
+    so editing the module without the template would silently ship the old
+    behaviour — which is exactly the trap here.
+    """
+    from eval_mcp.tools.create_config import JURY_SCORER_BLOCK
+
+    # The block is emitted verbatim; assert the guard survives .format() by
+    # confirming it carries no unescaped format placeholders around the guard.
+    guard_start = JURY_SCORER_BLOCK.index("TRUNCATED")
+    guard = JURY_SCORER_BLOCK[guard_start - 400 : guard_start + 400]
+    assert "stop_reason ==" in guard or 'stop_reason == "max_tokens"' in guard

--- a/tests/test_database_region.py
+++ b/tests/test_database_region.py
@@ -1,0 +1,72 @@
+"""The RDS region is required under IAM auth, and is NOT the Bedrock region.
+
+Two regions legitimately differ in this codebase: Bedrock model calls default to
+us-east-2 (the only region serving the OpenAI frontier models), while RDS lives
+wherever it was deployed. Signing an RDS IAM token for the wrong region fails as
+an opaque auth error, so the database region is never guessed.
+
+Leaving it merely unset was its own trap: boto3 then builds
+``https://rds..amazonaws.com`` and raises "Invalid endpoint" — precisely the
+cryptic failure the no-guessing rule exists to avoid. It is validated where it
+is actually consumed (IAM auth) rather than unconditionally, because password
+auth never touches it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _pg_env(monkeypatch):
+    """Minimal required Postgres env, with every region hint removed."""
+    monkeypatch.setenv("POSTGRES_HOST", "db.example.internal")
+    monkeypatch.setenv("POSTGRES_DB", "evaldb")
+    monkeypatch.setenv("POSTGRES_USER", "evaluser")
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
+def test_iam_auth_without_region_fails_with_actionable_message(_pg_env, monkeypatch):
+    monkeypatch.setenv("POSTGRES_USE_IAM_AUTH", "true")
+    from backend.core.database import Database
+
+    with pytest.raises(RuntimeError) as excinfo:
+        Database()
+
+    message = str(excinfo.value)
+    assert "AWS_REGION" in message
+    # Must not send the reader chasing the Bedrock region.
+    assert "Bedrock" in message
+
+
+def test_password_auth_without_region_is_fine(_pg_env, monkeypatch):
+    """Only IAM auth consumes the region; don't break password-auth setups."""
+    monkeypatch.setenv("POSTGRES_USE_IAM_AUTH", "false")
+    from backend.core.database import Database
+
+    assert Database().region == ""
+
+
+def test_iam_auth_uses_the_configured_region(_pg_env, monkeypatch):
+    monkeypatch.setenv("POSTGRES_USE_IAM_AUTH", "true")
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
+    from backend.core.database import Database
+
+    assert Database().region == "eu-west-1"
+
+
+def test_region_is_not_taken_from_the_bedrock_default(_pg_env, monkeypatch):
+    """The database must never inherit bedrock_client.DEFAULT_REGION.
+
+    If it did, a user in eu-west-1 would sign RDS tokens for us-east-2 and see an
+    auth failure with no hint as to why.
+    """
+    monkeypatch.setenv("POSTGRES_USE_IAM_AUTH", "false")
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
+    from backend.core.database import Database
+    from eval_mcp.core.bedrock_client import DEFAULT_REGION
+
+    region = Database().region
+    assert region == "eu-west-1"
+    assert region != DEFAULT_REGION

--- a/tests/test_eval_results_headline.py
+++ b/tests/test_eval_results_headline.py
@@ -29,3 +29,20 @@ def test_mean_is_unweighted():
     a = _mean_scores({"x": 0.0, "y": 1.0})
     b = _mean_scores({"y": 1.0, "x": 0.0})
     assert a == b == 0.5
+
+
+def test_benchmark_precompute_has_no_undefined_config_name():
+    """Benchmark runs have no task_file, and that path referenced an undefined name.
+
+    `_build_detail_from_logs` fell back to `f"{config_name}.json"` in the
+    no-task_file branch, but config_name is never bound in that function. Every
+    benchmark run therefore raised NameError during pre-compute — the run
+    succeeded but its results never reached the viewer.
+    """
+    import inspect as _inspect
+
+    from eval_mcp.core import eval_results
+
+    src = _inspect.getsource(eval_results._build_detail_from_logs)
+    assert "f\"{config_name}.json\"" not in src, "undefined name reintroduced"
+    assert "f\"{task_name}.json\"" in src

--- a/tests/test_external_providers.py
+++ b/tests/test_external_providers.py
@@ -2,12 +2,37 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from eval_mcp.tools import external_providers as ep
 
 
 def _enabled(config):
     """Treat every provider as enabled regardless of keys/AWS creds."""
     return True
+
+
+# Bound before the autouse fixture patches the name, so the catalog tests below
+# can exercise the real implementation while the filtering tests stay offline.
+_real_list_mantle_models = ep.list_mantle_models
+
+
+@pytest.fixture(autouse=True)
+def _offline_mantle():
+    """Force the static-fallback path for every test in this module.
+
+    ``get_external_models`` now prefers the *live* Mantle catalog, so without
+    this the whole file would make network calls and its assertions would depend
+    on which models AWS happens to serve in the caller's region today. Tests
+    that specifically care about the live path patch in their own fixture data.
+    """
+    with patch.object(ep, "list_mantle_models", lambda *a, **k: None):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Provider filtering / aliasing
+# ---------------------------------------------------------------------------
 
 
 def test_openai_filter_includes_mantle_gpt5():
@@ -42,3 +67,204 @@ def test_unrelated_filter_excludes_mantle():
     with patch.object(ep, "_provider_enabled", _enabled):
         ids = [m["id"] for m in ep.get_external_models("google")]
     assert not any("bedrock/gpt-5" in m_id for m_id in ids)
+
+
+# ---------------------------------------------------------------------------
+# Static fallback list
+# ---------------------------------------------------------------------------
+
+
+def test_static_fallback_covers_gpt56_family():
+    """The offline fallback must list the current GPT-5.6 variants.
+
+    This list is only consulted when the live catalog is unreachable, so it can
+    rot silently. It's asserted here because a user with no network still gets
+    *some* usable set of IDs — and a fallback that omits the newest models is
+    how we ended up telling users gpt-5.6-sol didn't exist.
+    """
+    ids = {m["id"] for m in ep.EXTERNAL_PROVIDERS["bedrock-mantle"]["models"]}
+    assert {
+        "openai/bedrock/gpt-5.6-sol",
+        "openai/bedrock/gpt-5.6-terra",
+        "openai/bedrock/gpt-5.6-luna",
+        "openai/bedrock/gpt-5.5",
+    } <= ids
+
+
+# ---------------------------------------------------------------------------
+# Live Mantle catalog parsing
+# ---------------------------------------------------------------------------
+
+
+def _mantle_payload():
+    """A trimmed real /v1/models response (us-east-2, 2026-07-27)."""
+    return {
+        "data": [
+            {"id": "openai.gpt-5.6-sol", "status": "available"},
+            {"id": "openai.gpt-5.6-luna", "status": "available"},
+            {"id": "openai.gpt-5.5", "status": "available"},
+            {"id": "openai.gpt-5.5-2026-04-23", "status": "available"},
+            # Not yet enabled in this region — must be filtered out.
+            {"id": "openai.gpt-5.9-unreleased", "status": "unavailable"},
+            # Non-OpenAI models share the endpoint but aren't reachable via
+            # Inspect's openai/bedrock/ prefix.
+            {"id": "anthropic.claude-opus-5", "status": "available"},
+            {"id": "qwen.qwen3-32b", "status": "available"},
+        ]
+    }
+
+
+def _patch_catalog(payload):
+    """Patch the HTTP + token layer that list_mantle_models uses."""
+
+    class _Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    return patch.dict(
+        "sys.modules",
+        {
+            "httpx": type("httpx", (), {"get": staticmethod(lambda *a, **k: _Response())}),
+            "aws_bedrock_token_generator": type(
+                "tokgen", (), {"provide_token": staticmethod(lambda **k: "tok")}
+            ),
+        },
+    )
+
+
+def test_mantle_catalog_filters_to_available_openai_models():
+    ep._MANTLE_CACHE.clear()
+    with _patch_catalog(_mantle_payload()):
+        models = _real_list_mantle_models(region="us-east-2")
+
+    ids = [m["id"] for m in models]
+    assert "openai/bedrock/gpt-5.6-sol" in ids
+    assert "openai/bedrock/gpt-5.5" in ids
+    # status != available is excluded
+    assert "openai/bedrock/gpt-5.9-unreleased" not in ids
+    # non-OpenAI vendors on the same endpoint are excluded
+    assert not any("claude" in i or "qwen" in i for i in ids)
+
+
+def test_mantle_catalog_labels_dated_snapshots():
+    """Pinned snapshots get a readable label, not a raw ID."""
+    ep._MANTLE_CACHE.clear()
+    with _patch_catalog(_mantle_payload()):
+        models = _real_list_mantle_models(region="us-east-2")
+
+    by_id = {m["id"]: m["name"] for m in models}
+    assert by_id["openai/bedrock/gpt-5.5-2026-04-23"].startswith("GPT-5.5 (2026-04-23)")
+    assert by_id["openai/bedrock/gpt-5.6-sol"].startswith("GPT-5.6 Sol")
+
+
+def test_mantle_catalog_returns_none_when_unreachable():
+    """A catalog failure must degrade to None so the static list can answer.
+
+    Returning [] instead would make list_available_models report zero OpenAI
+    models — indistinguishable from "your account has no access".
+    """
+    ep._MANTLE_CACHE.clear()
+
+    def _boom(*a, **k):
+        raise RuntimeError("no network")
+
+    with patch.dict(
+        "sys.modules",
+        {"httpx": type("httpx", (), {"get": staticmethod(_boom)})},
+    ):
+        assert _real_list_mantle_models(region="us-east-2") is None
+
+
+def test_mantle_empty_openai_section_treated_as_unknown():
+    """Zero OpenAI models means 'response shape changed', not 'none exist'."""
+    ep._MANTLE_CACHE.clear()
+    with _patch_catalog({"data": [{"id": "qwen.qwen3-32b", "status": "available"}]}):
+        assert _real_list_mantle_models(region="us-east-2") is None
+
+
+def test_mantle_catalog_is_cached_per_region():
+    """A second call for the same region must not re-fetch."""
+    ep._MANTLE_CACHE.clear()
+    calls = []
+
+    class _Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            calls.append(1)
+            return _mantle_payload()
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "httpx": type("httpx", (), {"get": staticmethod(lambda *a, **k: _Response())}),
+            "aws_bedrock_token_generator": type(
+                "tokgen", (), {"provide_token": staticmethod(lambda **k: "tok")}
+            ),
+        },
+    ):
+        first = _real_list_mantle_models(region="us-east-2")
+        second = _real_list_mantle_models(region="us-east-2")
+
+    assert first == second
+    assert len(calls) == 1
+
+
+def test_cache_holds_multiple_regions_simultaneously():
+    """Probing several regions must not evict earlier ones.
+
+    find_mantle_regions_for_model() walks 4 regions to report where a model
+    lives; a single-slot cache would make every probe a fresh HTTP call and
+    then leave the cache holding whichever region happened to be last.
+    """
+    ep._MANTLE_CACHE.clear()
+    with _patch_catalog(_mantle_payload()):
+        _real_list_mantle_models(region="us-east-1")
+        _real_list_mantle_models(region="us-west-2")
+
+    assert set(ep._MANTLE_CACHE) == {"us-east-1", "us-west-2"}
+
+
+def test_find_regions_for_model_reports_where_it_lives():
+    """The region probe that turns 'not available' into an actionable message."""
+    per_region = {
+        "us-east-1": [{"id": "openai/bedrock/gpt-5.6-sol", "name": "s"}],
+        "us-east-2": [{"id": "openai/bedrock/gpt-5.6-sol", "name": "s"}],
+        "us-west-2": [{"id": "openai/bedrock/gpt-5.6-luna", "name": "l"}],
+        "eu-west-1": None,  # unreachable
+    }
+    with patch.object(ep, "list_mantle_models", lambda region=None: per_region.get(region)):
+        assert ep.find_mantle_regions_for_model("openai/bedrock/gpt-5.6-sol") == [
+            "us-east-1",
+            "us-east-2",
+        ]
+        assert ep.find_mantle_regions_for_model("openai/bedrock/gpt-5.6-luna") == ["us-west-2"]
+        assert ep.find_mantle_regions_for_model("openai/bedrock/gpt-nope") == []
+
+
+def test_find_regions_accepts_bare_mantle_id():
+    """Callers may pass either ID form; both must resolve."""
+    with patch.object(
+        ep,
+        "list_mantle_models",
+        lambda region=None: [{"id": "openai/bedrock/gpt-5.5", "name": "x"}]
+        if region == "us-east-2"
+        else None,
+    ):
+        assert ep.find_mantle_regions_for_model("openai.gpt-5.5") == ["us-east-2"]
+        assert ep.find_mantle_regions_for_model("openai/bedrock/gpt-5.5") == ["us-east-2"]
+
+
+def test_live_catalog_preferred_over_static_list():
+    """When the catalog answers, its region-accurate list wins."""
+    live = [{"id": "openai/bedrock/gpt-5.6-sol", "name": "GPT-5.6 Sol"}]
+    with patch.object(ep, "_provider_enabled", _enabled), patch.object(
+        ep, "list_mantle_models", lambda *a, **k: live
+    ):
+        ids = [m["id"] for m in ep.get_external_models("bedrock-mantle")]
+    # Only the live entry — the static gpt-5.4 must not leak through.
+    assert ids == ["openai/bedrock/gpt-5.6-sol"]

--- a/tests/test_external_providers.py
+++ b/tests/test_external_providers.py
@@ -268,3 +268,57 @@ def test_live_catalog_preferred_over_static_list():
         ids = [m["id"] for m in ep.get_external_models("bedrock-mantle")]
     # Only the live entry — the static gpt-5.4 must not leak through.
     assert ids == ["openai/bedrock/gpt-5.6-sol"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_mantle_region — making GPT-5.x work for users outside us-east
+# ---------------------------------------------------------------------------
+
+
+def test_no_routing_when_home_region_serves_the_model():
+    """The common case must cost nothing: no hop, no probing."""
+    home = [{"id": "openai/bedrock/gpt-5.6-luna", "name": "l"}]
+    with patch.object(ep, "list_mantle_models", lambda region=None: home), patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-east-1"]
+    ):
+        assert ep.resolve_mantle_region("openai/bedrock/gpt-5.6-luna") is None
+
+
+def test_routes_to_another_region_when_home_lacks_the_model():
+    def _list(region=None):
+        return (
+            [{"id": "openai/bedrock/gpt-5.6-luna", "name": "l"}]
+            if region == "us-west-2"
+            else None
+        )
+
+    with patch.object(ep, "list_mantle_models", _list), patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-east-1", "us-east-2"]
+    ), patch(
+        "eval_mcp.core.bedrock_client.resolve_region", lambda *a, **k: "us-west-2"
+    ):
+        assert ep.resolve_mantle_region("openai/bedrock/gpt-5.6-sol") == "us-east-1"
+
+
+def test_never_routes_to_the_home_region_itself():
+    """Returning the home region would be a pointless no-op override."""
+    with patch.object(ep, "list_mantle_models", lambda region=None: None), patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-west-2"]
+    ), patch(
+        "eval_mcp.core.bedrock_client.resolve_region", lambda *a, **k: "us-west-2"
+    ):
+        assert ep.resolve_mantle_region("openai/bedrock/gpt-5.5") is None
+
+
+def test_pinned_region_env_var_wins(monkeypatch):
+    monkeypatch.setenv("EVAL_MCP_MANTLE_REGION", "eu-west-1")
+    assert ep.resolve_mantle_region("openai/bedrock/gpt-5.5") == "eu-west-1"
+
+
+def test_cross_region_can_be_disabled(monkeypatch):
+    """Data-residency escape hatch: prefer a clear failure over a silent hop."""
+    monkeypatch.setenv("EVAL_MCP_NO_CROSS_REGION", "1")
+    with patch.object(ep, "list_mantle_models", lambda region=None: None), patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-east-1"]
+    ):
+        assert ep.resolve_mantle_region("openai/bedrock/gpt-5.6-sol") is None

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -78,6 +78,57 @@ def test_bedrock_mantle_distinct_pricing(pricing):
     )
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "openai/bedrock/gpt-5.5",
+        "openai/bedrock/gpt-5.6-sol",
+        "openai/bedrock/gpt-5.6-terra",
+        "openai/bedrock/gpt-5.6-luna",
+    ],
+)
+def test_gpt5x_mantle_models_priced_offline(pricing, model_id):
+    """Every GPT-5.x model we surface must price from the vendored snapshot.
+
+    These IDs are advertised by list_available_models, so an unpriced one shows
+    up in the viewer as a blank cost column. The snapshot lagged the gpt-5.6
+    launch and returned None for all three variants until `make sync-pricing`.
+    """
+    cost = pricing.get_model_cost(model_id)
+    assert cost is not None, f"{model_id} unpriced — run `make sync-pricing`"
+    assert cost["input"] > 0 and cost["output"] > 0
+
+
+def test_gpt56_price_tiers_ordered(pricing):
+    """Sol > Terra > Luna, per AWS's positioning of the three variants.
+
+    Guards against a snapshot refresh silently scrambling which ID maps to
+    which price — the numbers are plausible individually but wrong in relation.
+    """
+    sol = pricing.get_model_cost("openai/bedrock/gpt-5.6-sol")
+    terra = pricing.get_model_cost("openai/bedrock/gpt-5.6-terra")
+    luna = pricing.get_model_cost("openai/bedrock/gpt-5.6-luna")
+    assert sol["input"] > terra["input"] > luna["input"]
+
+
+def test_dated_snapshot_falls_back_to_floating_alias(pricing):
+    """Pinned date snapshots price as their floating alias.
+
+    Mantle serves both `gpt-5.5` and `gpt-5.5-2026-04-23`; LiteLLM keys only the
+    former. The pinned ID is the better choice for a reproducible eval, so
+    reporting its cost as unknown would penalize the right decision.
+    """
+    dated = pricing.get_model_cost("openai/bedrock/gpt-5.5-2026-04-23")
+    alias = pricing.get_model_cost("openai/bedrock/gpt-5.5")
+    assert dated is not None
+    assert dated == alias
+
+
+def test_date_fallback_does_not_invent_prices(pricing):
+    """The fallback must not price a model family that genuinely isn't listed."""
+    assert pricing.get_model_cost("openai/bedrock/gpt-9.9-imaginary-2030-01-01") is None
+
+
 def test_unknown_model_returns_none(pricing):
     """Unknown models return None (distinct from a $0 cost)."""
     assert pricing.get_model_cost("bedrock/totally.invented-model-v9:0") is None

--- a/tests/test_run_eval_fail_loud.py
+++ b/tests/test_run_eval_fail_loud.py
@@ -17,7 +17,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from eval_mcp.tools.run_eval import is_catastrophic_eval_failure
+import json
+from unittest.mock import patch
+
+from eval_mcp.tools import external_providers as ep
+from eval_mcp.tools.run_eval import (
+    _PROVIDER_PATTERN,
+    _mantle_region_hint,
+    _summarize_failure,
+    is_catastrophic_eval_failure,
+)
 
 
 @dataclass
@@ -99,3 +108,187 @@ def test_results_object_without_expected_attrs_does_not_crash():
     # Has neither total_samples nor completed_samples — getattr defaults
     # to 0, so total_samples (0) > 0 is False → not catastrophic.
     assert is_catastrophic_eval_failure([], _Bare()) is False
+
+
+# ---------------------------------------------------------------------------
+# _summarize_failure — recovering the cause from Inspect's output
+#
+# Companion bug to the above: when the subprocess exits non-zero we used to read
+# only stderr, but Inspect's CLI renders fatal errors through its Rich console
+# on **stdout**. The result was the least useful report possible —
+# `success: false, exit code 1, stderr: ""` — with the real cause unread.
+#
+# The strings below are verbatim captures from real failing `inspect eval` runs
+# (2026-07-27, inspect_ai 0.3.241), trimmed for length. Box-drawing characters
+# and line wrapping are preserved because that framing is exactly what the
+# parser has to cope with.
+# ---------------------------------------------------------------------------
+
+
+# Missing task file. stdout only; stderr was literally 0 bytes.
+_STDOUT_NO_TASKS = "\nError: No inspect tasks were found at the specified paths.\n"
+
+# Credential failure mid-run, rendered as a Rich traceback panel on stdout.
+# Note the exit code was 0 here — a different failure mode, but the same
+# "the cause is in stdout" property.
+_STDOUT_RICH_TRACEBACK = """\
+╭──────────────────────────────────────────────────────────────────────────────╮
+│eval_task (1 sample): openai/bedrock/gpt-5.4                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭───────────────────── Traceback (most recent call last) ──────────────────────╮
+│ /path/to/site-packages/openai/_base_client.py                                │
+│ in _refresh_api_key                                                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+CredentialRetrievalError: Error when retrieving credentials from custom-process:
+Task interrupted (no samples completed before interruption)
+"""
+
+# An ImportError in the task file DOES go to stderr, wrapped in ASCII box
+# framing (Rich falls back to `|` when it can't use Unicode).
+_STDERR_ASCII_FRAMED = """\
+| /path/to/configs/broken.py:2 in <module>                                     |
+| ModuleNotFoundError: No module named 'nonexistent_module_xyz'                |
+"""
+
+
+def test_summarize_reads_stdout_when_stderr_is_empty():
+    """The core regression: stderr empty, cause sitting in stdout.
+
+    This is the exact shape of the bug — an eval that failed with an unhelpful
+    `stderr: ""` while stdout said precisely what was wrong.
+    """
+    assert (
+        _summarize_failure("", _STDOUT_NO_TASKS)
+        == "Error: No inspect tasks were found at the specified paths."
+    )
+
+
+def test_summarize_extracts_exception_from_rich_traceback_panel():
+    """Pull the exception line out of Inspect's box-drawn traceback."""
+    result = _summarize_failure("", _STDOUT_RICH_TRACEBACK)
+    assert result.startswith("CredentialRetrievalError:")
+    # Box-drawing characters must not survive into the message.
+    assert "│" not in result
+
+
+def test_summarize_strips_ascii_box_framing():
+    """Rich uses `|` framing on terminals without Unicode; strip it too.
+
+    Without this the agent sees "| ModuleNotFoundError: ..." — readable, but
+    it leaks our rendering details into what should be a clean error string.
+    """
+    result = _summarize_failure(_STDERR_ASCII_FRAMED, "")
+    assert result == "ModuleNotFoundError: No module named 'nonexistent_module_xyz'"
+
+
+def test_summarize_prefers_stderr_over_stdout():
+    """A genuine crash on stderr outranks whatever stdout was mid-render.
+
+    stdout during a failed run is mostly progress UI; if stderr has content
+    it's the more direct signal.
+    """
+    result = _summarize_failure(_STDERR_ASCII_FRAMED, _STDOUT_NO_TASKS)
+    assert result.startswith("ModuleNotFoundError")
+
+
+def test_summarize_returns_empty_when_nothing_recognizable():
+    """No marker match → "" so the caller keeps its generic exit-code message.
+
+    Inventing a summary from unrecognized output would be worse than saying
+    nothing: it would bury the exit code behind a misleading line.
+    """
+    assert _summarize_failure("", "eval_task (5 samples): all good\nmean 0.6\n") == ""
+
+
+def test_summarize_handles_both_streams_empty():
+    """Process died with no output at all (e.g. SIGKILL / OOM)."""
+    assert _summarize_failure("", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# _mantle_region_hint — "not available" must not mean "doesn't exist"
+#
+# OpenAI's frontier models launch region-by-region on Bedrock. gpt-5.5 and
+# gpt-5.6-sol were us-east-1/us-east-2 only while gpt-5.6-terra/luna and
+# gpt-5.4 were also in us-west-2. A bare "model not available" reads as "this
+# model doesn't exist" — which is precisely the wrong conclusion to invite.
+# ---------------------------------------------------------------------------
+
+
+def test_region_hint_names_regions_that_serve_the_model():
+    with patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-east-1", "us-east-2"]
+    ):
+        hint = _mantle_region_hint("openai/bedrock/gpt-5.6-sol", "us-west-2")
+
+    assert "us-west-2" in hint  # where we looked
+    assert "us-east-1" in hint and "us-east-2" in hint  # where it lives
+    assert "AWS_REGION=us-east-1" in hint  # the actionable fix
+
+
+def test_region_hint_excludes_the_region_we_already_tried():
+    """Suggesting the region that just failed would be nonsense."""
+    with patch.object(
+        ep, "find_mantle_regions_for_model", lambda _m: ["us-east-2", "us-west-2"]
+    ):
+        hint = _mantle_region_hint("openai/bedrock/gpt-5.5", "us-west-2")
+
+    assert "AWS_REGION=us-east-2" in hint
+    assert "AWS_REGION=us-west-2" not in hint
+
+
+def test_region_hint_when_model_found_nowhere():
+    """Genuinely unknown model — don't imply a region change will help."""
+    with patch.object(ep, "find_mantle_regions_for_model", lambda _m: []):
+        hint = _mantle_region_hint("openai/bedrock/gpt-9.9-nope", "us-west-2")
+
+    assert "wasn't found in any other region" in hint
+    assert "AWS_REGION=" not in hint
+
+
+def test_provider_pattern_matches_both_bedrock_endpoints():
+    """Mantle model IDs must be extracted for pre-flight validation.
+
+    The old pattern was `"(bedrock/[^"]+)"`, whose leading `"` anchor made
+    "openai/bedrock/gpt-5.5" unmatchable. Every GPT-5.x config therefore skipped
+    validation entirely and failed later with an opaque non-zero exit instead of
+    the actionable region/access message.
+    """
+    config = json.dumps(
+        {
+            "providers": [
+                "openai/bedrock/gpt-5.6-sol",
+                "bedrock/us.anthropic.claude-sonnet-4-6",
+            ],
+            "judge_models": {"openai/bedrock/gpt-5.5": "openai/bedrock/gpt-5.5"},
+        }
+    )
+    found = set(_PROVIDER_PATTERN.findall(config))
+    assert "openai/bedrock/gpt-5.6-sol" in found
+    assert "openai/bedrock/gpt-5.5" in found
+    assert "bedrock/us.anthropic.claude-sonnet-4-6" in found
+
+
+def test_provider_pattern_does_not_match_unrelated_strings():
+    """Don't sweep up direct-API or non-Bedrock IDs — they need no smoke test."""
+    config = json.dumps(
+        {"providers": ["openai/gpt-5.4", "anthropic/claude-opus-4-6", "google/gemini-3-flash"]}
+    )
+    assert _PROVIDER_PATTERN.findall(config) == []
+
+
+def test_region_hint_survives_probe_failure():
+    """A failed probe must degrade to the plain message, not break validation.
+
+    This runs inside the error path of _validate_providers — an exception here
+    would replace an actionable model error with an unrelated stack trace.
+    """
+
+    def _boom(_m):
+        raise RuntimeError("network down")
+
+    with patch.object(ep, "find_mantle_regions_for_model", _boom):
+        hint = _mantle_region_hint("openai/bedrock/gpt-5.5", "us-west-2")
+
+    assert "us-west-2" in hint
+    assert "AWS_REGION=" not in hint

--- a/tests/test_run_eval_fail_loud.py
+++ b/tests/test_run_eval_fail_loud.py
@@ -310,3 +310,72 @@ def test_eval_launches_with_raised_max_tokens():
     from eval_mcp.tools.run_eval import _DEFAULT_MAX_TOKENS
 
     assert _DEFAULT_MAX_TOKENS > 2048, "must exceed Inspect's Bedrock default"
+
+
+# ---------------------------------------------------------------------------
+# Cross-region routing for Mantle models
+#
+# Mantle availability is per-region but AWS credentials are global, so a user in
+# us-west-2 or eu-west-1 CAN invoke a us-east-only model by pointing that request
+# at us-east-2. Without this the MCP only worked for users who happened to be in
+# a us-east region and told everyone else the model did not exist.
+# ---------------------------------------------------------------------------
+
+
+def test_region_for_run_prefers_a_region_serving_the_models():
+    from eval_mcp.tools.run_eval import _region_for_run
+
+    cfg = {"mantle_regions": {"openai/bedrock/gpt-5.6-sol": "us-east-2"}}
+    models = ["bedrock/us.anthropic.claude-haiku-4-5", "openai/bedrock/gpt-5.6-sol"]
+    assert _region_for_run(cfg, models) == "us-east-2"
+
+
+def test_region_for_run_falls_back_to_ambient_when_no_override_needed():
+    """No routing when the caller's own region already serves everything."""
+    from eval_mcp.core.bedrock_client import resolve_region
+    from eval_mcp.tools.run_eval import _region_for_run
+
+    assert _region_for_run({}, ["bedrock/us.anthropic.claude-haiku-4-5"]) == resolve_region()
+
+
+def test_region_for_run_ignores_overrides_for_models_not_in_this_run():
+    """A stale entry for an unused model must not relocate the run."""
+    from eval_mcp.core.bedrock_client import resolve_region
+    from eval_mcp.tools.run_eval import _region_for_run
+
+    cfg = {"mantle_regions": {"openai/bedrock/gpt-5.5": "us-east-1"}}
+    assert _region_for_run(cfg, ["bedrock/amazon.nova-pro-v1:0"]) == resolve_region()
+
+
+def test_region_for_run_is_deterministic_with_conflicting_regions():
+    """Two models wanting different regions must resolve the same way every time.
+
+    Non-deterministic selection would make a config's behaviour depend on dict
+    iteration order — the kind of flake that is nearly impossible to diagnose.
+    """
+    from eval_mcp.tools.run_eval import _region_for_run
+
+    cfg = {
+        "mantle_regions": {
+            "openai/bedrock/gpt-5.5": "us-east-2",
+            "openai/bedrock/gpt-5.6-sol": "us-east-1",
+        }
+    }
+    models = ["openai/bedrock/gpt-5.5", "openai/bedrock/gpt-5.6-sol"]
+    picks = {_region_for_run(cfg, models) for _ in range(5)}
+    assert picks == {"us-east-1"}, "must sort, not depend on dict order"
+
+
+def test_task_file_scan_fallback_does_not_raise_name_error():
+    """The no-JSON-config branch referenced an undefined `task_content`.
+
+    It raised NameError instead of scanning, so a config missing its sibling
+    JSON silently got "no models" rather than the intended fallback.
+    """
+    import inspect as _inspect
+
+    from eval_mcp.tools import run_eval
+
+    src = _inspect.getsource(run_eval.handle_run_evaluation)
+    idx = src.index("Fallback: scan the task .py")
+    assert "task_content = Path(task_file).read_text()" in src[idx : idx + 600]

--- a/tests/test_run_eval_fail_loud.py
+++ b/tests/test_run_eval_fail_loud.py
@@ -292,3 +292,21 @@ def test_region_hint_survives_probe_failure():
 
     assert "us-west-2" in hint
     assert "AWS_REGION=" not in hint
+
+
+# ---------------------------------------------------------------------------
+# max_tokens default
+# ---------------------------------------------------------------------------
+
+
+def test_eval_launches_with_raised_max_tokens():
+    """Every eval must pass an explicit --max-tokens above Inspect's 2048.
+
+    Inspect's Bedrock provider defaults to 2048, which reasoning models can
+    consume entirely on their reasoning channel — producing an empty completion
+    that scores 0 while the run reports success. Measured: gpt-5.6-luna and
+    gpt-5.6-sol both hit 2048/2048 reasoning tokens with no visible output.
+    """
+    from eval_mcp.tools.run_eval import _DEFAULT_MAX_TOKENS
+
+    assert _DEFAULT_MAX_TOKENS > 2048, "must exceed Inspect's Bedrock default"


### PR DESCRIPTION
Adds working support for the OpenAI frontier models on Bedrock Mantle — GPT-5.6 Sol/Terra/Luna and GPT-5.5 — as both **evaluation targets and jury judges**, from **any AWS region**.

Verified against real Bedrock throughout (no mocks, per `never-mockllm` convention): custom eval configs through the MCP handler, a 5-model mixed comparison, and four `inspect_evals` benchmarks (HumanEval with Docker sandbox, GSM8K, AIME 2025, GPQA Diamond).

## The core problem

AWS rolls Mantle models out region by region. As of 2026-07-27 `gpt-5.5` and `gpt-5.6-sol` are **us-east-1/us-east-2 only**, while `gpt-5.6-terra`, `gpt-5.6-luna` and `gpt-5.4` are also in us-west-2. Nine call sites did `os.environ.get("AWS_REGION", "us-west-2")`, ignoring the user's configured profile — so those two models were unreachable and the tool reported they **did not exist**.

The enabling fix: AWS credentials are global, only the Mantle *endpoint* is regional. So a model the caller's region doesn't serve is routed to one that does.

- `resolve_region()` — `AWS_REGION` → `AWS_DEFAULT_REGION` → **resolved profile's region** → `us-east-2`
- `resolve_mantle_region()` — per-model routing, decided once at config-creation time and stored in `mantle_regions`; returns `None` (no hop) when the local region already serves the model
- Judges apply it per-model in the generated task file; targets arrive via `--model` on the CLI so the whole subprocess relocates instead

Two obvious shortcuts are dead ends, confirmed by testing: `-M aws_region=` is global and errors on Converse models, and `BEDROCK_OPENAI_BASE_URL` alone gives `401 Credential should be scoped to a valid region` because the bearer token is still minted for the ambient region.

Scope is narrow: **only `openai/bedrock/*` inference moves.** Converse models, S3, RDS and logs stay in the user's region. `EVAL_MCP_MANTLE_REGION` pins a region; `EVAL_MCP_NO_CROSS_REGION=1` disables the hop.

## Other defects fixed

Several were cases where the tool reported a plausible number that was wrong — the worst failure mode for an eval tool.

| Defect | Impact |
|---|---|
| Provider regex `"(bedrock/…)"` couldn't match `openai/bedrock/*` | **Every GPT-5.x config skipped pre-flight validation entirely**, then failed with an opaque non-zero exit |
| Only stderr read on failure | Inspect renders fatal errors on **stdout** → `exit code 1, stderr: ""` with the cause unread |
| Reasoning models scored 0 on a token limit | luna/sol burn the whole budget on reasoning and return an empty completion. Cost gpt-oss-20b 3 AIME samples and flipped it from 1st to last |
| Truncation reported as ability | 12/30 truncated samples all scored 0; a 0.467 was a floor, not a measurement |
| Errored samples silently excluded from the denominator | Flattered whichever model failed most (0.519 was 14/27, not 16/30) |
| Benchmark results never reached the viewer | `NameError` on an undefined `config_name` in the no-`task_file` branch — i.e. the benchmark path |
| `--limit` overstated sample counts | A 3-sample smoke test reported `totalTests: 164` |
| Registry stale + never verified | Replaced with Mantle's live `/v1/models` catalog (10-min per-region cache), matching the repo's existing no-allowlist approach |
| `extract_text_from_response` returned `""` for non-Anthropic bodies | gpt-oss returns HTTP 200 with `choices`; the empty string was consumed as a real answer |
| `temperature` sent to reasoning models | Hard 400 `unsupported_parameter`, not a warning |
| gpt-5.6 unpriced offline | Snapshot refreshed; pinned date snapshots fall back to their floating alias |
| Pre-existing `NameError` on `main` | `task_content` undefined in the no-JSON-config fallback |

## Notes for review

- **`DEFAULT_REGION` is us-east-2 deliberately** — it carries the full model set. us-east-2 has 81 Converse models vs us-west-2's 86, and the entire difference is retired variants (Llama 3.0, Mistral 2402/2407, Mixtral 8x7B, Claude 3 Sonnet). Every current-generation model is in both. Pinned by a test.
- **Bedrock region ≠ storage region.** `user_storage.py`, `s3_client.py` and `database.py` intentionally do *not* use `resolve_region()` — they address S3/RDS whose location is fixed at deploy time. They have no guessed default; the RDS one is validated under IAM auth so it fails with a clear message rather than `https://rds..amazonaws.com`.
- **Terraform region defaults changed but are effectively dead code** — `deploy.sh` errors without `AWS_REGION` and `buildspec-scripts/deploy.sh` always writes an explicit `region = ...`. No deployed infrastructure relocates as a result of this PR.
- **The `--max-tokens` default is 8192, not 32k.** Only the hardest benchmark truncated, and only for one model; a blanket 4× would slow every eval. Truncation is now *visible* instead, so the caller can raise it where it matters.

## Testing

432 → 517 tests. Also exercised end-to-end via the real MCP handler, including a deliberately mixed run from a us-west-2 shell (gpt-5.5 + gpt-5.6-sol, neither available locally, plus a Converse Claude model, judged by gpt-5.6-sol — all 5/5 samples).

⚠️ **Not deployed to EKS.** `backend/` and `infra/` are touched, so CLAUDE.md's deploy-then-merge rule applies. Skipped at the maintainer's explicit direction; the pod risk was closed by inspection (`infra/platform/kubernetes.tf:41` sets `AWS_REGION` unconditionally, both containers read it via `envFrom`) but not proven in a live pod.