### PR TITLE
fix(deps): cap mcp below 2.0 so the MCP server starts on a fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,20 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    # Core MCP + eval engine
-    "mcp>=1.0.0",
+    # Core MCP + eval engine.
+    #
+    # Capped below 2.0: mcp 2.0.0 (published 2026-07-28) REMOVED `FastMCP` from
+    # `mcp.server` — it is not relocated, `mcp.server.fastmcp` and a top-level
+    # `fastmcp` both 404. `eval_mcp/server.py` builds the entire server from
+    # FastMCP, so an unpinned resolve installs 2.0.0 and the MCP dies on import
+    # with "cannot import name 'FastMCP'". Every new install was affected within
+    # hours of that release, in 0.13.0 and 0.14.0 alike.
+    #
+    # The cap is a stopgap, not the destination: mcp 2.x replaces FastMCP with
+    # `MCPServer`, whose __init__ and `.tool()` decorator are close enough that
+    # migration is tractable (tracked separately). Keeping the cap until that
+    # lands means users get a working server today instead of waiting on it.
+    "mcp>=1.0.0,<2",
     # Floor (no upper cap) is intentional: we import several private inspect-ai
     # modules (._view.common, .tool._tool_info, .log._samples, .event._model),
     # so the floor guarantees those paths exist. The deployed image and local

--- a/tests/test_server_boots.py
+++ b/tests/test_server_boots.py
@@ -1,0 +1,98 @@
+"""The MCP server must actually import and start — not merely respond to --help.
+
+This exists because mcp 2.0.0 removed `FastMCP` from `mcp.server` and shipped a
+broken MCP in two consecutive releases (0.13.0, 0.14.0) without anything failing.
+The dependency was pinned `mcp>=1.0.0`, so every fresh install resolved 2.0.0 and
+died at `eval_mcp/server.py` with "cannot import name 'FastMCP'".
+
+It went unnoticed because the obvious checks all route around the failure:
+
+  - `eval-mcp --help` is a Click callback that returns BEFORE
+    `eval_mcp.server` is imported, so it exits 0 on a completely broken install.
+  - `eval-mcp view --help` / `serve --help` likewise.
+  - A developer venv pinned to mcp 1.x never reproduces it.
+
+So the only check that catches this class of breakage is one that imports the
+server module and confirms the tools actually registered.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+def test_server_module_imports():
+    """`import eval_mcp.server` must succeed.
+
+    This is the exact line that broke: `from mcp.server import FastMCP`. In a
+    subprocess so a failure is an assertion rather than a collection error that
+    takes down the rest of the suite.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import eval_mcp.server"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"eval_mcp.server failed to import — the MCP would not start.\n"
+        f"{result.stderr}"
+    )
+
+
+def test_server_registers_tools():
+    """Importing the server must produce a populated tool registry.
+
+    Guards the case where the import succeeds against a future mcp API but the
+    registration decorators silently no-op, which would present to users as an
+    MCP that connects and then offers nothing.
+    """
+    code = (
+        "import asyncio, eval_mcp.server as s;"
+        "tools = asyncio.run(s.mcp.list_tools());"
+        "print(len(tools))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"listing tools failed:\n{result.stderr}"
+    count = int(result.stdout.strip().splitlines()[-1])
+    # ~27 at the time of writing; assert a floor rather than an exact number so
+    # adding a tool doesn't break the test, but wholesale loss does.
+    assert count >= 20, f"expected the full tool set, got {count}"
+
+
+def test_fastmcp_is_importable():
+    """Pin the specific symbol whose removal caused the outage.
+
+    A dependency bump that takes FastMCP away must fail here — loudly, in CI —
+    rather than in a user's IDE after release.
+    """
+    try:
+        from mcp.server import FastMCP  # noqa: F401
+    except ImportError as e:
+        pytest.fail(
+            "mcp.server.FastMCP is unavailable, so the MCP server cannot be "
+            "constructed. mcp 2.x removed it in favour of MCPServer — either "
+            "keep the `mcp<2` cap in pyproject.toml or migrate "
+            f"eval_mcp/server.py to the 2.x API. Underlying error: {e}"
+        )
+
+
+def test_mcp_dependency_is_capped_below_2():
+    """The declared requirement must exclude the incompatible major version.
+
+    Asserted on package metadata rather than the pyproject text so it reflects
+    what a user actually resolves.
+    """
+    import importlib.metadata as md
+
+    reqs = md.requires("llm-evaluation-system") or []
+    mcp_reqs = [r for r in reqs if r.split(";")[0].strip().startswith("mcp")]
+    assert mcp_reqs, "no mcp requirement declared"
+    assert any("<2" in r for r in mcp_reqs), (
+        f"mcp must be capped below 2.0 until server.py migrates off FastMCP; "
+        f"found {mcp_reqs}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ requires-dist = [
     { name = "inspect-ai", specifier = ">=0.3.241" },
     { name = "inspect-evals", specifier = ">=0.14.1" },
     { name = "inspect-k8s-sandbox", marker = "extra == 'k8s-sandbox'", specifier = ">=0.4.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.0.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "openai", specifier = ">=2.40.0" },
     { name = "openai", marker = "extra == 'providers'", specifier = ">=2.26.0" },
@@ -3990,7 +3990,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Cap `mcp>=1.0.0,<2` — mcp 2.0.0 removed `FastMCP` from `mcp.server`, so every fresh PyPI install of the MCP crashes on import
- Add `tests/test_server_boots.py` (4 tests) that actually **boots** the server, which is the check whose absence let this ship twice
- Refresh `uv.lock` (still resolves mcp 1.28.1 — no change for the deployed container)

## Why

mcp 2.0.0 was published **2026-07-28 13:45 UTC**, a few hours before v0.14.0. It removed `FastMCP` — not relocated, `mcp.server.fastmcp` and a top-level `fastmcp` both `ModuleNotFoundError`. `eval_mcp/server.py:19` builds the entire server from it, so with the previous unbounded range a fresh resolve installs 2.0.0 and dies:

```
ImportError: cannot import name 'FastMCP' from 'mcp.server'
```

**Scope: new PyPI installs only.** `0.13.0` and `0.14.0` are equally affected, so there is no good version to fall back to.

| Install path | Resolves mcp | Works |
|---|---|---|
| EKS pod (`uv sync --locked`) | 1.28.1 from `uv.lock` | ✅ |
| Existing dev venv | whatever was installed (1.27.x) | ✅ |
| `uvx --from llm-evaluation-system` | **2.0.0** | ❌ |

Lockfiles ignore the declared range, which is why the deployment and local development were both unaffected — and why this went unnoticed.

## The real fix is the test

Every obvious check routes around the broken import:

- `eval-mcp --help` is a Click callback that returns **before** `eval_mcp.server` is imported — it exits 0 on a completely broken install. Same for `view --help` / `serve --help`.
- A dev venv already pinned to mcp 1.x never reproduces it.

`tests/test_server_boots.py` therefore:
1. imports `eval_mcp.server` in a subprocess (the exact line that broke)
2. asserts the tool registry is populated — catches a future API change that no-ops registration, which would present as an MCP that connects then offers nothing
3. asserts `FastMCP` is importable, with a message pointing at either the cap or the migration
4. asserts the `<2` cap is in the **installed metadata**, not the pyproject text, so it reflects what a user resolves

## The cap is a stopgap

mcp 2.x replaces `FastMCP` with `MCPServer`, whose `__init__` and `.tool()` decorator are close enough that migration is tractable rather than a rewrite (~24 `mcp` touchpoints, mostly `TextContent` imports). Tracked separately; noted in the pin comment so the cap isn't mistaken for the destination. Capping now means users get a working server today instead of waiting on that work.

## Test plan

- [x] `pytest tests/` — 521 passed (was 517)
- [x] **Built the wheel and installed it into a clean venv**: resolves mcp 1.29.0, server boots, 27 tools served over stdio. This is the check that should have gated 0.14.0.
- [x] Confirmed the new tests fail against the un-capped metadata before the fix
- [ ] Post-release: `uvx --from llm-evaluation-system eval-mcp` boots on a cleaned cache