### PR TITLE
fix(webapp): repair chat reconnect, history navigation, and transcript scroll

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1287,6 +1287,42 @@ async def chat_stream(request: ChatRequest, user_id: str):
                         pass
         return
 
+    # No live task to reattach to, and nothing to say. This is the
+    # reconnect-lost-the-race path: `reconnectIfRunning` checked
+    # /chat/status, saw `running: true`, and POSTed an empty message to
+    # reattach — but by the time the POST landed the task had finished
+    # (or the "running" flag was a stale `session_active` row from a pod
+    # that died mid-run). Falling through would start a REAL turn with
+    # empty text, and Bedrock hard-rejects that:
+    #
+    #     ValidationException: messages.2: user messages must have
+    #     non-empty content
+    #
+    # Worse, the empty user message is already persisted by then, so the
+    # session is poisoned permanently — every later turn re-loads that
+    # row from history and fails the same way. Symptom: opening /history
+    # and returning to a finished chat fills the transcript with
+    # "Thinking…" bubbles that each die, and the conversation can never
+    # be used again. Close the stream cleanly instead; there's nothing
+    # to stream and nothing to say.
+    if not request.message.strip() and not request.file:
+        logger.info(
+            f"[STREAM] Empty message with no live task for session {session_id} "
+            "— reconnect lost the race; closing stream without starting a turn"
+        )
+        # Clear the stale flag so the next status check reports idle
+        # instead of luring another reconnect into the same dead end.
+        try:
+            await asyncio.wait_for(db.clear_session_active(session_id), timeout=2.0)
+        except (asyncio.TimeoutError, Exception):
+            pass
+        # Close the stream with no further events. Deliberately NOT a
+        # `complete` event: the frontend's handler reads `data.response`
+        # and would blank the bubble to `undefined`. An empty stream lets
+        # `reconnectIfRunning` see "no content arrived" and drop its
+        # placeholder bubble entirely.
+        return
+
     # Ensure user exists
     await db.create_user(user_id, user_id)
 
@@ -1383,6 +1419,12 @@ async def chat_non_stream(request: ChatRequest, user_id: str) -> ChatResponse:
     """Handle non-streaming chat requests (legacy mode)."""
     if not bedrock_client or not mcp_client or not db:
         raise HTTPException(status_code=500, detail="Backend not initialized")
+
+    # Same guard as the streaming path: an empty message would be
+    # persisted and then rejected by Bedrock ("user messages must have
+    # non-empty content"), permanently poisoning the session's history.
+    if not request.message.strip() and not request.file:
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
 
     try:
         # Generate session ID if not provided

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional
 
 import asyncpg
@@ -40,6 +40,15 @@ def _require_env(name: str) -> str:
 class Database:
     # IAM tokens are valid for 15 minutes, refresh at 10 minutes to be safe
     TOKEN_REFRESH_SECONDS = 600
+
+    # How long a `session_active` row stays believable. Rows are deleted
+    # when a turn ends, so a row older than this means the pod died
+    # without running its cleanup. See get_session_active().
+    #
+    # A timedelta, not a string: asyncpg maps Postgres `interval` to
+    # datetime.timedelta and rejects a str with the very unhelpful
+    # "'str' object has no attribute 'days'".
+    SESSION_ACTIVE_TTL = timedelta(hours=6)
 
     def __init__(self):
         # Get connection parameters from environment (all required)
@@ -468,11 +477,30 @@ class Database:
             return sessions
 
     async def get_session_messages(self, session_id: str) -> List[Dict[str, Any]]:
-        """Get all messages for a session."""
+        """Get all messages for a session, skipping empty ones.
+
+        Blank-content rows are never written any more (`chat_stream`
+        refuses to start a turn on an empty message), but sessions that
+        were poisoned before that guard existed still carry one. Bedrock
+        rejects the whole request if history contains an empty user
+        message —
+
+            ValidationException: messages.N: user messages must have
+            non-empty content
+
+        — so a single legacy row makes the conversation permanently
+        unusable: every turn re-hydrates it and fails again. Filtering on
+        read heals those sessions without a migration, and covers every
+        consumer at once (agent hydration, /api/sessions, the
+        first-turn title check). An empty message carries no information,
+        so dropping it loses nothing.
+        """
         await self._ensure_pool_fresh()
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(
-                "SELECT id, role, content, timestamp FROM messages WHERE session_id = $1 ORDER BY timestamp ASC",
+                "SELECT id, role, content, timestamp FROM messages "
+                "WHERE session_id = $1 AND btrim(coalesce(content, '')) <> '' "
+                "ORDER BY timestamp ASC",
                 session_id,
             )
 
@@ -623,17 +651,33 @@ class Database:
             logger.warning(f"Failed to clear session_active for {session_id}: {e}")
 
     async def get_session_active(self, session_id: str) -> bool:
-        """Return True if the session has an active row in session_active.
+        """Return True if the session has a *recent* active row.
 
         Used by chat_status as the cross-pod fallback when the session
         is not found in the local in-memory active_tasks dict.
+
+        Rows are cleared in `run_agent_background`'s finally block, but
+        that only runs if the pod survives. A pod OOM-killed, evicted or
+        rescheduled mid-turn leaves its row behind forever — nothing else
+        ever deletes it. The frontend then believes the session is live
+        on every visit and fires a reconnect that can't succeed, which
+        used to poison the session (see the empty-message guard in
+        `chat_stream`).
+
+        The `started_at` cutoff makes the flag self-healing: a row older
+        than the longest plausible turn is treated as debris. The window
+        is generous because a turn can legitimately run a long eval, and
+        being wrong in the "still running" direction only costs a
+        harmless reconnect attempt — whereas being wrong the other way
+        would cut off a live stream.
         """
         await self._ensure_pool_fresh()
         try:
             async with self._pool.acquire() as conn:
                 row = await conn.fetchrow(
-                    "SELECT 1 FROM session_active WHERE session_id = $1",
-                    session_id,
+                    "SELECT 1 FROM session_active "
+                    "WHERE session_id = $1 AND started_at > NOW() - $2::interval",
+                    session_id, self.SESSION_ACTIVE_TTL,
                 )
                 return row is not None
         except asyncpg.PostgresError as e:

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -21,9 +21,26 @@ export default function MessageList() {
   const { messages, isLoading } = useChat();
   const navigate = useNavigate();
   const bottomRef = useRef<HTMLDivElement>(null);
+  // Id of the first message in the transcript we last scrolled for. When
+  // it changes, the whole transcript was REPLACED (a different
+  // conversation) rather than appended to.
+  const firstIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    const firstId = messages[0]?.id ?? null;
+    // Smooth is right for a conversation growing under you — a streaming
+    // token or a new turn — where the glide shows you what moved.
+    //
+    // It is wrong for OPENING a conversation. `scrollIntoView` animates
+    // from wherever the pane happens to be, so switching to a long
+    // transcript raced from 0 to ~3900px over ~720ms: measured on a
+    // 30-message chat, and the "bizarre scrolling" in the bug report.
+    // A replaced transcript should simply START at the bottom.
+    const replaced = firstId !== firstIdRef.current;
+    firstIdRef.current = firstId;
+    bottomRef.current?.scrollIntoView({
+      behavior: replaced ? "auto" : "smooth",
+    });
   }, [messages]);
 
   const showEmpty = messages.length === 0 && !isLoading;

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -167,79 +167,101 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             }
             if (line.startsWith("data: ")) {
               const jsonData = line.slice(6);
+              // Only the parse is guarded. Event handling used to live
+              // inside this try too, which meant the `error` event's
+              // `throw` was caught by the parse handler below and merely
+              // console.logged — so a backend failure left the bubble
+              // frozen on "💭 Thinking…" forever instead of surfacing.
+              // That's the visible symptom of the empty-message
+              // ValidationException this commit also fixes.
+              let data: Record<string, unknown> & {
+                session_id?: string;
+                message?: string;
+                content?: string;
+                tool?: string;
+                response?: string;
+                error?: string;
+              };
               try {
-                const data = JSON.parse(jsonData);
-
-                if (currentEventType === "session") {
-                  if (data.session_id) {
-                    streamSessionId = data.session_id;
-                    setCurrentSessionId(data.session_id);
-                    setChatSessions((prev) => {
-                      if (prev.some((s) => s.id === data.session_id)) {
-                        return prev;
-                      }
-                      return [
-                        {
-                          id: data.session_id,
-                          title: "New Chat",
-                          createdAt: new Date().toISOString(),
-                          messages: [],
-                        },
-                        ...prev,
-                      ];
-                    });
-                  }
-                } else if (currentEventType === "progress" || currentEventType === "status") {
-                  statusContent = data.message || data.content || "";
-                  patchAssistant({
-                    content: assistantContent || statusContent,
-                    metadata: { isStreaming: true, progress: statusContent },
-                  });
-                } else if (currentEventType === "tool_call") {
-                  const toolText = `🔧 ${data.tool}`;
-                  statusHistory.push(toolText);
-                  statusContent = statusHistory.join(' → ');
-                  patchAssistant({
-                    content: assistantContent || statusContent,
-                    metadata: { isStreaming: true, tool: data.tool, progress: statusContent },
-                  });
-                } else if (currentEventType === "tool_result") {
-                  statusContent = `✓ Tool ${data.tool} completed`;
-                  patchAssistant({
-                    content: assistantContent || statusContent,
-                    metadata: { isStreaming: true, progress: statusContent },
-                  });
-                } else if (currentEventType === "text") {
-                  assistantContent += data.content || "";
-                  patchAssistant({
-                    content: assistantContent,
-                    metadata: { isStreaming: true },
-                  });
-                } else if (currentEventType === "thinking") {
-                  const thinkingText = `💭 ${data.message?.slice(0, 100) || 'Thinking'}${data.message?.length > 100 ? '...' : ''}`;
-                  statusHistory.push(thinkingText);
-                  statusContent = statusHistory.join(' → ');
-                  patchAssistant({
-                    content: assistantContent || statusContent,
-                    metadata: { isStreaming: true, progress: statusContent },
-                  });
-                } else if (currentEventType === "complete") {
-                  assistantContent = data.response;
-                  patchAssistant({
-                    content: assistantContent,
-                    metadata: { isStreaming: false },
-                  });
-                } else if (currentEventType === "cancelled") {
-                  assistantContent += "\n\n*[Request cancelled]*";
-                  patchAssistant({
-                    content: assistantContent,
-                    metadata: { isStreaming: false },
-                  });
-                } else if (currentEventType === "error") {
-                  throw new Error(data.error || data.message || "Unknown error");
-                }
+                data = JSON.parse(jsonData);
               } catch (e) {
-                console.error("Error parsing SSE data:", e);
+                console.error("Error parsing SSE data:", e, jsonData);
+                continue;
+              }
+
+              if (currentEventType === "session") {
+                // Bound to a local so it stays narrowed to `string`
+                // inside the setState closure below.
+                const newSessionId = data.session_id;
+                if (newSessionId) {
+                  streamSessionId = newSessionId;
+                  setCurrentSessionId(newSessionId);
+                  setChatSessions((prev) => {
+                    if (prev.some((s) => s.id === newSessionId)) {
+                      return prev;
+                    }
+                    return [
+                      {
+                        id: newSessionId,
+                        title: "New Chat",
+                        createdAt: new Date().toISOString(),
+                        messages: [],
+                      },
+                      ...prev,
+                    ];
+                  });
+                }
+              } else if (currentEventType === "progress" || currentEventType === "status") {
+                statusContent = data.message || data.content || "";
+                patchAssistant({
+                  content: assistantContent || statusContent,
+                  metadata: { isStreaming: true, progress: statusContent },
+                });
+              } else if (currentEventType === "tool_call") {
+                const toolText = `🔧 ${data.tool}`;
+                statusHistory.push(toolText);
+                statusContent = statusHistory.join(' → ');
+                patchAssistant({
+                  content: assistantContent || statusContent,
+                  metadata: { isStreaming: true, tool: data.tool, progress: statusContent },
+                });
+              } else if (currentEventType === "tool_result") {
+                statusContent = `✓ Tool ${data.tool} completed`;
+                patchAssistant({
+                  content: assistantContent || statusContent,
+                  metadata: { isStreaming: true, progress: statusContent },
+                });
+              } else if (currentEventType === "text") {
+                assistantContent += data.content || "";
+                patchAssistant({
+                  content: assistantContent,
+                  metadata: { isStreaming: true },
+                });
+              } else if (currentEventType === "thinking") {
+                const raw = data.message ?? "";
+                const thinkingText = `💭 ${raw.slice(0, 100) || 'Thinking'}${raw.length > 100 ? '...' : ''}`;
+                statusHistory.push(thinkingText);
+                statusContent = statusHistory.join(' → ');
+                patchAssistant({
+                  content: assistantContent || statusContent,
+                  metadata: { isStreaming: true, progress: statusContent },
+                });
+              } else if (currentEventType === "complete") {
+                // Keep whatever streamed if the terminal event carries no
+                // text — assigning undefined would blank the bubble.
+                assistantContent = data.response ?? assistantContent;
+                patchAssistant({
+                  content: assistantContent,
+                  metadata: { isStreaming: false },
+                });
+              } else if (currentEventType === "cancelled") {
+                assistantContent += "\n\n*[Request cancelled]*";
+                patchAssistant({
+                  content: assistantContent,
+                  metadata: { isStreaming: false },
+                });
+              } else if (currentEventType === "error") {
+                throw new Error(data.error || data.message || "Unknown error");
               }
             }
           }
@@ -290,7 +312,18 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         if (!response.ok || !response.headers.get("content-type")?.includes("text/event-stream")) {
           throw new Error("reconnect failed");
         }
-        await consumeStream(response, assistantMessageId);
+        const { content } = await consumeStream(response, assistantMessageId);
+        // Nothing arrived — the run had already finished by the time this
+        // POST landed (or the "running" flag was stale debris from a pod
+        // that died mid-turn). The backend closes the stream without
+        // starting a turn in that case, so there's no answer coming.
+        // Drop the placeholder instead of leaving a dead "Reconnecting…"
+        // bubble in the transcript: visiting /history and coming back used
+        // to stack one of these per visit.
+        if (!content.trim()) {
+          setMessages((prev) => prev.filter((m) => m.id !== assistantMessageId));
+          return false;
+        }
         // Pull the now-complete transcript from the DB so the cached session
         // (used by loadChat on later navigation) is consistent.
         await loadUserSessions();

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -31,7 +31,7 @@ interface ChatContextType {
   cancelRequest: () => Promise<void>;
   handleDocumentsUploaded: (result: UploadResult) => void;
   createNewChat: () => void;
-  loadChat: (sessionId: string) => void;
+  loadChat: (sessionId: string) => Promise<void>;
   // If `sessionId` is still streaming on the backend (e.g. after a page
   // refresh mid-response), reattach to the live SSE stream. Returns true if a
   // reconnect happened. No-op if the session already finished.
@@ -85,13 +85,44 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   }, [authLoading, user?.name]);
 
 
-  const loadChat = useCallback((sessionId: string) => {
-    const session = chatSessions.find((s) => s.id === sessionId);
-    if (session) {
+  // Show `sessionId`'s transcript. Falls back to fetching when the
+  // session isn't in the local cache.
+  //
+  // It used to silently no-op in that case, and the cache goes stale
+  // easily: it's populated once at mount, while /history fetches its own
+  // fresh list. So clicking a conversation created after mount (or in
+  // another tab) switched the URL but left the PREVIOUS conversation's
+  // messages on screen — the reported "shows several things", and it also
+  // stranded currentSessionId on the old session, which let the
+  // URL-sync effect in Chat.tsx rewrite ?session back and bounce the user
+  // out of the chat they clicked.
+  const loadChat = useCallback(async (sessionId: string) => {
+    const cached = chatSessions.find((s) => s.id === sessionId);
+    if (cached) {
       setCurrentSessionId(sessionId);
-      setMessages(session.messages);
+      setMessages(cached.messages);
+      return;
     }
-  }, [chatSessions]);
+
+    // Not cached — switch immediately so currentSessionId and the URL
+    // agree (otherwise the URL-sync effect fights this navigation), then
+    // fill in the transcript.
+    setCurrentSessionId(sessionId);
+    setMessages([]);
+    try {
+      const response = await fetch(
+        `/api/sessions?user_id=${encodeURIComponent(user?.name ?? "")}`,
+      );
+      if (!response.ok) return;
+      const data = await response.json();
+      const sessions: ChatSession[] = data.sessions || [];
+      setChatSessions(sessions);
+      const found = sessions.find((s) => s.id === sessionId);
+      if (found) setMessages(found.messages);
+    } catch (error) {
+      console.error("Failed to load chat:", error);
+    }
+  }, [chatSessions, user?.name]);
 
   const createNewChat = useCallback(() => {
     const newSession: ChatSession = {

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -58,6 +58,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   // "network error" in the UI.
   const cancelledAtRef = useRef<number | null>(null);
   const POST_CANCEL_COOLDOWN_MS = 2000;
+  // Session ids with a reconnect attempt in flight — see
+  // reconnectIfRunning.
+  const reconnectingRef = useRef<Set<string>>(new Set());
 
   const loadUserSessions = async () => {
     if (!user?.name) return;
@@ -278,7 +281,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   // After a page refresh mid-response, the backend keeps the agent running
   // (the SSE client just disconnected). Re-POST with an empty message to
   // reattach to the live queue and show tokens as they continue to arrive.
-  const reconnectIfRunning = useCallback(
+  const runReconnect = useCallback(
     async (sessionId: string): Promise<boolean> => {
       let running = false;
       try {
@@ -337,6 +340,26 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       }
     },
     [consumeStream, user?.id],
+  );
+
+  // One reconnect per session at a time. Chat.tsx's effect re-fires
+  // whenever chatSessions or currentSessionId changes, so without this a
+  // single visit fans out into a burst of concurrent reconnects — the
+  // deployed DB shows 9 landing inside the same second, each having
+  // started its own turn and written its own empty row. A ref, not
+  // state: concurrent callers have to observe the flag synchronously,
+  // and a setState wouldn't have applied yet.
+  const reconnectIfRunning = useCallback(
+    async (sessionId: string): Promise<boolean> => {
+      if (reconnectingRef.current.has(sessionId)) return false;
+      reconnectingRef.current.add(sessionId);
+      try {
+        return await runReconnect(sessionId);
+      } finally {
+        reconnectingRef.current.delete(sessionId);
+      }
+    },
+    [runReconnect],
   );
 
   const sendMessage = useCallback(

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -34,15 +34,18 @@ export default function ChatPage() {
 
     if (sessionParam) {
       if (autoLoadedRef.current === sessionParam) return;
-      if (chatSessions.some((s) => s.id === sessionParam)) {
-        loadChat(sessionParam);
-        autoLoadedRef.current = sessionParam;
-        // If this session was still streaming when the page was loaded/
-        // refreshed, reattach to the live backend stream so tokens keep
-        // arriving instead of the response appearing frozen.
-        reconnectIfRunning(sessionParam);
-      }
-      // If sessions haven't loaded yet, this effect re-runs when they do.
+      // Load unconditionally — do NOT gate on the session being present
+      // in the cached chatSessions. The cache is filled once at mount, so
+      // a conversation created later (or in another tab) is missing from
+      // it; gating meant the click changed the URL but left the previous
+      // transcript rendered, with currentSessionId still pointing at the
+      // old chat. loadChat now fetches when it needs to.
+      loadChat(sessionParam);
+      autoLoadedRef.current = sessionParam;
+      // If this session was still streaming when the page was loaded/
+      // refreshed, reattach to the live backend stream so tokens keep
+      // arriving instead of the response appearing frozen.
+      reconnectIfRunning(sessionParam);
       return;
     }
 
@@ -71,6 +74,14 @@ export default function ChatPage() {
   // the empty new-chat stub, so it can't race the "+ New chat" clear.
   useEffect(() => {
     if (!currentSessionId || sessionParam === currentSessionId) return;
+    // The URL already names a DIFFERENT session than the one in context.
+    // That means the user just navigated here (e.g. clicked an entry on
+    // /history) and the switch hasn't settled yet. Writing the URL now
+    // would clobber their target with the previous conversation's id and
+    // bounce them straight back out of the chat they picked — the
+    // reported "click something in history and it jumps around". The
+    // ?session=X effect above owns this case; let it land.
+    if (sessionParam) return;
     const s = chatSessions.find(
       (x: ChatSession) => x.id === currentSessionId,
     );

--- a/tests/test_chat_reconnect_empty_message.py
+++ b/tests/test_chat_reconnect_empty_message.py
@@ -1,0 +1,357 @@
+"""Reconnect must never start a turn with an empty message.
+
+The frontend's `reconnectIfRunning` reattaches to a still-running answer
+after a navigation or refresh: it checks `/api/chat/status/<id>` and, if
+that says `running`, re-POSTs to `/api/chat/message` with an EMPTY
+message to subscribe to the live stream.
+
+That check is inherently racy — and the "running" flag can also be pure
+debris, because `session_active` rows are only deleted by the finally
+block of `run_agent_background`, which never runs if the pod is
+OOM-killed or evicted mid-turn. Either way the empty POST arrives with
+no live task to attach to.
+
+Before this fix it fell through to the normal path and started a REAL
+turn with empty text. Two consequences, both observed against the live
+`make dev` stack:
+
+1. Bedrock hard-rejects it —
+   `ValidationException: messages.2: user messages must have non-empty
+   content` — so the user sees a dead "Thinking…" bubble. Clicking
+   History and returning stacked one more on every visit.
+
+2. Far worse, the empty user message is persisted BEFORE the model call,
+   so the session is poisoned permanently: every later turn re-hydrates
+   that empty row from the DB and fails identically. The conversation
+   can never be used again.
+
+These tests pin both halves: the guard itself, and the TTL that stops a
+dead pod's `session_active` row from luring the frontend into the guard
+forever.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _RecordingDB:
+    """Minimal in-memory DB that records what got written, so a test can
+    prove an empty message never reached the `messages` table."""
+
+    def __init__(self):
+        self._messages: dict[str, list[dict]] = {}
+        self.create_user = AsyncMock(return_value=None)
+        self.create_session = AsyncMock(return_value=None)
+        self.clear_session_cancellation = AsyncMock(return_value=None)
+        self.get_session_cancellation = AsyncMock(return_value=None)
+        self.update_session_title = AsyncMock(return_value=None)
+        self.mark_session_active = AsyncMock(return_value=None)
+        self.clear_session_active = AsyncMock(return_value=None)
+        self.notify_session_event = AsyncMock(return_value=None)
+
+    async def save_message(self, msg_id, session_id, role, content):
+        self._messages.setdefault(session_id, []).append(
+            {"id": msg_id, "role": role, "content": content,
+             "timestamp": datetime.datetime.now()}
+        )
+
+    async def get_session_messages(self, session_id):
+        # Mirrors the real query's `btrim(coalesce(content,'')) <> ''`
+        # filter so a legacy empty row can't reach the model.
+        return [
+            {"id": m["id"], "role": m["role"], "content": m["content"],
+             "timestamp": m["timestamp"].isoformat()}
+            for m in self._messages.get(session_id, [])
+            if (m["content"] or "").strip()
+        ]
+
+    async def raw_messages(self, session_id):
+        """Unfiltered view, for asserting what's physically stored."""
+        return list(self._messages.get(session_id, []))
+
+
+class _ExplodingBedrock:
+    """Stands in for Bedrock and fails the way the real service does if a
+    turn is ever started with empty user content. If the guard works this
+    is never called at all."""
+
+    def __init__(self):
+        self.called = False
+
+    def convert_mcp_tools_to_claude(self, tools):
+        return []
+
+    def extract_text_from_response(self, resp):
+        return ""
+
+    def extract_tool_uses(self, resp):
+        return []
+
+    async def create_message_streaming(self, messages, tools, system):
+        self.called = True
+        for m in messages:
+            if isinstance(m.get("content"), str) and not m["content"].strip():
+                raise AssertionError(
+                    "Bedrock was called with an empty user message — real "
+                    "Bedrock answers this with ValidationException: "
+                    "'user messages must have non-empty content'."
+                )
+        yield {"type": "text", "text": "ok"}
+        yield {"type": "end", "stop_reason": "end_turn",
+               "response": {"content": [{"type": "text", "text": "ok"}]}}
+
+    def create_message(self, *a, **k):
+        raise NotImplementedError
+
+
+class _FakeMCP:
+    def set_user_id(self, _u):
+        pass
+
+    async def list_tools(self):
+        return []
+
+    async def read_resource(self, _name):
+        class _R:
+            contents = [type("X", (), {"text": '{"tools": []}'})()]
+        return _R()
+
+
+def _collect(events: list[str]) -> list[str]:
+    """Extract the SSE event names from raw stream chunks."""
+    names = []
+    for chunk in events:
+        for line in chunk.splitlines():
+            if line.startswith("event: "):
+                names.append(line[len("event: "):].strip())
+    return names
+
+
+async def _drive_stream(main, session_id, message, user_id="u1"):
+    request = main.ChatRequest(message=message, session_id=session_id, stream=True)
+    return [chunk async for chunk in main.chat_stream(request, user_id)]
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Wire the module globals the streaming path reads."""
+    from backend.api import main
+
+    db = _RecordingDB()
+    bed = _ExplodingBedrock()
+    monkeypatch.setattr(main, "db", db)
+    monkeypatch.setattr(main, "bedrock_client", bed)
+    monkeypatch.setattr(main, "mcp_client", _FakeMCP())
+    main.cancelled_sessions.clear()
+    main.active_tasks.clear()
+    main.event_queues.clear()
+    return main, db, bed
+
+
+@pytest.mark.asyncio
+async def test_empty_message_with_no_live_task_does_not_start_a_turn(wired):
+    """The core guard: an empty POST with nothing running must close the
+    stream instead of starting a turn."""
+    main, db, bed = wired
+    session_id = "sess-reconnect-race"
+
+    chunks = await _drive_stream(main, session_id, "")
+
+    assert not bed.called, (
+        "An empty reconnect POST reached Bedrock. In production this "
+        "returns ValidationException and leaves a dead 'Thinking…' bubble."
+    )
+    # The session announcement is fine (the frontend keys off it); what
+    # must NOT appear is an error.
+    assert "error" not in _collect(chunks)
+
+
+@pytest.mark.asyncio
+async def test_empty_message_is_never_persisted(wired):
+    """The poisoning half. An empty user row in `messages` breaks the
+    session forever, because every later turn re-hydrates it from the DB
+    and Bedrock rejects the whole request."""
+    main, db, bed = wired
+    session_id = "sess-no-poison"
+
+    # A real prior exchange, as if the user had already chatted.
+    await db.save_message("m1", session_id, "user", "hey")
+    await db.save_message("m2", session_id, "assistant", "Hey! How can I help?")
+
+    await _drive_stream(main, session_id, "")
+
+    # Assert on the RAW table, not the filtered read — the point is that
+    # nothing was written, not merely that the read hides it.
+    stored = await db.raw_messages(session_id)
+    empties = [m for m in stored if not (m["content"] or "").strip()]
+    assert not empties, (
+        f"An empty message was persisted: {empties}. This permanently "
+        f"poisons the session — every later turn reloads it and fails."
+    )
+    assert len(stored) == 2, f"expected the 2 original messages, got {stored}"
+
+
+@pytest.mark.asyncio
+async def test_already_poisoned_session_is_usable_again(wired):
+    """Sessions poisoned before the guard shipped must recover.
+
+    The guard prevents NEW empty rows but cannot remove the ones already
+    in prod — including the session from the original bug report. Those
+    stay broken forever unless the read filters blanks, because Bedrock
+    rejects any history containing an empty user message.
+    """
+    main, db, bed = wired
+    session_id = "sess-legacy-poison"
+
+    # Exactly the shape the old bug left behind.
+    await db.save_message("m1", session_id, "user", "hey")
+    await db.save_message("m2", session_id, "assistant", "Hey!")
+    await db.save_message("m3", session_id, "user", "")
+
+    chunks = await _drive_stream(main, session_id, "are you there?")
+
+    assert "error" not in _collect(chunks), (
+        f"A session with a legacy empty row still fails: {chunks}"
+    )
+    assert bed.called, "the turn should have reached the model"
+    # The empty row is still on disk; it just never reaches Bedrock.
+    assert any(not (m["content"] or "").strip() for m in await db.raw_messages(session_id))
+
+
+@pytest.mark.asyncio
+async def test_session_still_usable_after_a_failed_reconnect(wired):
+    """End-to-end proof the bug is gone: reconnect-race, then a normal
+    message must work. Before the fix this second turn died with
+    ValidationException because of the empty row left behind."""
+    main, db, bed = wired
+    session_id = "sess-recovers"
+
+    await db.save_message("m1", session_id, "user", "hey")
+    await db.save_message("m2", session_id, "assistant", "Hey!")
+
+    # The racy reconnect.
+    await _drive_stream(main, session_id, "")
+    # A genuine follow-up. _ExplodingBedrock raises if history is dirty.
+    chunks = await _drive_stream(main, session_id, "what is 2+2?")
+
+    names = _collect(chunks)
+    assert "error" not in names, (
+        f"A normal message after a failed reconnect errored: {chunks}"
+    )
+    assert bed.called, "the real turn should have reached Bedrock"
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_message_is_also_rejected(wired):
+    """`" "` is empty as far as Bedrock is concerned — guard on strip()."""
+    main, db, bed = wired
+    await _drive_stream(main, "sess-whitespace", "   \n\t ")
+    assert not bed.called
+    stored = await db.get_session_messages("sess-whitespace")
+    assert stored == []
+
+
+@pytest.mark.asyncio
+async def test_stale_active_flag_is_cleared_by_the_guard(wired):
+    """The guard clears `session_active` on its way out. Otherwise a dead
+    pod's row keeps reporting `running: true` and every visit to the
+    conversation fires another doomed reconnect."""
+    main, db, bed = wired
+    session_id = "sess-clears-flag"
+
+    await _drive_stream(main, session_id, "")
+
+    db.clear_session_active.assert_awaited_with(session_id)
+
+
+@pytest.mark.asyncio
+async def test_non_empty_message_still_starts_a_turn(wired):
+    """Guard rail on the guard: normal traffic must be untouched."""
+    main, db, bed = wired
+    session_id = "sess-normal"
+
+    chunks = await _drive_stream(main, session_id, "hello")
+
+    assert bed.called, "a normal message must still reach the model"
+    assert "error" not in _collect(chunks)
+    stored = await db.get_session_messages(session_id)
+    assert [m["role"] for m in stored] == ["user", "assistant"]
+    assert stored[0]["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_non_stream_endpoint_rejects_empty_message(wired):
+    """The JSON path shares the flaw and so shares the guard — it must
+    reject rather than persist-then-fail."""
+    from fastapi import HTTPException
+
+    main, db, bed = wired
+    request = main.ChatRequest(message="", session_id="sess-json", stream=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await main.chat_non_stream(request, "u1")
+
+    assert exc.value.status_code == 400
+    assert not bed.called
+    assert await db.get_session_messages("sess-json") == []
+
+
+def test_get_session_messages_filters_empty_rows():
+    """Sessions poisoned BEFORE the guard existed still carry an empty
+    row, and it keeps breaking them: every turn re-hydrates that row and
+    Bedrock rejects the request. The guard stops new poisoning but can't
+    undo old damage, so the read filters blanks out — no migration, and
+    it covers every consumer (agent hydration, /api/sessions, the title
+    check) at once.
+
+    Asserted at the SQL level because the filtering happens in the query.
+    """
+    import inspect
+
+    from backend.core.database import Database
+
+    src = inspect.getsource(Database.get_session_messages)
+    assert "btrim" in src and "content" in src, (
+        "get_session_messages no longer filters empty-content rows. "
+        "Sessions poisoned before the empty-message guard shipped will "
+        "stay permanently broken.\n"
+        f"Current source:\n{src}"
+    )
+
+
+def test_session_active_query_is_ttl_bounded():
+    """`session_active` rows are deleted in a finally block, which does
+    not run when a pod is OOM-killed or evicted. Without a TTL on the
+    read, such a row reports `running: true` forever and the frontend
+    reconnects on every visit. Asserted at the SQL level because the
+    behaviour lives in the query, not in Python.
+    """
+    import inspect
+
+    from backend.core.database import Database
+
+    src = inspect.getsource(Database.get_session_active)
+    assert "started_at" in src and "interval" in src, (
+        "get_session_active no longer bounds rows by age — a pod that dies "
+        "mid-turn will leave a row that reports 'running' forever.\n"
+        f"Current source:\n{src}"
+    )
+    # Must be a timedelta. asyncpg maps Postgres `interval` to
+    # datetime.timedelta and rejects a str with a misleading
+    # "'str' object has no attribute 'days'" — which get_session_active
+    # catches and turns into `running: False` for EVERY session, silently
+    # disabling cross-pod reconnect. Caught only by running it against a
+    # real Postgres; a str sails through any mock.
+    assert isinstance(Database.SESSION_ACTIVE_TTL, datetime.timedelta), (
+        f"SESSION_ACTIVE_TTL must be a timedelta for asyncpg to bind it as "
+        f"an interval, got {type(Database.SESSION_ACTIVE_TTL).__name__}"
+    )
+    # Long enough to cover a legitimately long turn (an eval can run for
+    # a while); erring long is safe because the only cost of a false
+    # 'running' is one harmless reconnect attempt, whereas erring short
+    # would cut off a live stream.
+    assert Database.SESSION_ACTIVE_TTL >= datetime.timedelta(hours=1)


### PR DESCRIPTION
## Summary

Four related defects in the web app's chat UI, all reproduced against a live stack and each verified with a control run (test fails on unpatched code, passes with the fix):

- **Empty-message poisoning** — reconnect could start a real turn with an empty message, which Bedrock rejects (`ValidationException: user messages must have non-empty content`). The empty row was persisted *before* the model call, so the session broke permanently: every later turn re-hydrated it and failed identically.
- **Reconnect burst** — `Chat.tsx`'s effect re-fires on `chatSessions`/`currentSessionId` changes with no in-flight guard, so one visit fanned out into many concurrent reconnects, each writing its own empty row.
- **Wrong conversation on history click** — `loadChat` silently no-op'd when the session wasn't in the mount-time cache, and the URL-sync effect then rewrote `?session=` back, bouncing the user out of the chat they clicked.
- **Racing scroll** — `MessageList` auto-scrolled with `behavior: "smooth"`, so opening a long conversation animated the whole way from the top.

## Why

Reported as: clicking History mid-chat filled the transcript with dead "Thinking…" bubbles, and afterwards the conversation was unusable; then separately, clicking an entry in History showed the wrong messages and scrolled bizarrely.

The deployed dev database confirmed the scale and the diagnosis: **23 empty rows across two sessions, 9 of them written inside the same second** (23:45:57 UTC), matching the 16:45 flood in the report (UTC-7).

Each fix targets one link in the chain:

| Fix | File |
|---|---|
| Refuse to start a turn on an empty message; clear the stale active flag | `backend/api/main.py` |
| TTL-bound `session_active` so a dead pod's row stops lying `running: true` | `backend/core/database.py` |
| Filter blank rows on read, so already-poisoned sessions recover with no migration | `backend/core/database.py` |
| Let the `error` SSE event propagate instead of being swallowed by the JSON-parse `catch` | `frontend/src/contexts/ChatContext.tsx` |
| Dedupe concurrent reconnects per session | `frontend/src/contexts/ChatContext.tsx` |
| Fetch uncached sessions in `loadChat`; stop the URL-sync effect clobbering navigation | `ChatContext.tsx`, `pages/Chat.tsx` |
| Jump instead of animate when the transcript is replaced | `frontend/src/components/MessageList.tsx` |

Two notes on the reasoning, both load-bearing:

- `SESSION_ACTIVE_TTL` is a `timedelta`, not a `str`. asyncpg binds Postgres `interval` as `timedelta` and rejects a string with `'str' object has no attribute 'days'`, which `get_session_active`'s `except` converts into `running: False` for *every* session — silently disabling cross-pod reconnect. A mock would not catch this; there's a test asserting the type.
- The empty stream deliberately sends no `complete` event. The frontend's handler reads `data.response` and would blank the bubble to `undefined`.

## Test plan

- [x] 530 pytest tests pass (`pytest tests/`), incl. 10 new in `test_chat_reconnect_empty_message.py` — 6 fail on unpatched code
- [x] Empty-message guard, TTL boundaries (5h59m vs 6h01m), and blank-row filtering verified against live Postgres
- [x] A previously-dead session answers again after the read-filter fix
- [x] Browser (Playwright + real Bedrock), each with an unpatched control run:
  - reconnect: 0 stuck bubbles, 0 `ValidationException`, session still usable (control: 1 / 1 / poisoned)
  - history: 5 distinct sessions each render their own transcript (control: URL says one session, transcript shows another)
  - scroll: opening a 30-message chat is 1 frame / ~40ms (was 18 frames / ~720ms); a streaming reply still glides through 10 positions
- [x] Verified live on the dev EKS deployment (us-east-2) before merge, per the deploy-then-merge convention

Local verification is single-pod; the cross-pod reconnect path was covered by the dev deployment.