### PR TITLE
fix(eval): resolve the token ceiling per model instead of hardcoding it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,14 +123,38 @@ Data-layer outputs flow into platform-layer via `-var=` flags (NOT `terraform_re
 
 ### Token ceilings are per model — don't reintroduce a constant
 
-`--max-tokens` is resolved per model by `run_eval._max_tokens_for_run()`, shared
-by `optimize_prompt` and `benchmarks`. A single number cannot work, because the
-two endpoints fail in *opposite* directions:
+**This is a workaround for an upstream Inspect AI gap.** Inspect's Bedrock
+provider supplies a *constant* default when the caller passes no `max_tokens`:
+`DEFAULT_MAX_TOKENS = 2048` (`inspect_ai/_util/constants.py`), routed through a
+hand-coded family table in `_providers/bedrock.py`. Verified against Inspect
+`main` as of 2026-07-30 — still a constant, still no per-model resolution, and
+no truncation warning (PR #3933 proposed one and was closed unmerged). On stock
+Inspect with nothing set, gpt-oss-20b returns 2048 output tokens and **zero
+visible characters**. When upstream resolves real limits, delete
+`eval_mcp/solvers/model_limit.py` and go back to plain `generate()`.
 
-- **Mantle (`openai/bedrock/*`) wants no ceiling.** Omit the flag and the model
-  runs to its own limit — measured, `gpt-5.6-sol` produced 8,413 tokens on a
-  long-form prompt that the old hardcoded 8192 truncated. Passing a cap is what
-  *created* the empty/truncated completions this design removes.
+The ceiling is resolved **inside the generated task file's solver**
+(`generate_at_model_limit`), where `get_model()` returns the model that sample is
+running against. That keeps every target in ONE subprocess — Inspect already
+runs targets concurrently, so splitting per model would serialise what is
+currently parallel — while giving each its own limit. Verified live: llama
+4096 / haiku 64000 / gpt-5.6-terra unbounded, in a single run.
+
+`run_eval` therefore passes **no** `--max-tokens` at all (a global flag would
+force every model down to the lowest limit in the run), and `optimize_prompt`
+inherits the solver because it builds its task with `create_inspect_task_file`.
+The one exception is `benchmarks`: it runs upstream `inspect_evals/*` tasks whose
+solvers we don't generate, so it keeps `run_eval._max_tokens_for_run()` and its
+lowest-limit-wins compromise.
+
+A single number cannot work, because the two endpoints fail in *opposite*
+directions:
+
+- **Mantle (`openai/bedrock/*`) wants no ceiling.** Inspect's OpenAI provider
+  has no `max_tokens()` override, so omitting the value lets the model run to
+  its own limit — measured, `gpt-5.6-sol` produced 9,052 tokens on a long-form
+  prompt that the old hardcoded 8192 truncated. Passing a cap is what *created*
+  the empty/truncated completions this design removes.
 - **Converse (`bedrock/*`) requires one.** Inspect's Bedrock provider falls back
   to `DEFAULT_MAX_TOKENS = 2048` (`inspect_ai/_util/constants.py`) and silently
   truncates.
@@ -147,11 +171,11 @@ Consequences worth knowing:
   same feed that backs pricing, so no extra fetch. AWS does **not** expose
   output limits (`GetFoundationModel` has no such field), so there is nothing to
   query instead.
-- A mixed run takes the **smallest** limit present, because `--max-tokens` is
-  global (targets share one `--model` flag). Never clamp that minimum *up* to
+- In `benchmarks` (the CLI-flag path) a mixed run takes the **smallest** limit
+  present, because `--max-tokens` is global. Never clamp that minimum *up* to
   the fallback — that pushes the value above a real API bound and turns a
   graceful truncation into a hard rejection that kills every sample for the
-  smaller-limit model.
+  smaller-limit model. The solver path has no such compromise.
 - The jury scorer flags both shapes: `truncated_no_output` (empty completion,
   scored 0 with a TRUNCATED explanation) and `truncated_partial_output` (answer
   cut off mid-stream — still scored, since partial output carries signal, but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,47 @@ Data-layer outputs flow into platform-layer via `-var=` flags (NOT `terraform_re
 
 `infra/eval-logs-bucket/` is a third, unrelated Terraform root — it's the optional S3 bucket for MCP team sharing, surfaced through `eval-mcp init`. Has its own provider block and account-ID-suffixed naming.
 
+### Token ceilings are per model — don't reintroduce a constant
+
+`--max-tokens` is resolved per model by `run_eval._max_tokens_for_run()`, shared
+by `optimize_prompt` and `benchmarks`. A single number cannot work, because the
+two endpoints fail in *opposite* directions:
+
+- **Mantle (`openai/bedrock/*`) wants no ceiling.** Omit the flag and the model
+  runs to its own limit — measured, `gpt-5.6-sol` produced 8,413 tokens on a
+  long-form prompt that the old hardcoded 8192 truncated. Passing a cap is what
+  *created* the empty/truncated completions this design removes.
+- **Converse (`bedrock/*`) requires one.** Inspect's Bedrock provider falls back
+  to `DEFAULT_MAX_TOKENS = 2048` (`inspect_ai/_util/constants.py`) and silently
+  truncates.
+
+And no high constant is safe either: exceeding a model's limit is a hard
+`ValidationException` ("The maximum tokens you requested exceeds the model limit
+of 10000"), **not** a clamp. Verified live — Nova Pro caps at 10,000, Claude
+Haiku 4.5 at 64,000, gpt-oss-20b at 128,000; each accepts exactly its advertised
+value and rejects one above it.
+
+Consequences worth knowing:
+
+- Limits come from LiteLLM's dataset via `pricing.get_max_output_tokens()` — the
+  same feed that backs pricing, so no extra fetch. AWS does **not** expose
+  output limits (`GetFoundationModel` has no such field), so there is nothing to
+  query instead.
+- A mixed run takes the **smallest** limit present, because `--max-tokens` is
+  global (targets share one `--model` flag). Never clamp that minimum *up* to
+  the fallback — that pushes the value above a real API bound and turns a
+  graceful truncation into a hard rejection that kills every sample for the
+  smaller-limit model.
+- The jury scorer flags both shapes: `truncated_no_output` (empty completion,
+  scored 0 with a TRUNCATED explanation) and `truncated_partial_output` (answer
+  cut off mid-stream — still scored, since partial output carries signal, but
+  marked because completeness criteria necessarily fail on a severed answer).
+
+**Mantle frontier models are Responses-API-only.** AWS's docs recommend
+`/v1/chat/completions`, but GPT-5.6 rejects it: *"The model
+'openai.gpt-5.6-terra' does not support the '/v1/chat/completions' API"*. Only
+`/openai/v1/responses` works for inference; the catalog stays at `/v1/models`.
+
 ### Adding a model
 
 Nothing to do. There is no allowlist and no hand-maintained price table — a newly

--- a/eval_mcp/core/pricing.py
+++ b/eval_mcp/core/pricing.py
@@ -273,6 +273,29 @@ def get_model_cost(model_id: str) -> Optional[dict]:
     }
 
 
+def get_max_output_tokens(model_id: str) -> Optional[int]:
+    """Model's maximum output tokens, or None if unknown.
+
+    Same LiteLLM dataset that backs pricing, so it needs no extra fetch and
+    inherits the ID-normalisation in ``_candidates`` (which is what makes
+    region-prefixed and Mantle IDs resolve).
+
+    Used to set a per-model ceiling on generation instead of one hardcoded
+    number. There is no way to discover this from AWS: Bedrock's
+    ``GetFoundationModel`` doesn't report output limits, and exceeding one is a
+    hard ValidationException ("The maximum tokens you requested exceeds the
+    model limit of 10000"), not a clamp. Verified against the live API — at the
+    advertised value every model accepts the request and one above it is
+    rejected, for Nova Pro (10000), Claude Haiku 4.5 (64000) and gpt-oss-20b
+    (128000).
+    """
+    entry = _lookup(model_id)
+    if entry is None:
+        return None
+    v = entry.get("max_output_tokens")
+    return int(v) if isinstance(v, (int, float)) and v > 0 else None
+
+
 def calculate_cost(
     model_id: str,
     input_tokens: int,

--- a/eval_mcp/solvers/model_limit.py
+++ b/eval_mcp/solvers/model_limit.py
@@ -1,0 +1,105 @@
+"""Solver that generates at each model's own output-token limit.
+
+Why this exists: Inspect AI's Bedrock provider supplies a *constant* default
+``max_tokens`` when the caller passes none —
+``inspect_ai/_util/constants.py:DEFAULT_MAX_TOKENS = 2048``, routed through a
+hand-coded family table in ``_providers/bedrock.py``. For reasoning models that
+default is actively wrong, not merely small: they can spend the whole budget on
+the reasoning channel and return an EMPTY completion with
+``stop_reason="max_tokens"``. Reproduced on stock Inspect with nothing set —
+gpt-oss-20b on Converse returned 2048 output tokens and zero visible characters.
+An empty answer scores 0 while the run reports success, so the model that
+reasoned hardest looks like the worst one.
+
+Passing a single ``--max-tokens`` doesn't fix it, because that flag is global
+while the real limits are per model and span a wide range (verified against live
+Bedrock: llama3.3-70b 4,096; Nova Pro 10,000; Claude Haiku 4.5 64,000;
+gpt-oss-20b 128,000). Exceeding a model's limit is a hard ValidationException —
+"The maximum tokens you requested exceeds the model limit of 10000" — not a
+clamp, so one value safe for the largest model kills the smallest, and a value
+safe for all of them is ~4k, which truncates the models we most want to measure.
+
+So resolve it per model at solve time, where the active model is known. That
+keeps every model in ONE subprocess (Inspect already runs targets concurrently,
+so splitting per model would serialise what is currently parallel) while giving
+each its own ceiling.
+
+Mantle (``openai/bedrock/*``) is deliberately left unbounded: Inspect's OpenAI
+provider has no ``max_tokens()`` override, so omitting the value lets the model
+run to its own limit — measured, gpt-5.6-sol produced 8,413 output tokens on a
+prompt that a hardcoded 8,192 truncated.
+
+This is a workaround for an upstream gap. When Inspect's Bedrock provider
+resolves real per-model limits instead of a family constant, delete this module
+and go back to a plain ``generate()``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.solver import solver
+
+logger = logging.getLogger(__name__)
+
+# Used only when the model is absent from the limits dataset. Above Inspect's
+# 2048 (which demonstrably produces empty completions) but low enough to be
+# accepted by every Bedrock model we've measured, since an unknown model's real
+# ceiling can't be checked. Unknown means "can't reason about it", not
+# "unlimited" — omitting the value entirely would hand it Inspect's 2048.
+FALLBACK_MAX_TOKENS = 8192
+
+
+def resolve_max_tokens(model_id: str) -> int | None:
+    """Ceiling for ``model_id``, or None to leave generation unbounded.
+
+    None for Mantle models — see the module docstring. Otherwise the model's
+    advertised maximum, falling back to ``FALLBACK_MAX_TOKENS`` when unknown.
+    """
+    if model_id.startswith("openai/bedrock/"):
+        return None
+
+    try:
+        from eval_mcp.core.pricing import get_max_output_tokens
+
+        limit = get_max_output_tokens(model_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("max-output-token lookup failed for %s: %s", model_id, exc)
+        limit = None
+
+    return limit or FALLBACK_MAX_TOKENS
+
+
+@solver
+def generate_at_model_limit(**kwargs):
+    """``generate()``, but with ``max_tokens`` resolved from the active model.
+
+    ``kwargs`` are forwarded to the underlying generate call, so this is a
+    drop-in replacement for ``generate()`` in a solver chain. An explicit
+    ``max_tokens`` in ``kwargs`` wins — a caller who asked for a specific
+    ceiling gets it.
+    """
+    async def solve(state, generate):
+        if "max_tokens" in kwargs:
+            return await generate(state, **kwargs)
+
+        # `get_model()` with no argument returns the model this task is
+        # currently running against, which is what makes a single subprocess
+        # able to serve several models at their own limits.
+        try:
+            model_id = str(get_model())
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("could not resolve active model: %s", exc)
+            return await generate(state, **kwargs)
+
+        max_tokens = resolve_max_tokens(model_id)
+        if max_tokens is None:
+            return await generate(state, **kwargs)
+
+        return await generate(state, max_tokens=max_tokens, **kwargs)
+
+    return solve
+
+
+__all__ = ["generate_at_model_limit", "resolve_max_tokens", "FALLBACK_MAX_TOKENS"]

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -42,7 +42,7 @@ from eval_mcp.core.bedrock_client import raise_if_autodetect_error, resolve_regi
 from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
-    _DEFAULT_MAX_TOKENS,
+    _max_tokens_for_run,
     _INSPECT_CMD,
     _running_evaluations,
     _terminate_process_gracefully,
@@ -407,9 +407,13 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
             "--no-log-images",
             "--no-fail-on-error",
             "--log-shared", "10",
-            # Same reasoning-model truncation guard as run_eval.
-            "--max-tokens", str(_DEFAULT_MAX_TOKENS),
         ]
+        # Per-model token ceiling, same rules as run_eval: omit for a
+        # Mantle-only run (model uses its own limit), else the smallest
+        # advertised limit among the Converse targets.
+        _mt = _max_tokens_for_run(providers)
+        if _mt is not None:
+            cmd.extend(["--max-tokens", str(_mt)])
         if limit:
             cmd.extend(["--limit", str(int(limit))])
         # Inject the resolved sandbox type for code-execution benchmarks (unless

--- a/eval_mcp/tools/create_config.py
+++ b/eval_mcp/tools/create_config.py
@@ -269,6 +269,8 @@ from pathlib import Path
 from inspect_ai import Task, task
 from inspect_ai.dataset import json_dataset, FieldSpec
 from inspect_ai.solver import generate, prompt_template
+
+from eval_mcp.solvers.model_limit import generate_at_model_limit
 {extra_imports}
 _config_path = Path(__file__).with_suffix(".json")
 CONFIG = json.loads(_config_path.read_text())
@@ -596,12 +598,16 @@ def create_inspect_task_file(
     #   and skipped even when RAG scorers are selected.
     # - RAG (live model): inject chunks via rag_prompt_solver, then generate.
     # - default: plain generate.
+    # generate_at_model_limit() replaces plain generate() so each target runs at
+    # its OWN output-token limit. Inspect's Bedrock provider otherwise injects a
+    # constant 2048, which makes reasoning models return empty completions that
+    # score 0 — see eval_mcp/solvers/model_limit.py for the full reasoning.
     if score_only:
         solver_chain = "static_output_solver()"
     elif rag_enabled:
-        solver_chain = "rag_prompt_solver(), generate()"
+        solver_chain = "rag_prompt_solver(), generate_at_model_limit()"
     else:
-        solver_chain = "generate()"
+        solver_chain = "generate_at_model_limit()"
 
     mode_doc = ""
     if score_only:

--- a/eval_mcp/tools/create_config.py
+++ b/eval_mcp/tools/create_config.py
@@ -390,13 +390,31 @@ def jury_scorer():
                     explanation=(
                         "TRUNCATED: the model hit its max_tokens limit before emitting "
                         "any answer (all output tokens went to the reasoning channel). "
-                        "This is a token-budget problem, NOT a quality result — raise "
-                        "max_tokens (e.g. --max-tokens 8192) and re-run before comparing "
-                        "this model against others."
+                        "This is a token-budget problem, NOT a quality result — do not "
+                        "compare this model against others on this run. The ceiling is "
+                        "resolved per model from its advertised maximum, so hitting it "
+                        "means either the model's own limit is genuinely too small for "
+                        "this task, or a lower-limit model in the same run pulled the "
+                        "shared ceiling down (a mixed run uses the smallest limit "
+                        "present) — re-run this model on its own."
                     ),
                     metadata={"truncated_no_output": True, "stop_reason": stop_reason},
                 )
             return Score(value=0.0, answer="", explanation="No output generated")
+
+        # Output exists but was cut off mid-answer. Unlike the empty case above
+        # this still gets scored — a partial answer carries real signal, and
+        # discarding it would throw away every long response. But the score is
+        # depressed by the truncation, not only by quality (criteria like
+        # completeness necessarily fail on a severed answer), so flag it: a
+        # reader comparing models needs to know this number is a floor, not a
+        # measurement. Recorded in metadata rather than the score so it can't
+        # silently pass as a clean result.
+        truncated_partial = (
+            getattr(state.output, "stop_reason", None) == "max_tokens"
+            if state.output
+            else False
+        )
 
         question = str(state.input)
         golden = target.text if target else ""
@@ -466,11 +484,22 @@ def jury_scorer():
         if errors:
             lines += ["", "Errors:"] + errors
 
+        if truncated_partial:
+            lines.append(
+                "NOTE: the answer was cut off at the token ceiling "
+                "(stop_reason=max_tokens), so this score is a floor — criteria "
+                "like completeness fail on a severed answer regardless of quality."
+            )
+
         return Score(
             value=jury_score,
             answer=output[:200],
             explanation="\\n".join(lines),
-            metadata={"jury_score": jury_score, "criteria_results": results},
+            metadata={
+                "jury_score": jury_score,
+                "criteria_results": results,
+                "truncated_partial_output": truncated_partial,
+            },
         )
 
     return score

--- a/eval_mcp/tools/optimize_prompt.py
+++ b/eval_mcp/tools/optimize_prompt.py
@@ -81,7 +81,6 @@ from eval_mcp.tools.create_config import (
 )
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
-    _max_tokens_for_run,
     _running_evaluations,
     _terminate_process_gracefully,
 )
@@ -396,12 +395,10 @@ async def _spawn_inspect_eval(
         "--no-fail-on-error",
         "--log-shared", "10",
     ]
-    # Per-model token ceiling, same rules as run_eval: None for a Mantle-only
-    # run (let the model use its own limit), otherwise the smallest advertised
-    # limit among the Converse targets.
-    _mt = _max_tokens_for_run(providers or [])
-    if _mt is not None:
-        cmd.extend(["--max-tokens", str(_mt)])
+    # No --max-tokens: the task file this builds comes from
+    # create_inspect_task_file, whose solver (generate_at_model_limit) resolves
+    # the ceiling per model at solve time. A global flag would cap every model
+    # at the lowest limit in the run.
     if providers:
         cmd.extend(["--model", ",".join(providers)])
 

--- a/eval_mcp/tools/optimize_prompt.py
+++ b/eval_mcp/tools/optimize_prompt.py
@@ -81,7 +81,7 @@ from eval_mcp.tools.create_config import (
 )
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 from eval_mcp.tools.run_eval import (
-    _DEFAULT_MAX_TOKENS,
+    _max_tokens_for_run,
     _running_evaluations,
     _terminate_process_gracefully,
 )
@@ -395,9 +395,13 @@ async def _spawn_inspect_eval(
         "--no-log-images",
         "--no-fail-on-error",
         "--log-shared", "10",
-        # Same reasoning-model truncation guard as run_eval.
-        "--max-tokens", str(_DEFAULT_MAX_TOKENS),
     ]
+    # Per-model token ceiling, same rules as run_eval: None for a Mantle-only
+    # run (let the model use its own limit), otherwise the smallest advertised
+    # limit among the Converse targets.
+    _mt = _max_tokens_for_run(providers or [])
+    if _mt is not None:
+        cmd.extend(["--max-tokens", str(_mt)])
     if providers:
         cmd.extend(["--model", ",".join(providers)])
 

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -18,6 +18,7 @@ from eval_mcp.core.bedrock_client import (
     raise_if_autodetect_error,
     resolve_region,
 )
+from eval_mcp.core.pricing import get_max_output_tokens
 from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
 from eval_mcp.tools.external_providers import _refresh_keys_from_file
 
@@ -38,18 +39,30 @@ _VALID_EVAL_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_:-]+$')
 
 # Output-token ceiling for every eval we launch.
 #
-# Inspect's Bedrock provider defaults to 2048, which is too low for reasoning
-# models and biases comparisons in a way that is easy to miss: gpt-5.6-luna,
-# gpt-5.6-sol and gpt-oss-20b can spend the WHOLE budget on their reasoning
-# channel and return an empty completion (stop_reason="max_tokens"). The sample
-# still "completes", so it scores 0 and the run reports success — the model that
-# reasoned hardest looks like the worst model. Measured on a hard proof task:
-# luna and sol both consumed 2048/2048 reasoning tokens with 0 visible output.
+# Ceiling on generated tokens, resolved PER MODEL to that model's own maximum.
 #
-# 8192 clears the observed worst case with headroom. It's a ceiling, not a
-# target — models that answer briefly are unaffected and cost nothing extra,
-# since Bedrock bills actual tokens generated.
-_DEFAULT_MAX_TOKENS = 8192
+# Why not a single number: the two endpoints fail in opposite directions when
+# you pick one.
+#
+#   * Converse (`bedrock/<id>`) needs a value. Inspect's global default is 2048
+#     (inspect_ai/_util/constants.py), which truncates real answers — and for
+#     reasoning models it's worse than truncation: gpt-oss and the GPT-5.6
+#     family can spend the entire budget on the reasoning channel and return an
+#     EMPTY completion (stop_reason="max_tokens"). The sample still "completes",
+#     so it scores 0 and the run reports success — the model that reasoned
+#     hardest looks like the worst model.
+#   * Mantle (`openai/bedrock/<id>`) needs NO value. Omit it and the model runs
+#     to its own limit; measured, gpt-5.6-sol produced 10,816 tokens on a
+#     long-form prompt. Any cap below that truncates it.
+#
+# And no single high number works either, because exceeding a model's limit is a
+# hard ValidationException, not a clamp: Nova Pro caps at 10,000 while
+# gpt-oss-20b allows 128,000. A value safe for one rejects the other outright.
+#
+# So we ask what each model actually supports (LiteLLM's dataset — the same one
+# that backs pricing, no extra fetch) and pass that. `None` means "unknown
+# model", in which case we fall back rather than guess.
+_MAX_TOKENS_FALLBACK = 8192
 
 # Model IDs to pull out of a config for pre-flight validation. Covers both
 # Bedrock endpoints: `bedrock/<id>` (Converse) and `openai/bedrock/<id>`
@@ -139,6 +152,47 @@ def _summarize_failure(stderr_str: str, stdout_str: str) -> str:
                 if marker in line and line:
                     return line[:500]
     return ""
+
+
+def _max_tokens_for_run(models: List[str]) -> Optional[int]:
+    """Value for ``--max-tokens``, or None to omit the flag entirely.
+
+    Returns None when every target is a Mantle model (``openai/bedrock/*``).
+    Those need no ceiling — the OpenAI provider Inspect routes them through has
+    no default, so omitting the flag lets the model run to its own limit.
+    Passing one only creates the truncation we're trying to avoid.
+
+    Otherwise a value is required, because Inspect's Bedrock provider falls back
+    to 2048 and silently truncates. We use the smallest advertised limit among
+    the models in the run (see the note at ``_MAX_TOKENS_FALLBACK`` for why
+    lowest, not highest), and fall back to a fixed value if the dataset doesn't
+    know a model — unknown means "can't reason about it", not "unlimited".
+    """
+    if not models:
+        return None
+
+    converse = [m for m in models if not m.startswith("openai/bedrock/")]
+    if not converse:
+        # Mantle-only run: no ceiling is the correct answer.
+        return None
+
+    limits: List[int] = []
+    for model_id in converse:
+        try:
+            limit = get_max_output_tokens(model_id)
+        except Exception:
+            limit = None
+        if limit:
+            limits.append(limit)
+
+    if not limits:
+        return _MAX_TOKENS_FALLBACK
+
+    # A mixed run is bounded by its most restrictive model. Deliberately NOT
+    # clamped up to the fallback: an advertised limit is a hard API bound, and
+    # raising a value above it turns a graceful truncation into a
+    # ValidationException that kills every sample for that model.
+    return min(limits)
 
 
 def _region_for_run(config_data: Optional[Dict[str, Any]], models: List[str]) -> str:
@@ -653,8 +707,18 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             "--no-log-images",
             "--no-fail-on-error",
             "--log-shared", "10",
-            "--max-tokens", str(_DEFAULT_MAX_TOKENS),
         ]
+
+        # Per-model token ceiling. `--max-tokens` is global (targets arrive on a
+        # single `--model` flag, so there is no per-model CLI slot), so with a
+        # mixed run we take the LOWEST limit among the models present: anything
+        # higher is a hard ValidationException from whichever model has the
+        # smaller cap, which kills that model's samples outright. A ceiling
+        # below what a model would have produced only truncates the tail, so
+        # erring low degrades gracefully while erring high does not.
+        max_tokens = _max_tokens_for_run(models if not score_only else [])
+        if max_tokens is not None:
+            cmd.extend(["--max-tokens", str(max_tokens)])
 
         # Pass models to inspect eval (comma-separated for multiple).
         # Score-only configs invoke no model — Inspect AI supports running

--- a/eval_mcp/tools/run_eval.py
+++ b/eval_mcp/tools/run_eval.py
@@ -155,7 +155,14 @@ def _summarize_failure(stderr_str: str, stdout_str: str) -> str:
 
 
 def _max_tokens_for_run(models: List[str]) -> Optional[int]:
-    """Value for ``--max-tokens``, or None to omit the flag entirely.
+    """Value for a global ``--max-tokens`` flag, or None to omit it.
+
+    Only for tasks whose solver we do NOT generate — i.e. ``benchmarks``, which
+    runs upstream ``inspect_evals/*`` tasks. Everything built by
+    ``create_inspect_task_file`` uses ``generate_at_model_limit()`` instead,
+    which resolves the ceiling per model and needs no flag. Prefer that path;
+    this one has to compromise (see below) precisely because a CLI flag is
+    global.
 
     Returns None when every target is a Mantle model (``openai/bedrock/*``).
     Those need no ceiling — the OpenAI provider Inspect routes them through has
@@ -709,16 +716,11 @@ async def handle_run_evaluation(args: Dict[str, Any]) -> List[TextContent]:
             "--log-shared", "10",
         ]
 
-        # Per-model token ceiling. `--max-tokens` is global (targets arrive on a
-        # single `--model` flag, so there is no per-model CLI slot), so with a
-        # mixed run we take the LOWEST limit among the models present: anything
-        # higher is a hard ValidationException from whichever model has the
-        # smaller cap, which kills that model's samples outright. A ceiling
-        # below what a model would have produced only truncates the tail, so
-        # erring low degrades gracefully while erring high does not.
-        max_tokens = _max_tokens_for_run(models if not score_only else [])
-        if max_tokens is not None:
-            cmd.extend(["--max-tokens", str(max_tokens)])
+        # No --max-tokens here on purpose. The generated task file's solver
+        # (generate_at_model_limit) resolves the ceiling from whichever model a
+        # sample is running against, so each target gets its own limit inside
+        # this one subprocess. A CLI flag is global and would force every model
+        # down to the lowest limit in the run.
 
         # Pass models to inspect eval (comma-separated for multiple).
         # Score-only configs invoke no model — Inspect AI supports running

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -141,8 +141,10 @@ def test_rag_scorer_renders_solver_and_metadata(jc: JudgeConfig) -> None:
     )
     # FieldSpec carries retrieval_context onto Sample.metadata
     assert 'metadata=["retrieval_context"]' in code
-    # Solver chain prepends the RAG solver before generate()
-    assert "solver=[rag_prompt_solver(), generate()]" in code
+    # Solver chain prepends the RAG solver before generation.
+    # generate_at_model_limit() replaces plain generate() so each target runs at
+    # its own output-token limit (see eval_mcp/solvers/model_limit.py).
+    assert "solver=[rag_prompt_solver(), generate_at_model_limit()]" in code
     # Wires the judge model at task-file import time
     assert "_rag_configure_judge(next(iter(CONFIG[\"judge_models\"].values())))" in code
     # Scorer call site
@@ -286,10 +288,14 @@ def test_score_only_with_prompts(jc: JudgeConfig) -> None:
 
 
 def test_non_score_only_unchanged(jc: JudgeConfig) -> None:
-    # Sanity: backward-compat path. Default mode emits generate(), no
-    # static solver, no metadata field, no score_only flag.
+    # Sanity: backward-compat path. Default mode generates normally — no static
+    # solver, no metadata field, no score_only flag. The generation step is
+    # generate_at_model_limit() rather than plain generate() so each target runs
+    # at its own output-token limit instead of Inspect's constant 2048 default
+    # (see eval_mcp/solvers/model_limit.py).
     code, cfg = _render(jc, scorers=["f1"])
-    assert "solver=[generate()]" in code
+    assert "solver=[generate_at_model_limit()]" in code
+    assert "from eval_mcp.solvers.model_limit import generate_at_model_limit" in code
     assert "static_output_solver" not in code
     assert 'metadata=["actual_output"]' not in code
     assert "score_only" not in cfg

--- a/tests/test_max_tokens_per_model.py
+++ b/tests/test_max_tokens_per_model.py
@@ -1,0 +1,142 @@
+"""The generation ceiling is resolved per model, not hardcoded.
+
+A single `--max-tokens` number cannot serve both Bedrock endpoints, because they
+fail in opposite directions:
+
+  * Converse (`bedrock/<id>`) NEEDS a value — Inspect's global default is 2048
+    (inspect_ai/_util/constants.py), which truncates real answers. Worse for
+    reasoning models: they can spend the whole budget on the reasoning channel
+    and return an EMPTY completion with stop_reason="max_tokens". The sample
+    still "completes", so it scores 0 and the run reports success — the model
+    that reasoned hardest looks like the worst.
+  * Mantle (`openai/bedrock/<id>`) needs NO value. Omit it and the model runs to
+    its own limit; measured against the live API, gpt-5.6-sol produced 10,816
+    tokens on a long-form prompt where an 8192 cap truncated it.
+
+Nor does one high number work, since exceeding a model's limit is a hard
+ValidationException rather than a clamp ("The maximum tokens you requested
+exceeds the model limit of 10000"). Verified live: Nova Pro caps at 10,000,
+Claude Haiku 4.5 at 64,000, gpt-oss-20b at 128,000 — each accepts exactly its
+advertised value and rejects one above it.
+
+So the limit comes from the model itself (LiteLLM's dataset, the same source
+that backs pricing — AWS does not expose output limits via GetFoundationModel).
+"""
+from __future__ import annotations
+
+import pytest
+
+from eval_mcp.tools.run_eval import _MAX_TOKENS_FALLBACK, _max_tokens_for_run
+
+
+MANTLE = "openai/bedrock/gpt-5.6-terra"
+NOVA = "bedrock/us.amazon.nova-pro-v1:0"          # advertised 10_000
+HAIKU = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"  # advertised 64_000
+UNKNOWN = "bedrock/some.model-that-does-not-exist-v9:0"
+
+
+def test_mantle_only_run_omits_the_flag():
+    """The whole point of the fix: no ceiling for Mantle-only runs.
+
+    Passing one is what created the empty-completion truncation this change
+    exists to remove.
+    """
+    assert _max_tokens_for_run([MANTLE]) is None
+    assert _max_tokens_for_run([MANTLE, "openai/bedrock/gpt-5.6-sol"]) is None
+
+
+def test_converse_run_uses_the_models_own_limit():
+    """Converse needs a value, and it must be the model's real maximum — not a
+    constant, or we're back to truncating whatever the constant is below."""
+    assert _max_tokens_for_run([NOVA]) == 10_000
+    assert _max_tokens_for_run([HAIKU]) == 64_000
+
+
+def test_mixed_run_takes_the_lowest_limit():
+    """`--max-tokens` is global (targets share one `--model` flag), so a mixed
+    run has to satisfy its most restrictive model.
+
+    Erring low truncates a tail; erring high is a ValidationException that
+    kills every sample for the smaller-limit model. Those are not symmetric,
+    which is why this is min() and not max().
+    """
+    assert _max_tokens_for_run([NOVA, HAIKU]) == 10_000
+    assert _max_tokens_for_run([HAIKU, NOVA]) == 10_000
+
+
+def test_mixed_mantle_and_converse_still_bounded_by_converse():
+    """A Mantle model in the run doesn't remove the need for a ceiling — the
+    Converse model alongside it would otherwise fall back to Inspect's 2048."""
+    assert _max_tokens_for_run([MANTLE, NOVA]) == 10_000
+
+
+def test_unknown_model_falls_back_rather_than_guessing():
+    """An unrecognised model means "can't reason about it", not "unlimited".
+    Omitting the flag would hand it Inspect's 2048."""
+    assert _max_tokens_for_run([UNKNOWN]) == _MAX_TOKENS_FALLBACK
+
+
+def test_lowest_limit_is_never_clamped_up_to_the_fallback():
+    """Regression guard on a bug in the first draft of this fix.
+
+    Clamping the minimum up to the fallback (`max(min(limits), FALLBACK)`) reads
+    like a sensible floor, but it pushes the value ABOVE a real API bound
+    whenever a model's limit is below the fallback — converting a graceful
+    truncation into the hard rejection this whole change is meant to avoid.
+    """
+    assert _max_tokens_for_run([NOVA]) == 10_000 < _MAX_TOKENS_FALLBACK * 2
+    # Explicitly: a model whose advertised limit is under the fallback must NOT
+    # be raised to it.
+    limit = _max_tokens_for_run([NOVA])
+    assert limit == 10_000, (
+        f"expected Nova's advertised 10000, got {limit} — a clamp to the "
+        f"fallback would make Bedrock reject the request outright"
+    )
+
+
+def test_score_only_run_omits_the_flag():
+    """No models means nothing generates; a ceiling is meaningless."""
+    assert _max_tokens_for_run([]) is None
+
+
+def test_max_output_tokens_lookup_resolves_bedrock_id_shapes():
+    """The limit lookup has to survive the ID shapes we actually pass.
+
+    Region-prefixed Converse IDs, `bedrock/` prefixes and Mantle's
+    `openai/bedrock/` all have to resolve, or the fix silently degrades to the
+    fallback for every model.
+    """
+    from eval_mcp.core.pricing import get_max_output_tokens
+
+    for model_id in (NOVA, HAIKU, "bedrock/openai.gpt-oss-20b-1:0", MANTLE):
+        limit = get_max_output_tokens(model_id)
+        assert isinstance(limit, int) and limit > 0, (
+            f"{model_id} did not resolve to a positive limit (got {limit!r}); "
+            f"check _candidates() normalisation in pricing.py"
+        )
+
+
+def test_generated_scorer_source_is_valid_python():
+    """`JURY_SCORER_BLOCK` reaches evals as SOURCE TEXT inside the generated
+    config, so a syntax error there breaks every eval rather than failing a
+    test. Cheap insurance whenever that block is edited."""
+    import ast
+
+    from eval_mcp.tools.create_config import JURY_SCORER_BLOCK
+
+    ast.parse(JURY_SCORER_BLOCK)
+
+
+def test_partial_truncation_is_flagged_in_the_generated_scorer():
+    """A cut-off answer used to be scored as though it were complete.
+
+    It still gets scored (partial output carries real signal), but the score is
+    a floor rather than a measurement — completeness criteria fail on a severed
+    answer regardless of quality — so it has to be visibly marked.
+    """
+    from eval_mcp.tools.create_config import JURY_SCORER_BLOCK
+
+    assert "truncated_partial" in JURY_SCORER_BLOCK
+    assert "truncated_partial_output" in JURY_SCORER_BLOCK, (
+        "the metadata flag is what downstream readers filter on"
+    )

--- a/tests/test_max_tokens_per_model.py
+++ b/tests/test_max_tokens_per_model.py
@@ -140,3 +140,119 @@ def test_partial_truncation_is_flagged_in_the_generated_scorer():
     assert "truncated_partial_output" in JURY_SCORER_BLOCK, (
         "the metadata flag is what downstream readers filter on"
     )
+
+
+# ---------------------------------------------------------------------------
+# The per-model solver (eval_mcp/solvers/model_limit.py)
+#
+# This is the primary path: it resolves the ceiling from the ACTIVE model at
+# solve time, so several models share one subprocess (Inspect runs targets
+# concurrently — splitting per model would serialise them) while each still gets
+# its own limit. `_max_tokens_for_run` above is only for `benchmarks`, whose
+# upstream inspect_evals tasks we don't generate and therefore can't give a
+# solver to.
+# ---------------------------------------------------------------------------
+
+
+def test_solver_leaves_mantle_unbounded():
+    """Mantle models must get no ceiling at all.
+
+    Inspect's OpenAI provider has no max_tokens() override, so omitting the
+    value lets the model run to its own limit — measured, gpt-5.6-sol produced
+    9,052 output tokens on a prompt that a hardcoded 8192 truncated.
+    """
+    from eval_mcp.solvers.model_limit import resolve_max_tokens
+
+    assert resolve_max_tokens("openai/bedrock/gpt-5.6-terra") is None
+    assert resolve_max_tokens("openai/bedrock/gpt-5.6-sol") is None
+
+
+def test_solver_resolves_converse_models_own_limit():
+    """Converse needs a value or Inspect injects 2048; it must be the model's
+    real maximum, not a constant."""
+    from eval_mcp.solvers.model_limit import resolve_max_tokens
+
+    assert resolve_max_tokens(NOVA) == 10_000
+    assert resolve_max_tokens(HAIKU) == 64_000
+    # llama3.3-70b is the low end of the range and the reason a single shared
+    # constant can't work: it would cap haiku at a twelfth of its capability.
+    assert resolve_max_tokens("bedrock/us.meta.llama3-3-70b-instruct-v1:0") == 4_096
+
+
+def test_solver_falls_back_for_unknown_models():
+    """Unknown means "can't reason about it", not "unlimited" — returning None
+    would hand the model Inspect's 2048."""
+    from eval_mcp.solvers.model_limit import FALLBACK_MAX_TOKENS, resolve_max_tokens
+
+    assert resolve_max_tokens(UNKNOWN) == FALLBACK_MAX_TOKENS
+    assert FALLBACK_MAX_TOKENS > 2048, "must beat Inspect's default"
+
+
+def test_generated_config_uses_the_per_model_solver():
+    """The task file must actually wire the solver in — this is what makes the
+    per-model ceiling reach a real eval, and it's easy to lose in a template
+    edit since the file is emitted as source text."""
+    from eval_mcp.core.judge_config import JudgeConfig
+    from eval_mcp.tools.create_config import create_inspect_task_file
+
+    jc = JudgeConfig(criteria=[{"name": "acc", "description": "right?", "weight": 1.0}])
+    code, _ = create_inspect_task_file(
+        dataset_path="/tmp/x.json",
+        providers=[NOVA, MANTLE],
+        config_name="probe",
+        config_dir="/tmp",
+        judge_config=jc,
+        prompts=["{question}"],
+        scorers=["jury"],
+    )
+    assert "from eval_mcp.solvers.model_limit import generate_at_model_limit" in code
+    assert "generate_at_model_limit()" in code
+
+
+def test_generated_config_parses_in_every_mode():
+    """The task file reaches evals as SOURCE TEXT, so a template break fails at
+    eval time rather than in CI. Parse all three solver-chain variants."""
+    import ast
+
+    from eval_mcp.core.judge_config import JudgeConfig
+    from eval_mcp.tools.create_config import create_inspect_task_file
+
+    jc = JudgeConfig(criteria=[{"name": "acc", "description": "right?", "weight": 1.0}])
+    variants = [
+        {"scorers": ["jury"]},
+        {"scorers": ["jury"], "score_only": True},
+        {"scorers": ["faithfulness"]},
+    ]
+    for kwargs in variants:
+        code, _ = create_inspect_task_file(
+            dataset_path="/tmp/x.json",
+            providers=[NOVA],
+            config_name="probe",
+            config_dir="/tmp",
+            judge_config=jc,
+            prompts=["{question}"],
+            **kwargs,
+        )
+        ast.parse(code)
+
+
+def test_run_eval_does_not_pass_a_global_max_tokens():
+    """A global --max-tokens would defeat the solver by forcing every model to
+    the same ceiling. Assert on the parsed source so a mention in a comment
+    doesn't trip it — only a real argument counts.
+    """
+    import ast
+    import inspect
+
+    from eval_mcp.tools import run_eval
+
+    tree = ast.parse(inspect.getsource(run_eval))
+    literals = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert "--max-tokens" not in literals, (
+        "run_eval must not build a global --max-tokens argument; the generated "
+        "task file's solver resolves the ceiling per model"
+    )

--- a/tests/test_run_eval_fail_loud.py
+++ b/tests/test_run_eval_fail_loud.py
@@ -299,17 +299,25 @@ def test_region_hint_survives_probe_failure():
 # ---------------------------------------------------------------------------
 
 
-def test_eval_launches_with_raised_max_tokens():
-    """Every eval must pass an explicit --max-tokens above Inspect's 2048.
+def test_converse_run_raises_max_tokens_above_inspect_default():
+    """A Converse run must pass a ceiling above Inspect's 2048.
 
     Inspect's Bedrock provider defaults to 2048, which reasoning models can
     consume entirely on their reasoning channel — producing an empty completion
     that scores 0 while the run reports success. Measured: gpt-5.6-luna and
     gpt-5.6-sol both hit 2048/2048 reasoning tokens with no visible output.
-    """
-    from eval_mcp.tools.run_eval import _DEFAULT_MAX_TOKENS
 
-    assert _DEFAULT_MAX_TOKENS > 2048, "must exceed Inspect's Bedrock default"
+    The value is now resolved per model from its advertised maximum rather than
+    a single constant (see _max_tokens_for_run), but the invariant that matters
+    to this failure — a Converse run never inherits the 2048 default — still
+    holds and is what this guards.
+    """
+    from eval_mcp.tools.run_eval import _MAX_TOKENS_FALLBACK, _max_tokens_for_run
+
+    assert _MAX_TOKENS_FALLBACK > 2048, "fallback must exceed Inspect's default"
+    # A known Converse model resolves to its real limit, which is far above 2048.
+    resolved = _max_tokens_for_run(["bedrock/us.amazon.nova-pro-v1:0"])
+    assert resolved is not None and resolved > 2048
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the empty and truncated GPT-5.6 results. The cause was **our own hardcoded `--max-tokens 8192`**, not a model limitation — so this removes the guess rather than tuning it.

Each target now generates at **its own** advertised output limit, resolved inside the generated task file's solver (`eval_mcp/solvers/model_limit.py`).

## Why a single number can't work

The two Bedrock endpoints fail in **opposite** directions:

| | omit `max_tokens` | our 8192 cap |
|---|---|---|
| **Mantle** (`openai/bedrock/*`) | ✅ runs to its own limit | ❌ **truncates** |
| **Converse** (`bedrock/*`) | ❌ **2048** (Inspect's default) | ✅ fine |

And no high constant is safe either, because exceeding a model's limit is a hard `ValidationException` — *"The maximum tokens you requested exceeds the model limit of 10000"* — **not** a clamp. Verified against live Bedrock:

```
llama3.3-70b →   4,096      haiku-4.5   →  64,000
nova-pro     →  10,000      gpt-oss-20b → 128,000
```

Each accepts exactly its advertised value and rejects one above it. So a constant safe for every model is ~4k — which is what truncated gpt-5.6-sol at 8,413 tokens. The lookup is what breaks that tie; limits come from LiteLLM's dataset (the same feed already backing pricing, so no extra fetch — AWS doesn't expose output limits via `GetFoundationModel` at all).

## Why in the solver, not on the CLI

`--max-tokens` is global (targets share one `--model` flag), so it would force every model down to the lowest limit in the run — llama's 4,096 capping haiku's 64,000.

`get_model()` inside a solver returns the model the current sample is running against, so `generate_at_model_limit()` gives each target its own ceiling while they all stay in **one** subprocess. That matters: Inspect already runs targets concurrently (verified — three models in a mixed run had identical start/end timestamps), so splitting per model would have serialised what is currently parallel.

`optimize_prompt` inherits this via `create_inspect_task_file`. **`benchmarks` is the one exception** — it runs upstream `inspect_evals/*` tasks whose solvers we don't generate, so it keeps a global flag and the lowest-limit compromise.

## This is an upstream gap

Confirmed against Inspect `main` (commit dated 2026-07-30), not assumed:

- `DEFAULT_MAX_TOKENS = 2048` — unchanged
- The Bedrock provider still picks limits from a **hand-coded family table** (`llama3-70`→2048, `claude3`→4096, `mistral-large`→8192, else→2048)
- **No truncation warning anywhere** — PR #3933 proposed one and was closed *unmerged*; issue #4295 tracks the adjacent cross-provider reasoning-default problem and is open with no maintainer fix

On stock Inspect with nothing set, gpt-oss-20b returns 2048 output tokens and **zero visible characters**. `model_limit.py` documents the condition for deleting this workaround when upstream fixes it. Also re-verified on inspect-ai 0.3.251 (newer than the 0.3.241 originally tested) — behaviour identical.

## Also fixed

The jury scorer only flagged *fully empty* completions, so an answer cut off mid-stream was scored as though complete. Partial output is still scored (it carries real signal) but now carries `truncated_partial_output` and a note that the score is a floor — completeness criteria necessarily fail on a severed answer.

## Test plan

Verified through the real MCP pipeline in a clean venv (mcp 2.0.0 + inspect 0.3.251), not standalone scripts:

- [x] **Mixed run in one subprocess** — applied `max_tokens` read back from the eval log: llama **4096**, haiku **64000**, gpt-5.6-terra **None**. 0 empty, 0 truncated.
- [x] **The prompt that truncated at 8192** — gpt-5.6-sol now runs unbounded to **9,052 output tokens**, `stop=stop`, score 1.0
- [x] `optimize_prompt` converged (test score 1.0); `score_only` unaffected (3/3 scored)
- [x] Model limits verified live: each accepts its advertised value, rejects one above
- [x] **547 pytest tests**, incl. parse checks on all three generated solver-chain variants — the task file ships as *source text*, so a template break would otherwise surface only at eval time
- [ ] **Deploy to us-east-2 and verify the live pod before merging** — this changes the eval subprocess and adds a module the MCP sidecar loads

One caveat: `FALLBACK_MAX_TOKENS = 8192` remains for models absent from the limits dataset. Still an arbitrary number, but it only applies to unknown Converse models, where the alternative is Inspect's 2048.