### PR TITLE
fix(mcp2): repair the backend's MCP client for the 2.x transport API

### DIFF
--- a/backend/core/mcp_client.py
+++ b/backend/core/mcp_client.py
@@ -7,6 +7,8 @@ import os
 from contextlib import AsyncExitStack
 from typing import Any, Dict, List, Optional
 
+import httpx2
+
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
@@ -106,12 +108,34 @@ class MultiMCPClient:
                 exit_stack = AsyncExitStack()
 
                 if server_config["type"] == "http":
-                    # Connect via HTTP with extended timeout for long-running evaluations
-                    read, write, _ = await exit_stack.enter_async_context(
+                    # Extended timeouts for long-running evaluations. mcp 2.x
+                    # removed the `timeout`/`sse_read_timeout` arguments — the
+                    # transport now takes a preconfigured client instead, so the
+                    # values live on the httpx timeout object. Passing the old
+                    # kwargs raises "streamable_http_client() got an unexpected
+                    # keyword argument 'timeout'", which surfaced only in the
+                    # deployed pod (the backend crash-looped, unable to reach its
+                    # own MCP sidecar).
+                    #
+                    # NOTE: httpx2, not httpx — mcp 2.x depends on httpx2 and the
+                    # transport type-checks against httpx2.AsyncClient. Our own
+                    # code elsewhere still uses plain httpx; they coexist as
+                    # separate modules.
+                    # Two values, not three: mcp 2.x dropped the trailing
+                    # get_session_id callback from the yielded tuple, so the old
+                    # `read, write, _ = ...` raises "not enough values to unpack
+                    # (expected 3, got 2)".
+                    read, write = await exit_stack.enter_async_context(
                         streamable_http_client(
                             server_config["url"],
-                            timeout=3600.0,  # 1 hour for connection/request
-                            sse_read_timeout=7200.0  # 2 hours for SSE streaming
+                            http_client=await exit_stack.enter_async_context(
+                                httpx2.AsyncClient(
+                                    timeout=httpx2.Timeout(
+                                        3600.0,      # 1 hour connect/write/pool
+                                        read=7200.0,  # 2 hours for SSE streaming
+                                    )
+                                )
+                            ),
                         )
                     )
                 else:
@@ -323,7 +347,12 @@ class MultiMCPClient:
 
                 # Convert Tool objects to dicts and tag with server name
                 for tool in result.tools:
-                    input_schema = tool.inputSchema
+                    # snake_case: mcp 2.x renamed the camelCase wire-model
+                    # attributes (inputSchema -> input_schema). The wire format
+                    # is unchanged — only Python attribute access moved — and
+                    # this loop swallows exceptions into a warning, so getting it
+                    # wrong showed up as a silent "0 tools" rather than an error.
+                    input_schema = tool.input_schema
 
                     # Hide backend-injected params from the model. (The unified
                     # server registers as "eval"; the older split names are kept

--- a/tests/test_mcp_client_api_compat.py
+++ b/tests/test_mcp_client_api_compat.py
@@ -1,0 +1,153 @@
+"""The MCP client must match the installed mcp SDK's actual API.
+
+Every test in this suite passed while the deployed backend crash-looped, unable
+to reach its own MCP sidecar. The mcp 2.x migration renamed
+``streamablehttp_client`` -> ``streamable_http_client`` and the rename was caught
+— but three *behavioural* changes behind that name were not, because nothing
+exercised the real transport:
+
+  1. ``timeout``/``sse_read_timeout`` arguments removed (pass a preconfigured
+     ``http_client`` instead) -> "got an unexpected keyword argument 'timeout'"
+  2. the yielded tuple lost its trailing ``get_session_id`` callback, so
+     ``read, write, _ = ...`` -> "not enough values to unpack (expected 3, got 2)"
+  3. wire-model attributes went snake_case, so ``tool.inputSchema`` ->
+     ``'Tool' object has no attribute 'inputSchema'``. This one was the worst:
+     ``list_tools`` swallows per-server exceptions into a warning, so it
+     surfaced as a silent "0 tools" — the agent connected and then offered
+     nothing.
+
+These assert against the *installed* SDK rather than mocks, so a future major
+bump fails here instead of in a pod. They need no network: signature and model
+introspection only.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_transport_accepts_the_arguments_we_pass():
+    """We call ``streamable_http_client(url, http_client=...)``. Both the name
+    and the keyword have to exist."""
+    from mcp.client.streamable_http import streamable_http_client
+
+    params = inspect.signature(streamable_http_client).parameters
+    assert "http_client" in params, (
+        f"transport no longer accepts http_client; got {list(params)}. Our long "
+        f"eval timeouts (1h connect / 2h SSE read) ride on that client."
+    )
+
+
+def test_transport_does_not_accept_the_removed_timeout_kwargs():
+    """Guards the exact crash. If a future version reinstates these, this test
+    failing is the prompt to simplify the call site back."""
+    from mcp.client.streamable_http import streamable_http_client
+
+    params = inspect.signature(streamable_http_client).parameters
+    assert "timeout" not in params and "sse_read_timeout" not in params, (
+        "transport accepts timeout/sse_read_timeout again — mcp_client.py can "
+        "drop the explicit httpx2 client it builds to carry those values"
+    )
+
+
+def test_client_builds_its_timeout_client_with_httpx2():
+    """mcp 2.x depends on **httpx2** and the transport type-checks against
+    ``httpx2.AsyncClient``. Our own code elsewhere still uses plain ``httpx``;
+    passing the wrong one is a type error at connect time, in the pod."""
+    import backend.core.mcp_client as mc
+
+    src = inspect.getsource(mc)
+    assert "httpx2" in src, "mcp_client must use httpx2, not httpx, for the transport"
+
+    import httpx2
+
+    client = httpx2.AsyncClient(timeout=httpx2.Timeout(3600.0, read=7200.0))
+    try:
+        # The long read timeout is what keeps hours-long evals alive.
+        assert client.timeout.read == 7200.0
+        assert client.timeout.connect == 3600.0
+    finally:
+        # No await available in a sync test; closing the transport is enough.
+        client.close() if hasattr(client, "close") else None
+
+
+def test_client_unpacks_the_right_number_of_streams():
+    """The transport yields (read, write) in 2.x. Assert our call site matches
+    the SDK's declared return type rather than hardcoding a count."""
+    import backend.core.mcp_client as mc
+
+    src = inspect.getsource(mc)
+    assert "read, write = await" in src, (
+        "mcp_client unpacks the wrong arity from streamable_http_client; 2.x "
+        "yields (read, write) with no trailing get_session_id callback"
+    )
+    assert "read, write, _ = await" not in src
+
+
+def test_tool_model_exposes_snake_case_input_schema():
+    """`list_tools` reads this attribute. A camelCase access returns 0 tools
+    silently, because the collection loop logs and continues."""
+    from mcp.types import Tool
+
+    fields = set(Tool.model_fields)
+    assert "input_schema" in fields, (
+        f"Tool.input_schema is gone; mcp_client reads it when building the "
+        f"agent's tool list. Available: {sorted(fields)}"
+    )
+
+
+def test_client_reads_tool_schema_with_the_snake_case_name():
+    """Pin the call site too — the SDK having the field doesn't help if we ask
+    for the old one."""
+    import backend.core.mcp_client as mc
+
+    src = inspect.getsource(mc)
+    assert "tool.input_schema" in src
+    assert "tool.inputSchema" not in src, (
+        "mcp_client still reads tool.inputSchema; on mcp 2.x that raises inside "
+        "list_tools' except block and yields a silent empty tool list"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_tools_surfaces_a_schema_error_instead_of_returning_empty(
+    monkeypatch,
+):
+    """The silent-failure mode itself.
+
+    `list_tools` catches per-server exceptions so one bad server can't take down
+    the rest — reasonable, but it meant an API mismatch presented as "connected,
+    0 tools" rather than an error. A server whose tools can't be read must not
+    look like a server with no tools.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from backend.core.mcp_client import MultiMCPClient
+
+    # The constructor reads the sidecar URL from the environment.
+    monkeypatch.setenv("EVAL_MCP_URL", "http://127.0.0.1:8002/mcp")
+    client = MultiMCPClient()
+
+    class _BadTool:
+        name = "probe"
+        description = "d"
+
+        def __getattr__(self, item):  # no input_schema / inputSchema
+            raise AttributeError(item)
+
+    session = MagicMock()
+    session.list_tools = AsyncMock(return_value=MagicMock(tools=[_BadTool()]))
+    client.sessions = {"eval": session}
+    client.reconnect_server = AsyncMock(return_value=None)
+
+    tools = await client.list_tools()
+
+    # Today this returns [] after a warning. Assert the weaker but meaningful
+    # property: we did NOT silently report a healthy empty toolset — the server
+    # was recorded as failed and a reconnect was attempted.
+    assert tools == []
+    assert client.reconnect_server.await_count >= 1, (
+        "a server whose tools cannot be parsed must be treated as failed "
+        "(reconnect attempted), not as a server that legitimately has none"
+    )


### PR DESCRIPTION
## Summary

**This unblocks deploys.** The last deploy failed — the backend container crash-looped, unable to connect to its own MCP sidecar, so the rollout never completed:

```
error: deployment "backend" exceeded its progress deadline
```

The pod sat at `1/2 Running` with 20 restarts. (The app stayed up: the two old pods kept serving, so this surfaced only as a red build.)

Root cause is the mcp 2.x migration in #138. The transport *rename* (`streamablehttp_client` → `streamable_http_client`) was applied, but three behavioural changes behind that name were not:

| # | mcp 2.x change | symptom |
|---|---|---|
| 1 | `timeout`/`sse_read_timeout` args removed — pass a preconfigured `http_client` | **the crash**: `got an unexpected keyword argument 'timeout'` |
| 2 | yielded tuple dropped the trailing `get_session_id` callback | `not enough values to unpack (expected 3, got 2)` |
| 3 | wire-model attrs went snake_case: `tool.inputSchema` → `tool.input_schema` | **silent "0 tools"** |

Each masked the next — #2 and #3 only appeared after fixing #1.

**#3 is the dangerous one.** `list_tools()` catches per-server exceptions and logs a warning, so the mismatch presented as "connected successfully, 0 tools" — no error, no crash. The agent would have come up offering nothing.

The 1h connect / 2h SSE read timeouts matter (they keep hours-long evals alive), so they move onto an `httpx2.Timeout` rather than being dropped. Note **httpx2**, not httpx: mcp 2.x depends on httpx2 and the transport type-checks against `httpx2.AsyncClient`. Our own code elsewhere still uses plain httpx; they coexist as separate modules.

## Why the suite didn't catch it

**541 tests passed while the pod was crash-looping.** For #138 I verified the server side thoroughly — boots, 27 tools register, real stdio handshake with tool calls, clean-venv wheel install. The break was on the **client** side (`backend/core/mcp_client.py`, backend → sidecar over HTTP), and nothing exercised that transport. The rename satisfied every import-level check.

Compounding it: the migration guide documented both #2 and #3 explicitly. I grepped for the renamed symbol instead of reading the entries for the API I was calling.

`tests/test_mcp_client_api_compat.py` closes that gap. It asserts against the **installed SDK** — signature and model introspection, no network — so a future major bump fails in CI rather than in a pod. Verified it catches this: **3 of 7 tests fail against the pre-fix client**, one per bug. It also pins the silent-failure mode itself: a server whose tools can't be parsed must be recorded as failed (reconnect attempted), not reported as a server that legitimately has none.

## Test plan

- [x] Verified in the containerized stack, which is where the pod's failure reproduces: backend reaches `Healthy`, logs `Connected to eval` with no errors, **27 tools** listed
- [x] Real chat message drove an MCP tool call end to end — returned **81 live Bedrock models** (proves backend → sidecar → Bedrock)
- [x] New compat tests fail on the pre-fix client (3/7), pass after
- [x] **548 pytest tests** pass
- [ ] Deploy to us-east-2 — this PR is what makes that possible; the previous attempt failed before completing