### PR TITLE
feat(mcp): migrate to the mcp 2.x SDK and lift the <2 cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,34 @@ and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
   absence. `run_eval` also reports this: a Mantle validation failure probes the
   other regions and names the ones that do serve the model.
 
+### The mcp SDK is 2.x — things not to "tidy" back
+
+`eval_mcp/server.py` is built on `mcp.server.MCPServer` (mcp >= 2.0). v1's
+`FastMCP` no longer exists, and `pyproject.toml` floors mcp at `>=2.0.0`
+(pinned by a test). Four consequences that look like mistakes but aren't:
+
+- **`port`/`host` are not constructor args.** 2.x moved every
+  transport-specific parameter onto the run/app methods. The HTTP branch in
+  `main()` passes them to its own `uvicorn.run(...)`, which is why the
+  constructor doesn't need them. Re-adding `MCPServer(..., port=)` is a
+  `TypeError`.
+- **`version=` is passed explicitly.** v1 derived it; 2.x defaults to `""`
+  and would report a blank `serverInfo.version` to every client. It comes
+  from installed package metadata because setuptools-scm owns the version.
+- **`streamable_http_app(max_request_body_size=...)` is deliberate.** 2.x
+  caps bodies at 4 MiB (HTTP 413); v1 had no cap. `save_dataset` accepts a
+  dataset inline via `file_content`, so the default would newly reject
+  uploads that used to work. Override with `EVAL_MCP_MAX_BODY_BYTES`.
+- **Annotations are camelCase in constructors, snake_case on attributes.**
+  `ToolAnnotations(readOnlyHint=True)` is still correct, but *reading* it is
+  `.read_only_hint`. The wire format stays camelCase, so clients are
+  unaffected.
+
+Client-side, the Streamable HTTP transport is `streamable_http_client`
+(renamed from `streamablehttp_client`). Note mcp 2.x depends on **`httpx2`**,
+a separately-named package; our own code still uses plain `httpx` and the two
+coexist as distinct modules.
+
 ### Adding a tool
 
 1. Async handler in `eval_mcp/tools/<name>.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,10 +195,12 @@ and `gpt-5.4` are also in us-west-2. Consequences worth knowing:
 - **`version=` is passed explicitly.** v1 derived it; 2.x defaults to `""`
   and would report a blank `serverInfo.version` to every client. It comes
   from installed package metadata because setuptools-scm owns the version.
-- **`streamable_http_app(max_request_body_size=...)` is deliberate.** 2.x
-  caps bodies at 4 MiB (HTTP 413); v1 had no cap. `save_dataset` accepts a
-  dataset inline via `file_content`, so the default would newly reject
-  uploads that used to work. Override with `EVAL_MCP_MAX_BODY_BYTES`.
+- **The 4 MiB Streamable HTTP body cap is kept.** 2.x added it (v1 had
+  none), and nothing here sends a large body: the web app truncates to ~11
+  rows before `analyze_dataset` and writes datasets in-process via
+  `save_dataset_to_db`, so files never cross the wire. If a client ever
+  needs more, pass `max_request_body_size=` to `streamable_http_app()`
+  rather than dropping the bound.
 - **Annotations are camelCase in constructors, snake_case on attributes.**
   `ToolAnnotations(readOnlyHint=True)` is still correct, but *reading* it is
   `.read_only_hint`. The wire format stays camelCase, so clients are

--- a/backend/core/mcp_client.py
+++ b/backend/core/mcp_client.py
@@ -8,7 +8,7 @@ from contextlib import AsyncExitStack
 from typing import Any, Dict, List, Optional
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 def setup_mcp_logging(log_dir: str = "backend/logs") -> logging.Logger:
@@ -108,7 +108,7 @@ class MultiMCPClient:
                 if server_config["type"] == "http":
                     # Connect via HTTP with extended timeout for long-running evaluations
                     read, write, _ = await exit_stack.enter_async_context(
-                        streamablehttp_client(
+                        streamable_http_client(
                             server_config["url"],
                             timeout=3600.0,  # 1 hour for connection/request
                             sse_read_timeout=7200.0  # 2 hours for SSE streaming

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -199,7 +199,7 @@ The repo hosts two deployable things that share some code:
 llm-evaluation-system/
 ├── eval_mcp/                     # MCP package (published to PyPI)
 │   ├── cli.py                    # `eval-mcp` CLI entry point
-│   ├── server.py                 # FastMCP server registering all tools
+│   ├── server.py                 # MCPServer (mcp 2.x) registering all tools
 │   ├── core/                     # Shared utilities (bedrock client, storage, pricing, ...)
 │   ├── tools/                    # MCP tool handlers (run_eval, generate_qa, ...)
 │   ├── bedrock_capture.py        # OTel-based Bedrock call capture for agent evals

--- a/eval_mcp/bedrock_capture.py
+++ b/eval_mcp/bedrock_capture.py
@@ -127,6 +127,18 @@ class _InspectLogExporter(LogExporter):
     def shutdown(self):
         pass
 
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Required by LogExporter as of opentelemetry-sdk 1.44.
+
+        It became an abstractmethod there, so without it the class can't be
+        instantiated at all: "Can't instantiate abstract class
+        _InspectLogExporter without an implementation for abstract method
+        'force_flush'". Our `export` is fully synchronous — records are turned
+        into Inspect events inline, nothing is buffered here — so there is
+        nothing to flush and True (success) is the honest answer.
+        """
+        return True
+
     def _process_record(self, record):
         event_name = getattr(record.log_record, "event_name", None) or ""
         body = record.log_record.body

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -1673,21 +1673,18 @@ def main():
                     )
                 return await call_next(request)
 
-        # mcp 2.x added a 4 MiB cap on Streamable HTTP request bodies
-        # (HTTP 413 past it). That's a sane default for most servers but
-        # too tight here: `save_dataset` accepts the dataset inline via
-        # `file_content` for callers whose data isn't on the local
-        # filesystem, and a mid-size CSV clears 4 MiB easily. v1 had no
-        # cap, so keeping the default would newly reject uploads that
-        # work today — a silent regression for existing users.
+        # mcp 2.x caps Streamable HTTP request bodies at 4 MiB (HTTP 413
+        # past it); v1 had no cap. We keep the default deliberately: no
+        # caller here sends a large body. The web app truncates to ~11
+        # rows before calling analyze_dataset (see
+        # _sample_content_for_analysis) and writes the full dataset
+        # in-process via save_dataset_to_db, so the file itself never
+        # crosses the wire. `save_dataset`'s inline `file_content`
+        # parameter is an unused fallback for out-of-tree clients.
         #
-        # 64 MiB is a deliberate compromise, not a measured limit: the
-        # layers in front of this impose none (nginx runs
-        # `client_max_body_size 0`, the backend sets no ceiling), so the
-        # alternative to a number here is no protection at all. Raise it
-        # with EVAL_MCP_MAX_BODY_BYTES if a real dataset ever exceeds it.
-        max_body = int(os.environ.get("EVAL_MCP_MAX_BODY_BYTES", 64 * 1024 * 1024))
-        app = mcp.streamable_http_app(max_request_body_size=max_body)
+        # If a client ever does need to POST something bigger, pass
+        # max_request_body_size= here rather than removing the bound.
+        app = mcp.streamable_http_app()
         app.add_middleware(OriginValidationMiddleware)
         app.routes.insert(0, Route("/eval-info/{user_id}", eval_info_handler, methods=["GET"]))
         app.routes.insert(0, Route("/cancel/{user_id}", cancel_handler, methods=["POST"]))

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -16,7 +16,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from mcp.server import FastMCP
+from mcp.server import MCPServer
 from mcp.types import ToolAnnotations
 
 from eval_mcp.core.bedrock_client import BedrockClient
@@ -60,8 +60,33 @@ DEFAULT_USER = os.environ.get("EVAL_MCP_USER", "local")
 if "USER_STORAGE_BASE" not in os.environ:
     os.environ["USER_STORAGE_BASE"] = str(Path.home() / ".eval-mcp" / "users")
 
-# Initialize server
-mcp = FastMCP("eval-server", port=port, host=host)
+
+def _server_version() -> str:
+    """Version reported in the MCP handshake's `serverInfo`.
+
+    Read from installed package metadata because the version is derived
+    from the git tag by setuptools-scm — there is no static version in
+    pyproject.toml to import (see CLAUDE.md). Falls back to "" (what mcp
+    itself defaults to) if the package isn't installed, e.g. when running
+    straight from a source checkout.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+        return version("llm-evaluation-system")
+    except PackageNotFoundError:
+        return ""
+
+# Initialize server.
+#
+# `port`/`host` are deliberately NOT passed here: mcp 2.x moved every
+# transport-specific parameter off the constructor and onto the run/app
+# methods. Our HTTP branch in main() builds `streamable_http_app()` and
+# hands it to its own `uvicorn.run(host=..., port=...)`, so the values are
+# applied there and the constructor never needed them.
+#
+# `version` IS passed explicitly: v1's FastMCP derived it, v2 defaults to
+# "" and would report an empty `serverInfo.version` to every client.
+mcp = MCPServer("eval-server", version=_server_version())
 
 # Shared clients
 bedrock = BedrockClient()
@@ -1648,7 +1673,21 @@ def main():
                     )
                 return await call_next(request)
 
-        app = mcp.streamable_http_app()
+        # mcp 2.x added a 4 MiB cap on Streamable HTTP request bodies
+        # (HTTP 413 past it). That's a sane default for most servers but
+        # too tight here: `save_dataset` accepts the dataset inline via
+        # `file_content` for callers whose data isn't on the local
+        # filesystem, and a mid-size CSV clears 4 MiB easily. v1 had no
+        # cap, so keeping the default would newly reject uploads that
+        # work today — a silent regression for existing users.
+        #
+        # 64 MiB is a deliberate compromise, not a measured limit: the
+        # layers in front of this impose none (nginx runs
+        # `client_max_body_size 0`, the backend sets no ceiling), so the
+        # alternative to a number here is no protection at all. Raise it
+        # with EVAL_MCP_MAX_BODY_BYTES if a real dataset ever exceeds it.
+        max_body = int(os.environ.get("EVAL_MCP_MAX_BODY_BYTES", 64 * 1024 * 1024))
+        app = mcp.streamable_http_app(max_request_body_size=max_body)
         app.add_middleware(OriginValidationMiddleware)
         app.routes.insert(0, Route("/eval-info/{user_id}", eval_info_handler, methods=["GET"]))
         app.routes.insert(0, Route("/cancel/{user_id}", cancel_handler, methods=["POST"]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     # `MCPServer`, whose __init__ and `.tool()` decorator are close enough that
     # migration is tractable (tracked separately). Keeping the cap until that
     # lands means users get a working server today instead of waiting on it.
-    "mcp>=1.0.0,<2",
+    "mcp>=2.0.0",
     # Floor (no upper cap) is intentional: we import several private inspect-ai
     # modules (._view.common, .tool._tool_info, .log._samples, .event._model),
     # so the floor guarantees those paths exist. The deployed image and local

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -3,7 +3,7 @@
 
 import asyncio
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 async def main():
@@ -12,7 +12,7 @@ async def main():
     print("=" * 80)
 
     # Connect to HTTP server
-    async with streamablehttp_client("http://localhost:8002/mcp") as (
+    async with streamable_http_client("http://localhost:8002/mcp") as (
         read_stream,
         write_stream,
         _,

--- a/tests/test_mcp_schema.py
+++ b/tests/test_mcp_schema.py
@@ -54,10 +54,10 @@ def test_read_only_tools_claim_read_only(tool_name: str):
     tool = srv.mcp._tool_manager.get_tool(tool_name)
     assert tool is not None, f"Tool {tool_name} not registered"
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True, (
+    assert tool.annotations.read_only_hint is True, (
         f"{tool_name} should declare readOnlyHint=True"
     )
-    assert tool.annotations.destructiveHint is False
+    assert tool.annotations.destructive_hint is False
 
 
 @pytest.mark.parametrize(
@@ -75,7 +75,7 @@ def test_read_only_tools_claim_read_only(tool_name: str):
 def test_write_tools_are_not_read_only(tool_name: str):
     tool = srv.mcp._tool_manager.get_tool(tool_name)
     assert tool is not None, f"Tool {tool_name} not registered"
-    assert tool.annotations.readOnlyHint is False
+    assert tool.annotations.read_only_hint is False
 
 
 def test_no_tool_declares_destructive_hint():
@@ -83,7 +83,7 @@ def test_no_tool_declares_destructive_hint():
     that changes, update the corresponding tool's annotation explicitly
     rather than relying on the default."""
     destructive = [
-        t.name for t in _registered_tools() if t.annotations and t.annotations.destructiveHint
+        t.name for t in _registered_tools() if t.annotations and t.annotations.destructive_hint
     ]
     assert destructive == [], f"Unexpected destructive tools: {destructive}"
 

--- a/tests/test_server_boots.py
+++ b/tests/test_server_boots.py
@@ -5,6 +5,11 @@ broken MCP in two consecutive releases (0.13.0, 0.14.0) without anything failing
 The dependency was pinned `mcp>=1.0.0`, so every fresh install resolved 2.0.0 and
 died at `eval_mcp/server.py` with "cannot import name 'FastMCP'".
 
+server.py has since migrated to the 2.x API, so the version assertions here are
+inverted from their original form — the hazard is now resolving mcp 1.x, which
+lacks `MCPServer`. The boot checks themselves are unchanged and are the reason
+the migration could be verified at all.
+
 It went unnoticed because the obvious checks all route around the failure:
 
   - `eval-mcp --help` is a Click callback that returns BEFORE
@@ -64,25 +69,30 @@ def test_server_registers_tools():
     assert count >= 20, f"expected the full tool set, got {count}"
 
 
-def test_fastmcp_is_importable():
-    """Pin the specific symbol whose removal caused the outage.
+def test_mcpserver_is_importable():
+    """Pin the constructor symbol the server is built from.
 
-    A dependency bump that takes FastMCP away must fail here — loudly, in CI —
-    rather than in a user's IDE after release.
+    The v1 counterpart of this test pinned `FastMCP`, whose removal in mcp
+    2.0.0 was the original outage. Now that server.py is on the 2.x API, the
+    symbol to guard is `MCPServer` — a future rename must fail here, loudly in
+    CI, rather than in a user's IDE after release.
     """
     try:
-        from mcp.server import FastMCP  # noqa: F401
+        from mcp.server import MCPServer  # noqa: F401
     except ImportError as e:
         pytest.fail(
-            "mcp.server.FastMCP is unavailable, so the MCP server cannot be "
-            "constructed. mcp 2.x removed it in favour of MCPServer — either "
-            "keep the `mcp<2` cap in pyproject.toml or migrate "
-            f"eval_mcp/server.py to the 2.x API. Underlying error: {e}"
+            "mcp.server.MCPServer is unavailable, so the MCP server cannot be "
+            f"constructed. Check the mcp changelog for a rename. Error: {e}"
         )
 
 
-def test_mcp_dependency_is_capped_below_2():
-    """The declared requirement must exclude the incompatible major version.
+def test_mcp_dependency_requires_2x():
+    """The declared requirement must floor at the major version we target.
+
+    server.py uses the 2.x API (`MCPServer`, transport args on the run
+    methods), which 1.x does not provide — so resolving 1.x would break the
+    import just as surely as unpinned 2.x did before the migration. This is the
+    mirror of the old `<2` cap: the hazard moved from "too new" to "too old".
 
     Asserted on package metadata rather than the pyproject text so it reflects
     what a user actually resolves.
@@ -92,7 +102,29 @@ def test_mcp_dependency_is_capped_below_2():
     reqs = md.requires("llm-evaluation-system") or []
     mcp_reqs = [r for r in reqs if r.split(";")[0].strip().startswith("mcp")]
     assert mcp_reqs, "no mcp requirement declared"
-    assert any("<2" in r for r in mcp_reqs), (
-        f"mcp must be capped below 2.0 until server.py migrates off FastMCP; "
+    assert any(">=2" in r.replace(" ", "") for r in mcp_reqs), (
+        f"mcp must require >=2.0 now that server.py uses the 2.x API; "
         f"found {mcp_reqs}"
+    )
+
+
+def test_server_reports_a_version():
+    """`serverInfo.version` must not be empty.
+
+    v1's FastMCP derived the version automatically; MCPServer defaults it to
+    "" and would silently report a blank version to every client. server.py
+    passes it explicitly from package metadata — this guards that wiring.
+    """
+    code = (
+        "import eval_mcp.server as s;"
+        "print(s.mcp.version or '<empty>')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"reading version failed:\n{result.stderr}"
+    reported = result.stdout.strip().splitlines()[-1]
+    assert reported != "<empty>", (
+        "MCPServer was constructed without an explicit version=, so clients "
+        "see an empty serverInfo.version."
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1082,6 +1082,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1126,12 +1139,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1156,11 +1176,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1679,7 +1699,7 @@ requires-dist = [
     { name = "inspect-ai", specifier = ">=0.3.241" },
     { name = "inspect-evals", specifier = ">=0.14.1" },
     { name = "inspect-k8s-sandbox", marker = "extra == 'k8s-sandbox'", specifier = ">=0.4.0" },
-    { name = "mcp", specifier = ">=1.0.0,<2" },
+    { name = "mcp", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "openai", specifier = ">=2.40.0" },
     { name = "openai", marker = "extra == 'providers'", specifier = ">=2.26.0" },
@@ -1783,15 +1803,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1801,9 +1821,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -2801,20 +2834,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3452,6 +3471,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lifts the `mcp<2` stopgap from v0.14.1 by migrating `eval_mcp/server.py` to the 2.x API. The whole non-comment code change is 6 lines of substance:

```
FastMCP                     → MCPServer
FastMCP(..., port=, host=)  → MCPServer(..., version=_server_version())
streamablehttp_client       → streamable_http_client   (×2)
"mcp>=1.0.0,<2"             → "mcp>=2.0.0"
+ _server_version()         (6 lines)
+ force_flush()             (1 line — unrelated otel fix, see below)
```

## Why now

The cap wasn't a neutral holding position. The SDK's own release notes: *"v1.x is in maintenance mode and will only receive security fixes from now on."* Ours was also the **only** `<2` constraint in the dependency tree — `anthropic`, `huggingface_hub` and `inspect_ai` all already accept 2.x.

To set expectations honestly: **this adds no capability you're using today.** v2's new surface (middleware, extensions, caching, subscriptions, elicitation) is unused here. The gains are (a) not being stranded on a maintenance line, (b) hardened stdio that keeps stray output off the JSON-RPC wire — a guard against a regression rather than a fix for a live bug, and (c) support for the 2026-07-28 protocol revision, which pays off only as clients adopt it.

## Non-obvious bits

- **`port`/`host` dropped from the constructor** — 2.x moved transport args to the run/app methods. Harmless because the HTTP branch already passes them to its own `uvicorn.run(...)`. Re-adding them is a `TypeError`.
- **`version=` must be explicit** — v1 derived it; v2 defaults to `""` and would report a blank `serverInfo.version` to every client. Sourced from package metadata since setuptools-scm owns the version. A new test pins this, because the regression is invisible without one.
- **Annotation casing** — constructors still take `readOnlyHint=`, but *reads* are `.read_only_hint`. The wire format stays camelCase, so clients are unaffected. Only test assertions changed.
- **The 4 MiB body cap is kept** — v2 added it, v1 had none. I initially overrode it to 64 MiB and reverted that in 4a90b38: nothing here sends a large body (the web app truncates to ~11 rows before `analyze_dataset` and writes datasets in-process), and the inline `file_content` path I'd been protecting has no caller in this repo.
- **The two v1-pinning tests are inverted, not deleted** — they now assert `MCPServer` imports and the requirement floors at `>=2`. The hazard moved from "too new" to "too old"; the failure mode is identical.
- **`uv.lock` had to be relocked** (75e2281). Both Dockerfiles run `uv sync --locked`, which ignores declared ranges — the lockfile still pinned mcp 1.28.1, so without this the Docker build fails outright rather than silently shipping the old SDK.

## One unrelated fix rides along

opentelemetry 1.44 made `LogExporter.force_flush` abstract, so `_InspectLogExporter` can no longer be instantiated. Our `opentelemetry-sdk>=1.30` is unbounded, so **this already breaks fresh PyPI installs today** — 12 tests were failing on it. It surfaced only because the migration test env resolved 1.44 while `uv.lock` pins 1.41.1 (which is why containers never hit it).

It's genuinely independent of mcp and could be split into its own PR — happy to do that if preferred.

## Test plan

pytest greens don't prove an MCP works, so verification went further:

- [x] **Real eval end-to-end over stdio against live Bedrock** — `save_dataset` → `generate_judge` → `create_eval_config` → `run_evaluation` → `list_evaluations`; 3-judge jury, score 0.778, 31s
- [x] **Both protocol eras from one server** — legacy `2025-06-18` handshake *and* the new `2026-07-28` stateless revision (27 tools, no handshake)
- [x] **HTTP transport** with the custom `/eval-info` + `/cancel` routes and the origin allowlist (403 on a foreign Origin)
- [x] **Clean-venv wheel install** — the exact path that broke in 0.14.0: resolves mcp 2.0.0, boots, 27 tools over stdio with real `tools/call`
- [x] `serverInfo.version` populated (`0.14.2.dev2`), all 27 tools carry annotations on the wire
- [x] 531 pytest tests pass
- [ ] **Deploy to us-east-2 and verify the live pod before merging** — this changes the MCP sidecar and the lockfile the container builds from; the backend↔sidecar link (`backend/core/mcp_client.py`) is where a mismatch would show up