### PR TITLE
feat(benchmarks): port the aiewf 30-turn multi-turn benchmark + a porting contract

### DIFF
--- a/.claude/skills/port-a-benchmark/SKILL.md
+++ b/.claude/skills/port-a-benchmark/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: port-a-benchmark
+description: Port an existing third-party benchmark or eval into this repo as an Inspect AI task, faithfully. Use this whenever the task is "add benchmark X", "port this eval", "can we run <github repo> here", or adapting any external eval harness (aiewf-eval, lm-evaluation-harness, a paper's repo, a colleague's script). Enforces the one rule that makes a port worth anything — copy the measuring instrument verbatim, adapt only the runner — plus the verification steps that prove the port is faithful rather than merely running.
+---
+
+# Port a Benchmark
+
+A ported benchmark has exactly one job: **produce the same measurement the
+original produces.** A port that runs cleanly but measures something subtly
+different is worse than no port, because the numbers look authoritative and
+nobody can tell they're wrong.
+
+The failure mode is specific and quiet: the dataset gets copied faithfully
+(obviously data), while a judge rubric living in a Python string literal gets
+"adapted" (looks like code). The suite stays green, because the suite exercises
+the plumbing. Only a line-by-line comparison against upstream catches it.
+
+## The rule
+
+> **Copy the measuring instrument verbatim. Adapt only the plumbing.**
+
+Sort every file in the upstream repo into one of two buckets before writing any
+code. When unsure which bucket something belongs in, it goes in COPY.
+
+### COPY — byte-for-byte, no edits, no reformatting
+
+Anything that influences what a score means:
+
+- Datasets, questions, golden/reference answers, expected outputs
+- **Prompts of every kind** — system prompts, judge/grader rubrics, user-turn
+  scaffolding, few-shot examples, instruction preambles
+- Tool/function schemas (names, descriptions, required-ness all change model
+  behaviour)
+- Scoring thresholds, weights, metric formulas, aggregation rules
+- Stop conditions, retry/recovery policy, turn boundaries
+
+**Prompts are data, not code.** This is the trap. A prompt in a `.py` string
+literal *looks* like code, so it feels adaptable. It isn't. The wording is the
+instrument. Rewriting it for concision or clarity is not a refactor — it's
+recalibrating a scale nobody asked you to recalibrate.
+
+### ADAPT — rewrite freely
+
+The mechanics of execution, which can't change what's measured:
+
+- Their runner → an Inspect `@task` with a solver + scorer
+- Their HTTP/SDK client → `get_model()` / `execute_tools()`
+- Their storage/logging → our log dir, viewer, S3 sync
+- Their CLI → an MCP tool
+- Their concurrency, retries-on-transport-error, progress output
+
+## Workflow
+
+### 1. Read the whole upstream harness before writing anything
+
+Not just the entry point. Specifically read, end to end:
+
+- the runner/pipeline (what constitutes one "turn" or one sample?)
+- the scorer/judge (what exactly does it receive? what does it *skip*?)
+- the recorder (what gets written, and does the scorer read all of it?)
+
+Score-relevant behaviours hide here that no README mentions. Two real examples
+from aiewf-eval, both found only by reading the source: the pipeline sets
+`default_tool_result_run_llm = False`, so a turn *ends* at the tool call (no
+second generate after the tool result — otherwise the model gets a free retry);
+and the judge silently skips recovery records
+(`if rec.get("recovery_turn"): continue`), so a tool call made only after a
+retry prompt earns no credit. Miss either and every score is inflated.
+
+### 2. Vendor the COPY bucket verbatim, as data files
+
+Put prompts in `data/*.txt`, datasets in `data/*.json` — even when upstream
+keeps them in Python. This makes fidelity checkable by `diff` and stops a future
+edit from quietly rewording the instrument.
+
+Add a test asserting the vendored copy is unmodified (length + a distinctive
+substring is enough).
+
+### 3. When you must edit a copied artifact, transform it in code
+
+Sometimes a genuine edit is required — e.g. dropping a dimension that needs
+audio we don't have. Do **not** hand-edit the vendored copy. Load the original
+and transform it at import time:
+
+```python
+_UPSTREAM = (Path(__file__).parent / "data" / "upstream_judge_prompt.txt").read_text()
+_OURS = _strip_audio_dimension(_UPSTREAM)   # mechanical, auditable
+```
+
+Then pin it with a test that diffs `_OURS` against `_UPSTREAM` and **fails on any
+difference you didn't explicitly justify**:
+
+```python
+for line in removed:
+    assert is_expected_removal(line), f"unexpected removal: {line!r}"
+```
+
+This is the load-bearing guardrail. It converts "someone tidied the prompt" from
+an invisible measurement change into a red test.
+
+### 4. Write the ADAPT bucket
+
+Standard Inspect work: solver, scorer, metrics. Route launches through
+`_INSPECT_CMD` so `inspect_patches` applies (see CLAUDE.md on `max_tokens`).
+
+### 5. Prove fidelity, not just execution
+
+Green tests do not mean the port is faithful. Run all of these:
+
+- [ ] **Byte-compare the target-facing prompt** against the upstream assembly.
+      Reconstruct it from their source and `assert ours == theirs`.
+- [ ] **Compare a real score against the upstream published figure**, same model
+      if it's in their table. Same ballpark isn't automatic — a large gap means
+      a behaviour wasn't ported, so go find it. Don't rationalise it.
+- [ ] **Hand-adjudicate the disagreements.** Read the failing samples against
+      the golden answers and the source data. Confirm each failure is a real
+      model error and not a harness artifact. This is how the recovery-nudge bug
+      surfaced.
+- [ ] **Real model, never mockllm** (see `never-mockllm-use-bedrock` in CLAUDE.md).
+
+### 6. Write a NOTICE.md next to the port
+
+Upstream repo, license, **pinned commit SHA**, and three lists: what was copied,
+what was adapted and why, what was deliberately not ported. Every intentional
+deviation gets a line with its justification and, where relevant, its measured
+score impact. `eval_mcp/benchmarks/aiwf/NOTICE.md` is the template.
+
+## Judge/grader models
+
+If the port is judge-scored, the judge is part of the measuring instrument:
+
+- Prefer upstream's judge model when it's available to us.
+- If you substitute one, **measure the substitution** — fix a transcript, run
+  each candidate N times, score against hand-adjudicated verdicts. Never compare
+  two judges across two different eval *runs*: each run produces a different
+  target transcript, so the delta measures the target model's variance rather
+  than the judge's — and can easily point the wrong way.
+- Check stability, not just accuracy. A judge that swings 0.100 in the headline
+  metric on identical input is unusable regardless of how smart it is.
+- Record the judge id in the score metadata so every number is self-describing.
+
+## Anti-patterns
+
+| Don't | Why |
+|---|---|
+| Rewrite a prompt "more cleanly" | The wording is the instrument. You'd be trading fidelity for concision nobody asked for. |
+| Hand-edit a vendored copy to make one small change | Untraceable. Transform the original in code and pin with a diff test. |
+| Let one legitimate edit license a general tidy-up | Dropping an unusable dimension is valid; restructuring the surrounding 100 lines is not. |
+| Assume a score gap is "just a different judge" | It's usually an unported behaviour. Go find it before you attribute it. |
+| Treat a passing test suite as proof of fidelity | The suite exercises the plumbing, not whether the instrument reads true. |
+| Compare judges across separate runs | Different transcripts, so you measure the target's variance, not the judge's. |
+
+## Checklist
+
+```
+[ ] Read upstream's runner, scorer AND recorder end to end
+[ ] Sorted every artifact into COPY vs ADAPT (unsure -> COPY)
+[ ] Prompts/datasets vendored verbatim as data files
+[ ] Any edit to a copied artifact done as a code transform, pinned by a diff test
+[ ] Test asserts the vendored copy is unmodified
+[ ] Target-facing prompt byte-compared against upstream's assembly
+[ ] Real Bedrock model run (never mockllm)
+[ ] Score compared against upstream's published figure; gaps explained, not excused
+[ ] Failing samples hand-adjudicated against golden answers
+[ ] NOTICE.md: upstream, license, pinned SHA, copied/adapted/not-ported, deviations + impact
+[ ] Judge model justified by measurement if it differs from upstream's
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,21 +176,32 @@ of rejecting), delete `inspect_patches.py` + `_inspect_main.py`, point
 'openai.gpt-5.6-terra' does not support the '/v1/chat/completions' API"*. Only
 `/openai/v1/responses` works for inference; the catalog stays at `/v1/models`.
 
-### Two kinds of benchmark — don't merge the two tools
+### Two benchmark sources, one set of tools
 
-There are two separate benchmark paths, and they are not interchangeable:
+Benchmarks come from two places, but callers use the **same tools** for both —
+`list_benchmarks` / `get_benchmark_details` / `run_benchmark`. Don't split them
+back apart; a separate tool pair meant an agent calling `list_benchmarks` never
+saw the bundled ones.
 
-- **`eval_mcp/tools/benchmarks.py`** (`list_benchmarks` / `run_benchmark`) is a
-  thin wrapper over the installed **`inspect_evals`** catalog (~130 single-turn
-  Q&A benchmarks: MMLU, GPQA, HumanEval…). It runs `inspect_evals/<task>` by
-  registry name, so it can only run what that package registers.
-- **`eval_mcp/benchmarks/`** (`list_multiturn_benchmarks` /
-  `run_multiturn_benchmark`) holds benchmarks we **vendor and run ourselves**,
-  for shapes `inspect_evals` doesn't cover. Currently `aiwf_medium_context` and
-  `aiwf_long_context` — a 30-turn scripted conversation with 5 tools, ported
-  from [kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval) (MIT).
-  Launched by **absolute path** (`<task_file>@<task_name>`), which works from
-  any cwd.
+- **`inspect_evals`** — the installed upstream catalog (~129 single-turn Q&A:
+  MMLU, GPQA, HumanEval…). Run by registry name, `inspect_evals/<task>`.
+- **`eval_mcp/benchmarks/`** — benchmarks we **vendor and run ourselves**, for
+  shapes `inspect_evals` doesn't cover. Launched by **absolute path**
+  (`<task_file>@<task_name>`), which works from any cwd. Currently `aiwf` (a
+  30-turn scripted conversation with 5 tools, ported from
+  [kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval), MIT).
+
+`eval_mcp/benchmarks/registry.py` discovers the bundled ones by globbing
+`*/eval.yaml` — the same mechanism `inspect_evals` uses. **Adding a benchmark
+means dropping in a directory (`eval.yaml` + `task.py` + `data/` + `NOTICE.md`)
+and editing no Python** — not the registry, not the tools, not `server.py`.
+`eval.yaml`'s schema mirrors `inspect_evals`' own so a port could later go to
+their register with little change. `run_benchmark` dispatches on
+`registry.resolve(task)`; bundled entries are flagged `bundled: true` and sort
+first in listings (no HuggingFace download, no extra, no sandbox).
+`list_bundled_benchmarks` is the drill-down that dumps every bundled
+`eval.yaml` without paging the upstream catalog. Full instructions:
+[`eval_mcp/benchmarks/README.md`](./eval_mcp/benchmarks/README.md).
 
 #### Porting a third-party benchmark: copy the instrument, adapt the plumbing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,54 @@ There are two separate benchmark paths, and they are not interchangeable:
   Launched by **absolute path** (`<task_file>@<task_name>`), which works from
   any cwd.
 
+#### Porting a third-party benchmark: copy the instrument, adapt the plumbing
+
+<EXTREMELY_IMPORTANT>
+When porting ANY external benchmark or eval into this repo, **prompts are data,
+not code.** Copy every prompt, rubric, dataset, golden answer, tool schema,
+threshold and scoring rule **byte-for-byte**. Adapt only the plumbing (runner →
+Inspect task, their client → `get_model()`, their CLI → an MCP tool). If you're
+unsure which category something falls in, it is data — copy it.
+
+**Never rewrite, condense, reformat or "clean up" a prompt you are porting**, and
+never hand-edit a vendored copy. If an edit is genuinely required (e.g. dropping
+a dimension that needs inputs we don't have), load the verbatim original and
+transform it **in code**, then pin it with a test that diffs the result against
+the original and fails on any unjustified difference.
+</EXTREMELY_IMPORTANT>
+
+This is not a style preference. A ported benchmark's only job is to reproduce the
+original's *measurement*; a port that runs cleanly while measuring something
+subtly different is worse than none, because the numbers look authoritative and
+nobody can tell they're wrong. The rubric's wording **is** the measuring
+instrument — paraphrasing it recalibrates the scale.
+
+Two traps worth naming, because both are easy to walk into:
+
+- A prompt in a Python string literal *looks* like code, so it feels adaptable.
+  It isn't. Vendor it as a data file and load it.
+- A legitimate small edit (dropping a dimension whose inputs we don't have) must
+  not license a general tidy-up of the surrounding text. Transform in code, diff
+  the result, justify every changed line.
+
+And note that **a green test suite is not evidence of fidelity** — the suite
+exercises the plumbing, not whether the instrument still reads true.
+
+Full workflow, verification steps and the anti-pattern table:
+[port-a-benchmark skill](./.claude/skills/port-a-benchmark/SKILL.md). Invoke it
+for any "add benchmark X" / "port this eval" / "can we run \<repo\> here" task.
+The non-negotiables from it:
+
+- Read upstream's runner, scorer **and** recorder end to end before coding —
+  turn boundaries and what the scorer *skips* are never in the README.
+- Byte-compare the target-facing prompt against upstream's own assembly.
+- Compare against upstream's published score for the same model. A gap means a
+  behaviour wasn't ported; find it rather than attributing it to "a different
+  judge".
+- Hand-adjudicate failing samples against the golden answers.
+- Write a `NOTICE.md`: upstream, license, pinned SHA, what was copied / adapted /
+  not ported, and every intentional deviation with its measured impact.
+
 **Why not add new benchmarks to `inspect_evals` instead:** as of 2026-05-08 it
 stopped accepting new eval code (its `EVAL_REGISTER.md` — a dependency-isolation
 decision, not a quality one). New evals now live in the author's own repo and get

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,11 +214,18 @@ Two things to know before touching `eval_mcp/benchmarks/aiwf/`:
   (1) A turn *ends at the tool call* — no second generate after the tool result
   (upstream's `default_tool_result_run_llm = False`); generating again hands the
   model a free retry. (2) The **recovery nudge**: when a turn expected a tool
-  call and none came, upstream injects one synthetic `"Please go ahead."` turn
-  and merges that attempt into the same turn. Measured on claude-haiku-4-5 over
-  18 turns: pass_rate **0.833 without it, 0.944 with**. Full fidelity notes and
-  what was deliberately not ported (all speech-to-speech) in
-  `eval_mcp/benchmarks/aiwf/NOTICE.md`.
+  call and none came, upstream injects one synthetic `"Please go ahead."` turn —
+  and does **not** score that attempt (its judge skips `recovery_turn` records).
+  The nudge unblocks the conversation; it earns the turn no credit. Merging it
+  into the turn, as an earlier version did, lets a model that only complied when
+  prodded score as if it complied immediately.
+- **The judge prompt is upstream's verbatim, not a paraphrase.** It's vendored at
+  `data/upstream_judge_system_prompt.txt` and the audio-only `turn_taking`
+  dimension is stripped programmatically at load time, with a test diffing the
+  result against the original so nothing else can drift. Rewriting the rubric for
+  readability silently changes what the benchmark measures — that already
+  happened once. Full fidelity notes, and what was deliberately not ported (all
+  speech-to-speech), in `eval_mcp/benchmarks/aiwf/NOTICE.md`.
 
 ### Adding a model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,50 @@ of rejecting), delete `inspect_patches.py` + `_inspect_main.py`, point
 'openai.gpt-5.6-terra' does not support the '/v1/chat/completions' API"*. Only
 `/openai/v1/responses` works for inference; the catalog stays at `/v1/models`.
 
+### Two kinds of benchmark — don't merge the two tools
+
+There are two separate benchmark paths, and they are not interchangeable:
+
+- **`eval_mcp/tools/benchmarks.py`** (`list_benchmarks` / `run_benchmark`) is a
+  thin wrapper over the installed **`inspect_evals`** catalog (~130 single-turn
+  Q&A benchmarks: MMLU, GPQA, HumanEval…). It runs `inspect_evals/<task>` by
+  registry name, so it can only run what that package registers.
+- **`eval_mcp/benchmarks/`** (`list_multiturn_benchmarks` /
+  `run_multiturn_benchmark`) holds benchmarks we **vendor and run ourselves**,
+  for shapes `inspect_evals` doesn't cover. Currently `aiwf_medium_context` and
+  `aiwf_long_context` — a 30-turn scripted conversation with 5 tools, ported
+  from [kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval) (MIT).
+  Launched by **absolute path** (`<task_file>@<task_name>`), which works from
+  any cwd.
+
+**Why not add new benchmarks to `inspect_evals` instead:** as of 2026-05-08 it
+stopped accepting new eval code (its `EVAL_REGISTER.md` — a dependency-isolation
+decision, not a quality one). New evals now live in the author's own repo and get
+*listed* upstream via the register. Register entries are **not shipped in the
+`inspect_evals` wheel** (`load_listing()` resolves the register dir as
+`package_dir.parent.parent / "register"`, a source-checkout path, and packaging
+only includes `inspect_evals/*/eval.yaml`), so nothing in the register is
+runnable through `run_benchmark` — verified: `internal: 129, external: 0` on the
+installed wheel. Bundling here is the only path that actually runs.
+
+Two things to know before touching `eval_mcp/benchmarks/aiwf/`:
+
+- **Multi-turn scoring is per-TURN, not per-sample.** One sample *is* the whole
+  conversation, so the metrics (`pass_rate`, `tool_use_rate`, …) are custom
+  `@metric`s that pool turn counters out of score metadata. `accuracy()` cannot
+  express this. Each rate needs its own decorated function — `@metric` fixes the
+  display name at decoration time, so one parameterised factory reports four
+  metrics all called `turn_metric`.
+- **Two upstream behaviours are load-bearing; don't "simplify" them away.**
+  (1) A turn *ends at the tool call* — no second generate after the tool result
+  (upstream's `default_tool_result_run_llm = False`); generating again hands the
+  model a free retry. (2) The **recovery nudge**: when a turn expected a tool
+  call and none came, upstream injects one synthetic `"Please go ahead."` turn
+  and merges that attempt into the same turn. Measured on claude-haiku-4-5 over
+  18 turns: pass_rate **0.833 without it, 0.944 with**. Full fidelity notes and
+  what was deliberately not ported (all speech-to-speech) in
+  `eval_mcp/benchmarks/aiwf/NOTICE.md`.
+
 ### Adding a model
 
 Nothing to do. There is no allowlist and no hand-maintained price table — a newly

--- a/eval_mcp/benchmarks/README.md
+++ b/eval_mcp/benchmarks/README.md
@@ -1,0 +1,62 @@
+# Bundled benchmarks
+
+Benchmarks that ship with this package, discovered from disk. They appear in
+`list_benchmarks` alongside the ~129 `inspect_evals` entries (flagged
+`bundled: true`) and run through the same `run_benchmark` tool — a caller never
+needs to know which catalog a task came from.
+
+```
+list_benchmarks                     → both catalogs, one list
+get_benchmark_details(<id-or-task>) → full eval.yaml for a bundled one
+list_bundled_benchmarks             → all bundled, full metadata, no paging
+run_benchmark(task=…, providers=[…]) → runs either kind
+```
+
+Bundled benchmarks need no HuggingFace download, no optional dependency group
+and no sandbox, so they're the cheapest thing here to run.
+
+## Adding one
+
+Create a directory. **Edit no Python outside it** — not `registry.py`, not the
+MCP tools, not `server.py`. The catalog is whatever is on disk.
+
+```
+eval_mcp/benchmarks/<name>/
+    eval.yaml     metadata — title, tasks, metrics, judge, source, caveats
+    task.py       Inspect @task functions, one per entry in tasks[]
+    data/         vendored datasets + prompts, verbatim from upstream
+    NOTICE.md     provenance: upstream URL, license, pinned 40-char SHA
+```
+
+`eval.yaml` mirrors the schema `inspect_evals` uses for its own benchmarks, so
+this stays familiar and a port could later be submitted to their register with
+little change. Copy `aiwf/eval.yaml` as a starting point. The fields that matter:
+
+| Field | Why |
+|---|---|
+| `tasks[].name` | Must match an `@task` function in `task.py`. This is the user-facing handle. |
+| `tasks[].approx_input_tokens_per_model` | Surfaced before a run so nobody is surprised by the bill. |
+| `metrics[]` | First entry is the headline metric reported back to the caller. |
+| `judge.default` | Required if judge-scored — the judge is part of the measurement. |
+| `source.repository_commit` | Full 40-char SHA. Pinned so fidelity stays re-checkable. |
+| `caveats[]` | Anything that makes a score non-comparable (ported subset, different judge, …). |
+
+`task.py` must `import eval_mcp.inspect_patches` so Bedrock applies each model's
+own token ceiling instead of Inspect's constant 2048 — see
+[CLAUDE.md](../../CLAUDE.md#dont-pass-max_tokens-to-evals--and-dont-reintroduce-a-lookup).
+
+Then, before you trust a single number:
+
+- **Read [the porting contract](../../.claude/skills/port-a-benchmark/SKILL.md).**
+  Prompts, rubrics, golden answers, tool schemas and thresholds are **data** —
+  copy them byte-for-byte. Only the plumbing gets adapted.
+- `tests/test_benchmark_port_fidelity.py` picks up the new directory
+  automatically and enforces the structural half of that contract.
+- Add a per-benchmark test pinning the actual prompt text (see
+  `tests/test_aiwf_benchmark.py` for the diff-against-upstream pattern).
+
+## What's here
+
+| Benchmark | Tasks | Measures |
+|---|---|---|
+| `aiwf` | `aiwf_medium_context`, `aiwf_long_context` | 30-turn conversation: tool use, instruction following, KB grounding as context grows. Text-mode port of [kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval). |

--- a/eval_mcp/benchmarks/__init__.py
+++ b/eval_mcp/benchmarks/__init__.py
@@ -1,0 +1,15 @@
+"""Bundled multi-turn benchmarks that ship with the MCP.
+
+Distinct from ``eval_mcp/tools/benchmarks.py``, which is a thin wrapper over the
+installed ``inspect_evals`` catalog. These are Inspect tasks we vendor and run
+ourselves, for benchmark shapes ``inspect_evals`` doesn't cover.
+
+Why they live here rather than upstream: as of 2026-05-08 ``inspect_evals``
+stopped accepting new eval code (see its EVAL_REGISTER.md — a dependency-
+isolation decision, not a quality one). New evals are expected to live in their
+author's own repo and be *listed* upstream via the register. Register entries
+aren't shipped in the ``inspect_evals`` wheel (``load_listing()`` resolves the
+register dir as ``package_dir.parent.parent / "register"``, a source-checkout
+path), so nothing in the register is runnable through ``run_benchmark``. Hence:
+bundled here, launched by absolute path.
+"""

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -44,45 +44,65 @@ shape (which is what makes upstream's early/late tool-call realignment
 possible), and the rubric text follows upstream closely. Two differences:
 
 - Model: upstream uses `claude-opus-4-5` via the Claude Agent SDK; we use our
-  configured Bedrock judge (Sonnet by default, overridable per run).
+  configured Bedrock judge (`claude-opus-5` by default, overridable per run —
+  see the bake-off below).
 - Upstream's two-phase output (`phase1_analysis` then `final_judgments`) is
   collapsed to a single forced tool call with per-turn verdicts.
 
 Consequence: **this reproduces the benchmark, not upstream's exact figures.**
 Relative model ordering should hold; absolute numbers will differ.
 
-### Judge choice was measured, not assumed — two negative results
+### Choosing the judge: measured against hand-adjudicated verdicts
 
-Both were tried and rejected. Don't redo them without new evidence.
+**How not to do this.** Comparing two judges by running the benchmark twice and
+diffing the scores is invalid — each run produces a *different* model transcript,
+so the delta measures the target model's variance, not the judge's. We made that
+mistake and it pointed the wrong way. The valid method: fix a transcript, run
+each candidate judge over it N times, and score them against verdicts adjudicated
+by hand from the transcript and knowledge base.
 
-**1. Sonnet 5 as judge — rejected, too unstable.** It looks better on a single
-run (96.7% vs 93.3% for the same target) but that comparison is invalid: the two
-runs had *different* model transcripts. Holding the transcript fixed and varying
-only the judge, 5 calls each:
+Ground truth used (2 transcripts, 30 turns each, contested turns read manually):
 
-| Transcript | Judge | pass_rate spread over 5 calls | Turns failed (count of 5) |
-|---|---|---:|---|
-| T1 | sonnet-4-6 | **0.000** | 12×5, 18×5 |
-| T1 | sonnet-5 | 0.000 | 12×5, 13×5, 18×5 |
-| T2 | sonnet-4-6 | 0.033 | 9×5, 27×2 |
-| T2 | sonnet-5 | **0.100** | 9×5, 11×2, 12×1, 14×2, 16×2, 17×1, 24×1 |
+| Turn | Verdict | Why |
+|---|---|---|
+| T1 12 | FAIL | expected `submit_session_suggestion`; model confirmed the *previous* suggestion, call only came after the nudge |
+| T1 18 | FAIL | user asked about SF weather (out of scope); model didn't deflect, it recapped the tech-support submission |
+| T1 13 | PASS | answer scoped to the user's stated day; all facts correct. Omission ≠ contradiction |
+| T2 9 | FAIL | golden offers to submit a suggestion; model deflected to external contacts |
+| T2 27 | PASS | correct time/place, and all 8 meetup topics it added are verifiably in the KB. Extra *correct* detail is allowed |
 
-On T2 Sonnet 5 flip-flops on six different turns across identical inputs — a
-0.100 swing in the headline number from judge noise alone. It is also uniformly
-*stricter*, not better in both directions, and one of its extra failures is
-wrong: on T1 turn 13 it fails `kb_grounding` because the assistant scoped a
-correct answer to the one day the user said they were attending, which is an
-omission, not the "clear factual contradiction" the rubric requires.
+Results, 16 calls per judge across both transcripts:
 
-A benchmark needs a stable ruler more than a clever one. Sonnet 4.6 stays.
+| Judge | Errors | False pos | False neg | Exact-match runs |
+|---|---:|---:|---:|---|
+| **`claude-opus-5`** | **2** | 2 | 0 | 14/16 |
+| `claude-opus-4-5` (upstream's) | 5 | 0 | 5 | 11/16 |
+| `claude-sonnet-4-6` (previous) | 9 | 8 | 1 | 7/16 |
 
-**2. Upstream's closing "Remember" reminder block — rejected.** Upstream's judge
-prompt ends with a recap including *"Be generous with kb_grounding unless there's
-a clear factual error"*. Adding it verbatim did **not** fix the turn-13 false
-positive, and it traded determinism for leniency on the default judge (spread
-0.000 → 0.033 on both transcripts, mean 0.933 → 0.940/0.953). The rubric already
-states each rule once in its dimension section; repeating them only loosened
-grading. Not ported.
+Opus 5 wins, and the failure modes differ in a way that matters: Sonnet 4.6's
+errors are almost all **false positives** — it failed T2 turn 27 on 8 of 8 calls,
+penalising an answer that is factually correct and merely more detailed than the
+golden text. That's the worst kind of judge error here, because it makes a good
+model look bad and the number still looks plausible. Opus 4.5 errs the other way
+(misses real failures). Cost is not a factor at this scale: ~$0.13 per
+benchmark run vs ~$0.08.
+
+### Rejected: Sonnet 5 as judge — too unstable
+
+Sonnet 5 swings **0.100 in `pass_rate` across repeated calls on identical
+input**, flip-flopping on six different turns (9, 11, 12, 14, 16, 17, 24 each
+failing 1–2 times out of 5). That's judge noise indistinguishable from a real
+difference between two target models. It is also uniformly stricter rather than
+more accurate, including the same T1-turn-13 false positive. A benchmark needs a
+stable ruler more than a clever one.
+
+### Rejected: upstream's closing "Remember" reminder block
+
+Upstream's judge prompt ends with a recap including *"Be generous with
+kb_grounding unless there's a clear factual error"*. Adding it verbatim did
+**not** fix the turn-13 false positive, and it traded determinism for leniency
+(spread 0.000 → 0.033 on both transcripts). The rubric already states each rule
+once in its dimension section; repeating them only loosened grading.
 
 ## What was deliberately not ported
 

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -1,0 +1,77 @@
+# Attribution: aiwf multi-turn benchmark
+
+The benchmark data and evaluation design in this directory are derived from
+**[kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval)** by Kwindla
+Hultman Kramer, used under the MIT License.
+
+Vendored from commit `d0dabb6c473d8e8d5a84a5504af3f68ec50e9e70` (2026-06-14).
+
+## What was taken
+
+| Ours | Upstream |
+|------|----------|
+| `data/turns.json` | `benchmarks/_shared/turns.py` (30 turns; `audio_file` key dropped, `index` added) |
+| `data/kb_medium.txt` | `benchmarks/aiwf_medium_context/data/knowledge_base.txt` (verbatim) |
+| `data/kb_long.txt` | `benchmarks/aiwf_long_context/data/knowledge_base.txt` (verbatim) |
+| `data/system_preamble.txt` | `_PREAMBLE` in `benchmarks/*/prompts/system.py` (verbatim) |
+| `data/system_tools_section.txt` | `_TOOLS_SECTION` in the same file (verbatim) |
+| tool schemas in `data_loader.py` | `benchmarks/_shared/tools.py`, transcribed from Pipecat `FunctionSchema` to Inspect `ToolDef` |
+| judge rubric in `task.py` | `src/multi_turn_eval/judging/claude_judge.py`, adapted (see below) |
+
+The two knowledge-base variants share identical turns, tools and prompt
+scaffolding — verified by test, and the reason one copy of each prompt block
+serves both.
+
+## What was changed, and why
+
+**Runner.** Upstream runs the conversation through a Pipecat pipeline; this is
+an Inspect AI task. The observable behaviours that affect scores were ported
+deliberately, not incidentally:
+
+- *Turn boundary.* Upstream's text pipeline sets
+  `default_tool_result_run_llm = False`, so a turn ends at the tool call. We do
+  the same — the tool result enters the context for the next turn, but there is
+  no second generate within the turn.
+- *Recovery nudge.* Upstream injects one synthetic `"Please go ahead."` turn
+  when a turn expected a tool call and none was made
+  (`_should_recover`/`MTE_ENABLE_RECOVERY`, default on), merging that attempt
+  into the same scripted turn. Ported. Measured on claude-haiku-4-5 over 18
+  turns: pass_rate 0.833 without it, 0.944 with — it is not optional if the
+  numbers are meant to resemble upstream's.
+
+**Judge.** Same three dimensions, same one-call-over-the-whole-conversation
+shape (which is what makes upstream's early/late tool-call realignment
+possible), and the rubric text follows upstream closely. Two differences:
+
+- Model: upstream uses `claude-opus-4-5` via the Claude Agent SDK; we use our
+  configured Bedrock judge (Sonnet by default, overridable per run).
+- Upstream's two-phase output (`phase1_analysis` then `final_judgments`) is
+  collapsed to a single forced tool call with per-turn verdicts.
+
+Consequence: **this reproduces the benchmark, not upstream's exact figures.**
+Relative model ordering should hold; absolute numbers will differ.
+
+## What was deliberately not ported
+
+Everything speech-to-speech — roughly 5,900 lines upstream, versus ~2,800 for
+the text path:
+
+- The four Pipecat pipelines (`realtime`, `nova_sonic`, `grok_realtime`,
+  `audio_in`) and the audio transports. Inspect has no duplex-audio transport,
+  so supporting speech models would mean embedding upstream's runner rather
+  than writing an Inspect task.
+- `benchmarks/_shared/audio/` — 31 WAVs, 5.9 MB, the spoken form of each turn.
+- The `turn_taking` judge dimension and all timing analysis (Silero VAD, 2 kHz
+  audio-tag alignment, voice-to-voice latency). Undefined without audio.
+
+Upstream's non-Bedrock providers (Cerebras, Ultravox, Groq, xAI) also don't come
+along; models are whatever Bedrock serves.
+
+## Why it lives here rather than in `inspect_evals`
+
+As of 2026-05-08 `inspect_evals` no longer accepts new eval code (see its
+`EVAL_REGISTER.md` — a dependency-isolation decision). New evals are expected to
+live in the author's own repo and be *listed* upstream via the register.
+Register entries are not shipped in the `inspect_evals` wheel, so nothing in the
+register is runnable through our `run_benchmark`. Hence: bundled here, launched
+by absolute path via `run_multiturn_benchmark`.

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -51,6 +51,39 @@ possible), and the rubric text follows upstream closely. Two differences:
 Consequence: **this reproduces the benchmark, not upstream's exact figures.**
 Relative model ordering should hold; absolute numbers will differ.
 
+### Judge choice was measured, not assumed — two negative results
+
+Both were tried and rejected. Don't redo them without new evidence.
+
+**1. Sonnet 5 as judge — rejected, too unstable.** It looks better on a single
+run (96.7% vs 93.3% for the same target) but that comparison is invalid: the two
+runs had *different* model transcripts. Holding the transcript fixed and varying
+only the judge, 5 calls each:
+
+| Transcript | Judge | pass_rate spread over 5 calls | Turns failed (count of 5) |
+|---|---|---:|---|
+| T1 | sonnet-4-6 | **0.000** | 12×5, 18×5 |
+| T1 | sonnet-5 | 0.000 | 12×5, 13×5, 18×5 |
+| T2 | sonnet-4-6 | 0.033 | 9×5, 27×2 |
+| T2 | sonnet-5 | **0.100** | 9×5, 11×2, 12×1, 14×2, 16×2, 17×1, 24×1 |
+
+On T2 Sonnet 5 flip-flops on six different turns across identical inputs — a
+0.100 swing in the headline number from judge noise alone. It is also uniformly
+*stricter*, not better in both directions, and one of its extra failures is
+wrong: on T1 turn 13 it fails `kb_grounding` because the assistant scoped a
+correct answer to the one day the user said they were attending, which is an
+omission, not the "clear factual contradiction" the rubric requires.
+
+A benchmark needs a stable ruler more than a clever one. Sonnet 4.6 stays.
+
+**2. Upstream's closing "Remember" reminder block — rejected.** Upstream's judge
+prompt ends with a recap including *"Be generous with kb_grounding unless there's
+a clear factual error"*. Adding it verbatim did **not** fix the turn-13 false
+positive, and it traded determinism for leniency on the default judge (spread
+0.000 → 0.033 on both transcripts, mean 0.933 → 0.940/0.953). The rubric already
+states each rule once in its dimension section; repeating them only loosened
+grading. Not ported.
+
 ## What was deliberately not ported
 
 Everything speech-to-speech — roughly 5,900 lines upstream, versus ~2,800 for

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -44,29 +44,12 @@ shape (which is what makes upstream's early/late tool-call realignment
 possible), and the rubric text follows upstream closely. Two differences:
 
 - Model: upstream uses `claude-opus-4-5` via the Claude Agent SDK; we use our
-  configured Bedrock judge (`claude-sonnet-5` by default, overridable per run).
+  configured Bedrock judge (Sonnet by default, overridable per run).
 - Upstream's two-phase output (`phase1_analysis` then `final_judgments`) is
   collapsed to a single forced tool call with per-turn verdicts.
 
 Consequence: **this reproduces the benchmark, not upstream's exact figures.**
 Relative model ordering should hold; absolute numbers will differ.
-
-Measured, judging the same benchmark with two different judges (target
-claude-haiku-4-5, full 30 turns, upstream publishes 98.0%):
-
-| Judge | pass_rate | Turns failed |
-|-------|----------:|--------------|
-| `claude-sonnet-5` | 96.7% | 9 |
-| `claude-sonnet-4-6` | 93.3% | 12, 18 |
-
-The judges disagree on *which* turns fail, not merely how many, which is worth
-knowing before comparing numbers across runs. Sonnet 5 failed turn 9 (the model
-deflected to external contacts where the golden answer offers to submit a
-suggestion — a real miss that Sonnet 4.6 passed) and cleared turn 18 (an
-out-of-scope weather question needing no tool, which Sonnet 4.6 wrongly failed).
-So the higher number came from *better* discrimination in both directions, not a
-softer grader. Judge choice is a real variable: hold it fixed when comparing
-targets, and record it — every run stores `judge_model` in score metadata.
 
 ## What was deliberately not ported
 

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -44,12 +44,29 @@ shape (which is what makes upstream's early/late tool-call realignment
 possible), and the rubric text follows upstream closely. Two differences:
 
 - Model: upstream uses `claude-opus-4-5` via the Claude Agent SDK; we use our
-  configured Bedrock judge (Sonnet by default, overridable per run).
+  configured Bedrock judge (`claude-sonnet-5` by default, overridable per run).
 - Upstream's two-phase output (`phase1_analysis` then `final_judgments`) is
   collapsed to a single forced tool call with per-turn verdicts.
 
 Consequence: **this reproduces the benchmark, not upstream's exact figures.**
 Relative model ordering should hold; absolute numbers will differ.
+
+Measured, judging the same benchmark with two different judges (target
+claude-haiku-4-5, full 30 turns, upstream publishes 98.0%):
+
+| Judge | pass_rate | Turns failed |
+|-------|----------:|--------------|
+| `claude-sonnet-5` | 96.7% | 9 |
+| `claude-sonnet-4-6` | 93.3% | 12, 18 |
+
+The judges disagree on *which* turns fail, not merely how many, which is worth
+knowing before comparing numbers across runs. Sonnet 5 failed turn 9 (the model
+deflected to external contacts where the golden answer offers to submit a
+suggestion — a real miss that Sonnet 4.6 passed) and cleared turn 18 (an
+out-of-scope weather question needing no tool, which Sonnet 4.6 wrongly failed).
+So the higher number came from *better* discrimination in both directions, not a
+softer grader. Judge choice is a real variable: hold it fixed when comparing
+targets, and record it — every run stores `judge_model` in score metadata.
 
 ## What was deliberately not ported
 

--- a/eval_mcp/benchmarks/aiwf/NOTICE.md
+++ b/eval_mcp/benchmarks/aiwf/NOTICE.md
@@ -16,7 +16,23 @@ Vendored from commit `d0dabb6c473d8e8d5a84a5504af3f68ec50e9e70` (2026-06-14).
 | `data/system_preamble.txt` | `_PREAMBLE` in `benchmarks/*/prompts/system.py` (verbatim) |
 | `data/system_tools_section.txt` | `_TOOLS_SECTION` in the same file (verbatim) |
 | tool schemas in `data_loader.py` | `benchmarks/_shared/tools.py`, transcribed from Pipecat `FunctionSchema` to Inspect `ToolDef` |
-| judge rubric in `task.py` | `src/multi_turn_eval/judging/claude_judge.py`, adapted (see below) |
+| `data/upstream_judge_system_prompt.txt` | `JUDGE_SYSTEM_PROMPT` in `src/multi_turn_eval/judging/claude_judge.py` (verbatim, 5802 chars) |
+| judge user prompt in `task.py` | `format_turns_for_claude` + the closing instructions in `judge_with_claude` (verbatim) |
+
+**The judge prompt is upstream's, not a paraphrase.** It's vendored verbatim and
+the audio-only `turn_taking` dimension is removed *programmatically* at load time
+(`_strip_audio_dimension`) rather than by hand-editing a copy, so the excision
+stays auditable and can't drift. A test diffs the two and fails if anything
+other than audio content differs. The complete diff is: `FOUR dimensions` →
+`THREE`, the `1. **turn_taking**` block deleted, the remaining three renumbered,
+the "be lenient if turn_taking=FALSE" sub-rule deleted, and `turn_taking`
+dropped from the JSON example plus its trailing note. Everything else — the
+two-phase structure, every scoring rule, the words-actions-mismatch section, the
+worked early/late examples, the "Remember" recap — is upstream's text.
+
+An earlier version of this port rewrote the rubric "more cleanly" (111 lines →
+51), dropping the two-phase framing and the worked examples. Don't do that: the
+wording *is* the measuring instrument.
 
 The two knowledge-base variants share identical turns, tools and prompt
 scaffolding — verified by test, and the reason one copy of each prompt block
@@ -32,16 +48,26 @@ deliberately, not incidentally:
   `default_tool_result_run_llm = False`, so a turn ends at the tool call. We do
   the same — the tool result enters the context for the next turn, but there is
   no second generate within the turn.
-- *Recovery nudge.* Upstream injects one synthetic `"Please go ahead."` turn
-  when a turn expected a tool call and none was made
-  (`_should_recover`/`MTE_ENABLE_RECOVERY`, default on), merging that attempt
-  into the same scripted turn. Ported. Measured on claude-haiku-4-5 over 18
-  turns: pass_rate 0.833 without it, 0.944 with — it is not optional if the
-  numbers are meant to resemble upstream's.
+- *Recovery nudge.* Upstream injects one synthetic `"Please go ahead."` turn when
+  a turn expected a tool call and none was made
+  (`_should_recover`/`MTE_ENABLE_RECOVERY`, default on). Ported — including the
+  subtle part: the nudge attempt is **not scored**. Upstream writes it as a
+  separate transcript record (`recovery_turn=True`) whose tool calls sit on that
+  record (`start_turn()` resets the recorder's `turn_calls` first), and its judge
+  skips those records outright — `if rec.get("recovery_turn"): continue`. So a
+  tool call that only happened *after* the prod earns the turn no credit; the
+  nudge's real effect is on the conversation, unblocking the workflow so later
+  turns aren't derailed by the missing call.
 
-**Judge.** Same three dimensions, same one-call-over-the-whole-conversation
-shape (which is what makes upstream's early/late tool-call realignment
-possible), and the rubric text follows upstream closely. Two differences:
+  An earlier version of this port merged the nudge's text and tool calls into the
+  scripted turn, which let a model that complied only when prodded score as if it
+  had complied immediately. We keep the recovery reply in
+  `recovery_assistant_text` / `recovery_tool_calls` for debugging, and never show
+  it to the judge.
+
+**Judge.** Upstream's prompt verbatim (see above), same three non-audio
+dimensions, same one-call-over-the-whole-conversation shape — which is what makes
+its early/late tool-call realignment possible. Remaining differences:
 
 - Model: upstream uses `claude-opus-4-5` via the Claude Agent SDK; we use our
   configured Bedrock judge (`claude-opus-5` by default, overridable per run —
@@ -96,13 +122,14 @@ difference between two target models. It is also uniformly stricter rather than
 more accurate, including the same T1-turn-13 false positive. A benchmark needs a
 stable ruler more than a clever one.
 
-### Rejected: upstream's closing "Remember" reminder block
+### On upstream's closing "Remember" recap — now included
 
-Upstream's judge prompt ends with a recap including *"Be generous with
-kb_grounding unless there's a clear factual error"*. Adding it verbatim did
-**not** fix the turn-13 false positive, and it traded determinism for leniency
-(spread 0.000 → 0.033 on both transcripts). The rubric already states each rule
-once in its dimension section; repeating them only loosened grading.
+This was briefly rejected, on the grounds that adding it to our *paraphrased*
+rubric traded determinism for leniency (spread 0.000 → 0.033) without fixing a
+false positive. That reasoning no longer applies: the judge prompt is now
+upstream's verbatim, and the recap is part of it — it belongs to the closing
+instructions in `judge_with_claude`, which `_render_user_prompt` reproduces.
+Fidelity wins over a marginal stability gain from a prompt upstream never wrote.
 
 ## What was deliberately not ported
 

--- a/eval_mcp/benchmarks/aiwf/__init__.py
+++ b/eval_mcp/benchmarks/aiwf/__init__.py
@@ -1,0 +1,41 @@
+"""AI Engineer World's Fair multi-turn benchmark (text mode).
+
+Ported from https://github.com/kwindla/aiewf-eval (MIT). Upstream runs the
+conversation through a Pipecat pipeline and supports text, realtime-audio and
+speech-to-speech models; this port covers **text mode only**. The dataset is
+shared between the two — same 30 turns, same 5 tools, same knowledge bases —
+so what we run is the same benchmark, minus the audio transport.
+
+Deliberately not ported:
+
+- The four Pipecat pipelines (``realtime``/``nova_sonic``/``grok_realtime``/
+  ``audio_in``) and the audio transports. Inspect has no duplex-audio
+  transport, so supporting speech models would mean embedding upstream's
+  runner rather than writing an Inspect task.
+- ``benchmarks/_shared/audio/`` (31 WAVs, 5.9 MB) — the spoken form of each
+  turn, used only by those pipelines.
+- The ``turn_taking`` judge dimension, which is derived from WAV timing
+  analysis (Silero VAD + 2 kHz tag detection). Undefined without audio.
+
+What that leaves is upstream's three judged dimensions — ``tool_use_correct``,
+``instruction_following``, ``kb_grounding`` — which is what its text-mode
+results table reports.
+"""
+
+from eval_mcp.benchmarks.aiwf.data_loader import (
+    AIWF_TASKS,
+    Turn,
+    knowledge_base,
+    system_prompt,
+    tool_defs,
+    turns,
+)
+
+__all__ = [
+    "AIWF_TASKS",
+    "Turn",
+    "knowledge_base",
+    "system_prompt",
+    "tool_defs",
+    "turns",
+]

--- a/eval_mcp/benchmarks/aiwf/data/kb_long.txt
+++ b/eval_mcp/benchmarks/aiwf/data/kb_long.txt
@@ -1,0 +1,5640 @@
+
+# AI Engineer World's Fair 2025
+
+Main website: https://ai.engineer/
+Basic llms info: https://ai.engineer/llms.txt
+LLms-full.txt including speakers: https://ai.engineer/llms-full.txt
+Calendar view schedule: https://ai.engineer/schedule
+Get all sessions in JSON for your vibecoded frontend: https://ai.engineer/sessions-speakers-details.json
+
+## Overview
+
+**June 3–5, 2025 • San Francisco**  
+The AI Engineer World's Fair is the largest technical conference for engineers working in AI today. Returning for its third year, this event is where the leading AI labs, founders, VPs of AI, and engineers gather to share what they're building and what's next.
+
+- ~3,000 attendees: Founders, VPs of AI, AI Engineers
+- ~150 launches and talks from top speakers
+- ~100 practical workshops and expo sessions
+- ~50 top DevTools and employers represented in the Expo
+
+Organized by the team behind the AI Engineer Summit.  
+**[Buy Tickets](https://ti.to/software-3/ai-engineer-worlds-fair-2025?source={{UTM_SOURCE}}) | [Watch 2023/2024/2025 Talks](https://youtube.com/@aidotengineer) | [Subscribe to Newsletter](https://ai.engineer/newsletter)**
+
+## Schedule
+
+June 3: Workshops + exclusive Speaker Dinner
+June 4: MCP, Tiny Teams, LLM RecSys, GraphRAG, Agent Reliability, Infrastructure, AI PM, Voice, AI in Fortune 500, AI Architects
+June 5: Reasoning + RL, SWE-Agents, Evals, Retrieval + Search, Security, Generative Media, AI Design, Robotics/Autonomy, AI in Fortune 500 (day 2), AI Architects (Day 2)
+
+### Tuesday, June 3 – Workshop Day + Evening Expo & Reception
+- Exclusive hands-on workshops across 5 tracks, instructed by industry-leading companies, founders, and engineers.
+- Topics span all levels of experience and specialties in AI Engineering.
+- **Evening Welcome Reception** (4:00–7:00pm): Held in the Grand Assembly & Expo Hall. Open to all ticketholders.
+
+### Wednesday & Thursday, June 4–5 – Conference Days
+- 19 tracks of talks, panels, and demos.
+- Keynotes from the biggest and most consequential labs and companies.
+- High-value hallway track and facilitated networking.
+- Workshops and exclusive access for "Conference + Workshop Pass" holders.
+
+## Meals and Events
+
+### June 3
+- Continental Breakfast.  7:15am - 9:45am.  Grand Assembly.
+- Registration. 8:00am - 7:00pm.  Atrium: Event Hub.
+- Rehearsals/Tech Check. 10:00am - 5:00pm.  Keynote/General Session (Yerba Buena 7&8)
+- Morning Break. 10:15am - 10:40am.  Grand Assembly.
+- Lunch. 12:00pm - 1:00pm.  Grand Assembly.
+- Afternoon Break. 3:00pm - 3:30pm.  Grand Assembly.
+- Welcome Reception.  4:00pm - 7:00pm.  Grand Assembly.
+- Community Meetups.  5:30pm - 9:00pm.  Atrium: Event Hub
+
+### June 4
+ - Continental Breakfast.  7:15am - 9:55am.  Grand Assembly.
+ - Registration. 7:00am - 7:00pm.  Atrium: Event Hub.
+ - Rehearsals/Tech Check. 7:45am - 8:45am.  Keynote/General Session (Yerba Buena 7&8)
+ - Morning Break. 10:15am - 11:00am.  Salons 9-15: Expo Hall.
+ - Lunch. 12:00pm - 2:00pm.  Salons 9-15: Expo Hall.
+ - Afternoon Break. 3:00pm - 3:45pm.  Salons 9-15: Expo Hall.
+ - The Toolbit Afterparty. 5:15pm - 7:00pm.  Salons 9-15: Expo Hall.
+ - Community Meetups.  7:00pm - 10:40pm.  Atrium: Event Hub
+
+### June 5
+ - Continental Breakfast.  7:15am - 9:55am.  Grand Assembly.
+ - Registration. 7:00am - 3:00pm.  Atrium: Event Hub.
+ - Rehearsals/Tech Check. 7:45am - 8:45am.  Keynote/General Session (Yerba Buena 7&8)
+ - Morning Break. 10:30am - 11:15am.  Salons 9-15: Expo Hall.
+ - Lunch. 12:00pm - 2:00pm.  Salons 9-15: Expo Hall.
+ - Afternoon Break. 3:00pm - 3:45pm.  Salons 9-15: Expo Hall.
+ - Community Meetups.  5:30pm - 9:00pm.  Atrium: Event Hub
+
+## Tracks
+
+======================================================================
+---  Track: AI ARCHITECTS (June 4-5) ---
+======================================================================
+
+    Session ID: 941249
+    Track: AI Architects
+    Speaker: Clay Bavor (Cofounder, Sierra)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: Rise of the AI Architect
+    Description:
+    As the amount of consumer facing AI products grows, the most forward leaning enterprises have created a new role: the AI Architect. These leaders are responsible for helping define, manage, and evolve their company's AI agent experiences over time.
+    
+    In this session, Clay Bavor (Cofounder of Sierra) will join Alessio Fanelli (co-host of Latent Space) in a fireside chat to share what it means to be an AI Architect, success stories from the market, and the future of the role.
+
+  ------------------------------------
+
+    Session ID: 913965
+    Track: AI Architects
+    Speaker: Dani Grant (CEO)
+    Format: Talk
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 09:55 AM
+    Session Title: The AI Engineer’s Guide to Raising VC
+    Description:
+    A no fluff, all tactics discussion. More AI engineers should build startups, the world needs more software. But there’s a way to raise VC and it’s hard to do it if you’ve never seen it done. We are going to walk through the exact playbook to raise your first round of funding. We will show you real pitch decks, real cold emails and real term sheets so when you go out to raise your first round of funding, you are setup to do it. Every AI Engineer should be equip to start their own company and this session makes sure raising $$$ is not going to be the blocker.
+
+  ------------------------------------
+
+    Session ID: 913965
+    Track: AI Architects
+    Speaker: Chelcie Taylor (Investor )
+    Format: Talk
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 09:55 AM
+    Session Title: The AI Engineer’s Guide to Raising VC
+    Description:
+    A no fluff, all tactics discussion. More AI engineers should build startups, the world needs more software. But there’s a way to raise VC and it’s hard to do it if you’ve never seen it done. We are going to walk through the exact playbook to raise your first round of funding. We will show you real pitch decks, real cold emails and real term sheets so when you go out to raise your first round of funding, you are setup to do it. Every AI Engineer should be equip to start their own company and this session makes sure raising $$$ is not going to be the blocker.
+
+  ------------------------------------
+
+    Session ID: 915067
+    Track: AI Architects
+    Speaker: Anoop Kotha (Applied AI)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Building Effective Voice Agents
+    Description:
+    How to build production voice applications and learnings from working with customers along the way
+
+  ------------------------------------
+
+    Session ID: 914401
+    Track: AI Architects
+    Speaker: Rossella Blatt Vital (VP of Engineering - AI)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: From Hype to Habit: How We’re Building an AI-First SaaS Company—While Still Shipping the Roadmap
+    Description:
+    What does it really take to move a modern SaaS company from AI experimentation to becoming truly AI-first?
+    
+    At Sprout Social, we’re in the midst of that transformation—rearchitecting strategy, systems, teams, and incentives to put AI at the heart of how we think, build, and deliver value. This is a story in motion: a behind-the-scenes look at how we’re evolving from isolated AI feature experiments to an AI-native operating model.
+    
+    I’ll share what we’re learning as we navigate the innovation dilemma—integrating disruptive AI capabilities without breaking what already works or our roadmap. That includes rethinking how we define success, how we hire, reward, grow talent, and how we handle legal and ethical complexity without slowing down. We’ll explore the real-world tensions between rapid innovation, value delivery, making progress on Responsible AI, all while elevating internal AI fluency, and engaging with the broader AI ecosystem to stay at the edge.
+    
+    This isn’t a playbook from the finish line—it’s a candid reflection from deep inside the journey.
+    
+    My goal is to help other leaders chart their own AI path with greater clarity, confidence, and care.
+
+  ------------------------------------
+
+    Session ID: 907834
+    Track: AI Architects
+    Speaker: Michael Albada (Principal Applied Scientist)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Building Applications with AI Agents
+    Description:
+    Generative AI has dramatically shortened the distance between ideas and implementation, enabling faster prototyping and deployment than ever before. But while language models can streamline individual tasks, true transformation comes from combining these capabilities into intelligent, autonomous systems—AI agents.
+    
+    This talk explores how to build and deploy foundation model-enabled agent systems that go beyond simple prompt chaining or chatbots. Drawing from real-world implementations and the latest research, it offers a clear and practical path to designing both single-agent and multi-agent systems capable of handling complex workflows with minimal oversight.
+    
+    Attendees will gain a deeper understanding of the core design principles behind agentic systems, the architectural trade-offs involved in orchestrating multiple agents, and the strategies required to develop tailored solutions that enhance efficiency and innovation. Whether just beginning or scaling up, participants will leave with actionable insights to navigate the rapidly evolving world of AI autonomy.
+
+  ------------------------------------
+
+    Session ID: 930540
+    Track: AI Architects
+    Speaker: Ilan Bigio (Developer Experience)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Model-Maxxing: RFT, DPO, SFT (Fine-tuning with OpenAI)
+    Description:
+    Covering all forms of fine-tuning and prompt engineering, like SFT, DPO, RFT, prompt engineering / optimization, and agent scaffolding.
+
+  ------------------------------------
+
+    Session ID: 933612
+    Track: AI Architects
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 914814
+    Track: AI Architects
+    Speaker: Ivan Burazin (CEO)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: AX is the only Experience that Matters
+    Description:
+    If you’re building devtools for humans, you’re building for the past.
+    
+    Already a quarter of Y Combinator’s latest batch used AI to write 95% or more of their code. AI agents are scaling at an exponential rate and soon, they’ll outnumber human developers by orders of magnitude.
+    
+    
+    The real bottleneck isn’t intelligence. It’s tooling. Terminals, local machines, and dashboards weren’t built for agents. They make do… until they can’t.
+    
+    In this talk, I’ll share how we killed the CLI at Daytona, rebuilt our infrastructure from first principles, and what it takes to build devtools that agents can actually use. Because in an agent-native future, if agents can’t use your tool, no one will.
+    
+
+  ------------------------------------
+
+    Session ID: 933641
+    Track: AI Architects
+    Speaker: Kshitij  Grover (Co-Founder & CTO, Orb Inc.)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 01:15 PM
+    Session Title: Revenue Engineering: How to Price (and Reprice) Your AI Product
+    Description:
+    You’ve trained the model—now it’s time to train the business. This talk dives into the engineering behind pricing systems that can evolve as fast as your AI stack.
+    
+    Orb CTO Kshitij Grover will walk through how leading AI companies design infrastructure to support experimentation, scale, and real-world monetization constraints.
+    
+    Topics include:
+    - How to meter usage and map it to pricing with accuracy and auditability
+    - Factoring in margins and underlying costs when designing pricing strategy
+    - Handling complexity across motions: self-serve vs. enterprise, pay-as-you-go vs. committed contracts
+    - How to test pricing changes safely (and roll them back when needed)
+    
+    Whether you’re bootstrapping a pricing system from scratch or replacing a brittle V1, you’ll leave with architectural patterns and mental models to make pricing a first-class engineering concern.
+    
+
+  ------------------------------------
+
+    Session ID: 933605
+    Track: AI Architects
+    Speaker: Mani Khanuja (Principal ML Services SA)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Data is Your Differentiator: Building Secure and Tailored AI Systems
+    Description:
+    As  organizations seek to harness their proprietary data while maintaining  security and compliance, Amazon Bedrock provides a comprehensive framework  for building tailored AI applications. Using Amazon Bedrock Knowledge Bases  and Amazon Bedrock Data Automation, organizations can create AI solutions  that truly understand their unique business context, terminology, and  requirements. Combined with Amazon Bedrock Guardrails, these capabilities  enhance the accuracy and relevance of AI-generated responses, while ensuring  that sensitive information remains protected within the organization's  control - enabling businesses to build secure and compliant enterprise-grade  generative AI solutions that accelerate time to value.
+
+  ------------------------------------
+
+    Session ID: 915921
+    Track: AI Architects
+    Speaker: Ben Hylak (Co-Founder)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: Testing the Un-Testable: Monitoring AI Products in the Wild
+    Description:
+    Evals are straightforward—like unit tests, they confirm your model got specific test cases right.
+    
+    But in the real world, your AI encounters millions of unpredictable interactions each day. How do you gauge user trust, identify frustrations, and adapt when there's no single "correct" output? Diving through endless logs and manually adding one eval at a time won't cut it.
+    
+    In this session, we'll explore how leading teams are moving beyond static evals; leveraging semantic analytics, LLM teachers, and AI-powered monitoring to deeply understand user experiences at scale—building AI products that don’t just pass tests, but genuinely resonate with users.
+
+  ------------------------------------
+
+    Session ID: 914798
+    Track: AI Architects
+    Speaker: Mark Bissell (Applied Interpretability Research )
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Why you should care about AI interpretability
+    Description:
+    The goal of mechanistic interpretability is to reverse engineer neural networks. Having direct, programmable access to the internal neurons of models unlocks new ways for developers and users to interact with AI — from more precise steering to guardrails to novel user interfaces. While interpretability has long been an interesting research topic, it is now finding real-world use cases, making it an important tool for AI engineers.
+
+  ------------------------------------
+
+    Session ID: 914912
+    Track: AI Architects
+    Speaker: Yegor Denisov-Blanch (Developer Productivity Researcher at Stanford University)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Does AI Actually Boost Developer Productivity? (Stanford / 100k Devs Study)
+    Description:
+    Forget vendor hype: Is AI actually boosting developer productivity, or just shifting bottlenecks? Stop guessing.
+    
+    Our study at Stanford cuts through the noise, analyzing real-world productivity data from nearly 100,000 developers across hundreds of companies. We reveal the hard numbers: while the average productivity boost is significant (~20%), the reality is complex – some teams even see productivity decrease with AI adoption.
+    
+    The crucial insights lie in why this variance occurs. Discover which company types, industries, and tech stacks achieve dramatic gains versus minimal impact (or worse). Leave with the objective, data-driven evidence needed to build a winning AI strategy tailored to your context, not just follow the trend.
+    
+
+  ------------------------------------
+
+    Session ID: 915974
+    Track: AI Architects
+    Speaker: Alex Duffy (Head of AI)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Benchmarks Are Memes: How What We Measure Shapes AI—and Us
+    Description:
+    Benchmarks shape more than just AI models—they shape our future. The things we choose to measure become self-fulfilling prophecies, guiding AI toward specific abilities and, ultimately, defining humanity’s evolving role in the AI era. Today’s benchmarks have propelled incredible progress, but now we have an exciting opportunity: thoughtfully designing benchmarks around what genuinely matters to us—cooperation, creativity, education, and meaningful human experiences.
+    
+    In this talk, we’ll explore how benchmarks function as powerful cultural memes, influencing not only technical outcomes but societal direction. Drawing on practical examples we have seen at Every consulting in industries like finance, journalism, education, and even personally making AI play diplomacy. We’ll uncover what makes a benchmark impactful, approachable, and inspiring. You’ll see our engaging new AI Diplomacy benchmark demo, illustrating vividly how thoughtful evaluation design can excite both engineers and the wider community.
+    
+    You’ll hopefully walk away inspired and equipped to define benchmarks intentionally, helping steer AI toward outcomes that truly matter.
+
+  ------------------------------------
+
+    Session ID: 933621
+    Track: AI Architects
+    Speaker: Laurie Voss (VP Developer Relations, LlamaIndex)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Effective agent design patterns in production
+    Description:
+    At LlamaIndex we see a lot of agents built every day, and we've got a sense of what works and what doesn't. We've distilled those learnings down into a series of patterns and best practices for building real-world, production agents, and we're here to share them. You'll learn patterns for applying structure and guidance to famously nondeterministic LLMs and get concrete instruction on how to implement them.
+
+  ------------------------------------
+
+    Session ID: 916157
+    Track: AI Architects
+    Speaker: Nathan Wan (Head of AI)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: AI That Pays: Lessons from Revenue Cycle
+    Description:
+    While much of the AI innovation in healthcare has centered on clinical and patient-facing applications, Revenue Cycle Management (RCM) remains an underexplored yet critical domain. Given the growing financial pressures facing providers, rethinking how healthcare gets paid is essential to ensuring access and sustainability. The combination of which makes RCM an opportune area for AI disruption.
+    
+    This session explores how the combination of vast structured and unstructured data, often rule-based workflows, and direct financial opportunity to drive meaningful outcomes. We’ll also share practical lessons from our journey evolving a traditional machine learning mindset to incorporate the latest advances in Generative AI, and how that shift is reshaping what's possible in healthcare operations.
+
+  ------------------------------------
+
+    Session ID: 914401
+    Track: AI Architects
+    Speaker: Deepsha Menghani (Director of Engineering – AI)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: From Hype to Habit: How We’re Building an AI-First SaaS Company—While Still Shipping the Roadmap
+    Description:
+    What does it really take to move a modern SaaS company from AI experimentation to becoming truly AI-first?
+    
+    At Sprout Social, we’re in the midst of that transformation—rearchitecting strategy, systems, teams, and incentives to put AI at the heart of how we think, build, and deliver value. This is a story in motion: a behind-the-scenes look at how we’re evolving from isolated AI feature experiments to an AI-native operating model.
+    
+    I’ll share what we’re learning as we navigate the innovation dilemma—integrating disruptive AI capabilities without breaking what already works or our roadmap. That includes rethinking how we define success, how we hire, reward, grow talent, and how we handle legal and ethical complexity without slowing down. We’ll explore the real-world tensions between rapid innovation, value delivery, making progress on Responsible AI, all while elevating internal AI fluency, and engaging with the broader AI ecosystem to stay at the edge.
+    
+    This isn’t a playbook from the finish line—it’s a candid reflection from deep inside the journey.
+    
+    My goal is to help other leaders chart their own AI path with greater clarity, confidence, and care.
+
+  ------------------------------------
+
+    Session ID: 933610
+    Track: AI Architects
+    Speaker: Mike Chambers (AI/ML Specialist DA AWS)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Ship it! Building Production-Ready Agents
+    Description:
+    Explore the practical challenges and solutions for deploying AI agents in real-world production environments. Through detailed technical analysis and practical examples, we'll examine strategies for building and orchestrating agent systems at scale. We'll cover critical infrastructure decisions, scalability frameworks, and best practices for creating robust, production-ready agent architectures.
+
+  ------------------------------------
+
+    Session ID: 904822
+    Track: AI Architects
+    Speaker: Denys Linkov (Head of ML)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Structuring a modern AI team
+    Description:
+    You've been given an AI mandate but don't have additional headcount, what next? Re-skilling, up-skilling and team augmentation become essential to delivering on a new mandate. In this talk we'll cover strategies to structure cross functional AI teams with domain experts, software engineers and ML engineers. We'll cover key skills and milestones that each traditional role can contribute to in unique ways.
+
+  ------------------------------------
+
+    Session ID: 912033
+    Track: AI Architects
+    Speaker: Alvaro Morales (CEO)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: Monetizing AI: From Zero to Profit
+    Description:
+    As AI continues to transform industries, companies are faced with the critical challenge of effectively monetizing AI-driven products in a way that captures value, ensures customer adoption, and scales revenue sustainably. Unlike traditional SaaS models, AI-powered products have unique complexities - such as fluctuating usage patterns, variable compute costs, and evolving customer demands, making conventional pricing strategies unhelpful to the growth of an AI product-led startup.
+    
+    In this session, Alvaro Morales, CEO and co-founder of Orb, will explore why the often overlooked monetization aspect of AI is critical for businesses. He’ll share real-world examples and data to demonstrate how adaptive pricing models can drive cost savings, enhance customer experience, and reduce operational bottlenecks.
+    
+    Alvaro will lead a live demo, showcasing how engineers can simulate AI pricing strategies and subsequently integrate them with a simple plug-and-play solution. He’ll also share how real-world revenue simulations enable companies to test and refine pricing before implementing — reducing risk, boosting adoption, and unlocking new revenue streams. As a quick example, cloud software development platform Replit was looking to adopt a usage-based pricing model for a new product, but their existing billing system couldn't support the new model, and building a new billing system would delay the launch timeline. In order to get things done, they turned to Orb, which enabled them to make pricing changes up to the last minute. After the launch, Orb became the single source of truth for both Replit and its customers - providing usage alerts to notify Replit when users hit cost thresholds and provide insights into user spend and payment methods.
+    
+    Key takeaways:
+    The challenge of AI monetization – Why traditional subscription-based SaaS pricing models don’t work for AI-powered products.
+    Precision pricing – Exploring how usage-based, tiered, and hybrid pricing models can maximize revenue potential.
+    Revenue simulation for AI pricing – Leveraging real-time data to test, adjust and optimize pricing strategies.
+    Avoiding common pricing pitfalls – Identifying mistakes that can lead to revenue leakage and customer churn.
+    
+    This session is designed for AI executives, product leaders, and engineering teams looking for actionable strategies to build adaptive, scalable pricing models that drive long-term growth and profitability.
+    
+    
+
+  ------------------------------------
+
+    Session ID: 941249
+    Track: AI Architects
+    Speaker: Alessio Fanelli (Co-Host, Latent Space)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: Rise of the AI Architect
+    Description:
+    As the amount of consumer facing AI products grows, the most forward leaning enterprises have created a new role: the AI Architect. These leaders are responsible for helping define, manage, and evolve their company's AI agent experiences over time.
+    
+    In this session, Clay Bavor (Cofounder of Sierra) will join Alessio Fanelli (co-host of Latent Space) in a fireside chat to share what it means to be an AI Architect, success stories from the market, and the future of the role.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI Architects
+    Speaker: Nina Lopatina (Lead Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI Architects
+    Speaker: Rajiv Shah (Chief Evangelist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 941906
+    Track: AI Architects
+    Speaker: Alex Atallah (CEO OpenRouter, co-founder of OpenSea)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:35 PM
+    Session Title: fun stories from building OpenRouter and where all this is going
+    Description:
+    How the first LLM aggregator got started, some of the weird moments in its early growth, architecture challenges, and where we'll be taking it down the road
+
+
+
+======================================================================
+---  Track: AI PRODUCT MANAGEMENT (TBA) ---
+======================================================================
+
+    Session ID: 925337
+    Track: AI Product Management
+    Speaker: Raiza Martin (CEO & Co-Founder Huxe || Previously NotebookLM)
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: [PM Keynote] Everything is ugly so go build something that isn't
+    Description:
+    We're in an awkward adolescent phase of AI product (design). But what if this chaotic moment is actually our greatest opportunity? Enter the rebuilding revolution.
+    
+    In this talk, we'll explore how the current state of AI interfaces offers a once-in-a-career chance to rethink fundamental UX patterns, with practical guidance on avoiding common pitfalls that plague first-generation AI products.
+    
+    Learn how to balance technical constraints with user needs, identify which conventional wisdom to keep versus discard, and ship AI experiences that actually delight users rather than frustrate them.
+
+  ------------------------------------
+
+    Session ID: 940848
+    Track: AI Product Management
+    Speaker: Tom Moor (Head of Engineering)
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Building the platform for agent coordination
+    Description:
+    Learn how we're evolving Linear into an operating system for engineering teams to ship product with agents as a first class citizen.
+
+  ------------------------------------
+
+    Session ID: 945392
+    Track: AI Product Management
+    Speaker: Kenneth  Auchenberg (Partner at AlleyCorp l, ex Product Lead at Stripe, Microsoft (VS Code))
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: Shipping something to someone always wins
+    Description:
+    Learnings from building products at Stripe and applying them in an AI native word
+
+  ------------------------------------
+
+    Session ID: 914842
+    Track: AI Product Management
+    Speaker: James Lowe (Head of AI Engineering)
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Why your product needs an AI product manager, and why it should be you
+    Description:
+    So you've built another cool demo. Now what? You have hype, but not impact. You have kudos but no users. Ultimately you have a demo, but not a product.
+    
+    The unique uncertainty of AI technology demands a new approach – beyond traditional product management. You need an AI Product Manager. This talk explains why this role is essential for building real AI products, using real case studies from the incubator for Artificial Intelligence in the UK Government.
+    
+    More importantly, it reveals why your technical depth makes you uniquely suited to step into this critical leadership gap. Discover why could be the ideal candidate to be the AI Product Manager your product needs, and how to step into that role.
+
+  ------------------------------------
+
+    Session ID: 914975
+    Track: AI Product Management
+    Speaker: Brian Balfour (Founder & CEO, Reforge)
+    Format: Keynote
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Survive the AI Knife-Fight: Building Products That Win
+    Description:
+    If you’ve ever been blocked by vague specs, shifting goals, or chasing “vibes,” things have only gotten messier in the age of AI. Everyone is obsessing over engineers doing PM work and PMs cranking out prototypes—but that skips the hardest question: What should we build, and why will it win? Today’s competitive landscape is a knife-fight.  When it’s trivial to ship “something,” true differentiation becomes brutally difficult.
+
+  ------------------------------------
+
+    Session ID: 915648
+    Track: AI Product Management
+    Speaker: Ben Stein (CEO)
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Shipping Products When You Don’t Know What they Can Do
+    Description:
+    A customer recently asked me: “Hey, can I tag your AI agent in a Google Doc comment?”
+    
+    The honest answer: I have no idea! We never designed our agents to handle Google Doc comments, but we tried it anyway… and it worked! The agent performed beautifully, the customer was thrilled, and I was left bewildered.
+    
+    Welcome to Product Management for AI agents, where roadmaps are fuzzy and we only learn the boundaries of our products after they’re released. When a product doesn’t follow predefined requirements but instead learns and improvises at runtime, PMs must give up control and lean into uncertainty, curiosity, experimentation, and fast feedback loops.
+    
+    This talk is a field guide for Product/Engineering teams navigating this new reality. We’ll cover how to write specs for affordances instead of features, how to use AI evals as a product development tool, and how to perform User Acceptance Testing on undocumented emergent behavior. Most importantly, we’ll explore how to build trust with customers even when the answer is, truthfully, “I don’t know.”
+    
+    If you’re managing AI-native products in 2025 the same way you managed web apps in 2020, you might find yourself A/B testing an agent that decided to go off and do C, D, and E all by themselves!
+    
+
+  ------------------------------------
+
+    Session ID: 933474
+    Track: AI Product Management
+    Speaker: Kenneth DuMez (DevRel Lead, Graphite)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: Cattle, not genies: building AI agents from first principles
+    Description:
+    As magical as they may seem, AI agents should be treated like any other software system. This talk will cover the best practices in designing and building AI systems including observability, security hardening, and proper UX.
+
+  ------------------------------------
+
+    Session ID: 933686
+    Track: AI Product Management
+    Speaker: Michael Grinich (Founder & CEO, WorkOS )
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: CIAM for AI: Who Are Your Agents and What Can They Do?
+    Description:
+    AI agents are changing the way modern SaaS products operate. Whether automating workflows, integrating with APIs, or acting on behalf of users, AI-driven assistants and autonomous systems are becoming core product features. But securing these agents presents a fundamental challenge: How do you authenticate AI agents? How do you control what they can access? How do you ensure they act within the right permissions? This talk will explore these concepts and more while highlighting current research and best practices.
+
+  ------------------------------------
+
+    Session ID: 915770
+    Track: AI Product Management
+    Speaker: Eliza Cabrera (Principal AI Product Manager @ Workday)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Build Dynamic Products, and Stop the AI Sideshow
+    Description:
+    AI across product, GTM, and strategy was a great approach in 2023, but by now, we all already know that AI is disrupting the global landscape and how business gets done. Now is the time to stop chasing your competitors, and letting the technology lead your product strategy. There’s a better way to build that will allow you to differentiate and keep pace.
+    
+    Join AI product managers Eliza Cabrera and Jeremy Silva to learn how to crawl, walk, and run your way towards building dynamic products.
+    
+
+  ------------------------------------
+
+    Session ID: 933622
+    Track: AI Product Management
+    Speaker: Chris Hernandez (Manager of AI Speech Analytics at Chime)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 11:00 AM
+    Session Title: The Build-Operate Divide: Bridging Product Vision and AI Operational Reality
+    Description:
+    Product leaders see AI possibilities. Operations teams see implementation chaos. That disconnect can kill promising AI features before they ever reach users.
+    
+    In this session, Chris Hernandez and Jeremy Silva share an integrated framework that bridges product strategy and operational reality. You'll learn how they transformed fragmented AI workflows into a unified approach—from prototyping and prompt testing to human review loops and model benchmarking.
+    
+    We’ll explore how to build evaluation systems that satisfy both technical and business stakeholders, create effective HITL processes from day one, and use QA as a strategic enabler of generative AI quality. Most importantly, we’ll show how product and operations can move beyond friction—working together to deliver AI features that scale responsibly and ship faster, with confidence.
+
+  ------------------------------------
+
+    Session ID: 915770
+    Track: AI Product Management
+    Speaker: Jeremy Silva (Product Lead )
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Build Dynamic Products, and Stop the AI Sideshow
+    Description:
+    AI across product, GTM, and strategy was a great approach in 2023, but by now, we all already know that AI is disrupting the global landscape and how business gets done. Now is the time to stop chasing your competitors, and letting the technology lead your product strategy. There’s a better way to build that will allow you to differentiate and keep pace.
+    
+    Join AI product managers Eliza Cabrera and Jeremy Silva to learn how to crawl, walk, and run your way towards building dynamic products.
+    
+
+
+
+======================================================================
+---  Track: AI IN ACTION (TBA) ---
+======================================================================
+
+    Session ID: 927324
+    Track: AI in Action
+    Speaker: Sarah Guo (Founder)
+    Format: Keynote
+    Session Title: The 2025 AI Landscape (tba)
+    Description:
+    Sarah Guo shares her insights on the evolving landscape of AI investment and innovation.
+
+  ------------------------------------
+
+    Session ID: 935987
+    Track: AI in Action
+    Speaker: Simon Willison (AI Engineer)
+    Format: Keynote
+    Session Title: Frontier LLMs: What's Changed, What Won't
+    Description:
+    What's changed in the world of LLMs since the AI World's Fair last year? A lot!
+    
+    I'll be taking full advantage of my role as a fiercely independent researcher to review the past 12 months of advances in the field and catch everyone up on the latest models, free from any influence of vendors or employers.
+    
+
+  ------------------------------------
+
+    Session ID: 936800
+    Track: AI in Action
+    Speaker: Asha  Sharma (CVP, Head of Product, Microsoft AI Platform)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 09:20 AM
+    Session Title: Spark to System: Building the Open Agentic Web
+    Description:
+    AI builders no longer ask whether to use agents—but how many and how fast. In this kickoff keynote, Microsoft’s Asha Sharma shows what happens when natural language creation meets an industrial grade backbone.  Watch live demos—to see agents move from idea to production in real time. Walk out with the commands, repos, and open protocols to build your piece of the agentic web.
+
+  ------------------------------------
+
+    Session ID: 910732
+    Track: AI in Action
+    Speaker: Philipp Schmid (AI Developer Experience)
+    Format: Workshop
+    Room: SOMA: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: AI Engineering with the Google Gemini 2.5 Model Family
+    Description:
+    Hands on Workshop on learning to use Gemini 2.5 Pro in combination with Agentic tooling and MCP Servers.
+
+  ------------------------------------
+
+    Session ID: 935461
+    Track: AI in Action
+    Speaker: Logan Kilpatrick (Product, Google Deepmind)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 09:05 AM
+    Session Title: A year of Gemini progress + what comes next
+    Description:
+    Over the last year, Google and Gemini models have shown rapid progress across all dimensions (model, product, etc). Let's highlight all the work that has happened, how we got the worlds best models, and where we are going next (across both the model landscape and out AI products).
+
+  ------------------------------------
+
+    Session ID: 925974
+    Track: AI in Action
+    Speaker: Sean Grove (Member of Technical Staff)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:55 PM
+    Session Title: Prompt Engineering is Dead - Everything is a Spec
+    Description:
+    [!!Subject to change!!]
+    
+    Large models are trained through mountains of data and learned reward functions, yet - quis custodiet ipsos custodes? - what exactly are those amorphous blobs of data and rewards trying to specify? Building LLMs in any domain demands both clarity of thought and the skill to communicate those thoughts precisely - not only to other humans but to the models themselves. Without either, we risk unpleasant surprises.
+    
+    This talk dives into:
+    •	Why prompt spaghetti and data gumbo inevitably collapse at scale, unleashing behaviors we never intended - while a rigorously versioned spec keeps safety, personality, and UX firmly aligned, and makes incidents easier and faster to diagnose and fix.
+    •	How OpenAI’s public Model Spec provides a clear template, complemented by emerging “dev tools” that turn hazy human intent into precise, human-and-machine-readable policy.
+    •	How deliberative alignment training teaches models to first read and reason about the spec, boosting robustness without inflating context windows.
+    •	Practical tactics for catching ambiguity, untangling contradictions, and preserving global consistency. Plus, techniques for verifying that deployed models truly follow the contract we crafted.
+    
+    Resources: Model Spec (2025‑04‑11) and Deliberative Alignment, Guan et al., 2024.
+
+  ------------------------------------
+
+    Session ID: 930540
+    Track: AI in Action
+    Speaker: Ilan Bigio (Developer Experience)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Model-Maxxing: RFT, DPO, SFT (Fine-tuning with OpenAI)
+    Description:
+    Covering all forms of fine-tuning and prompt engineering, like SFT, DPO, RFT, prompt engineering / optimization, and agent scaffolding.
+
+  ------------------------------------
+
+    Session ID: 905792
+    Track: AI in Action
+    Speaker: Ahmad Awais (Founder & CEO, CHAI.new by Langbase)
+    Format: Online Talk
+    Session Title: Why the Best AI Agents Are Built Without Frameworks (Primitives over Frameworks)
+    Description:
+    Cursor, v0, chai.new, lovable, bolt — what do they all have in common? They weren’t built on AI frameworks—they're built using primitives optimized for speed, scale, and flexibility.
+    
+    LLMs are evolving fast—like, literally every week. New standards pop up (looking at you, MCP), and APIs change faster than you can keep track. Frameworks just can't move at this speed.
+    
+    In this talk, I'll challenge conventional engineering wisdom, sharing my real-world experience scaling thousands of AI agents to handle over 100 million monthly runs.
+    
+    You'll discover how using AI primitives can dramatically speed up iteration, provide bigger scale, and simplify maintenance.
+    
+    I'll share eight practical agent architectures—covering memory management, auto tool integration, and simple serverless deployment—to help you quickly build reliable and scalable AI agents.
+    
+    By the end of this session, you'll clearly see why we must rethink and rebuild our infrastructure and focus on AI-native primitives instead of heavy, bloated, and quickly outdated frameworks.
+    
+    I wonder if we need another S3-moment but for the AI agent infrastructure.
+
+  ------------------------------------
+
+    Session ID: 914551
+    Track: AI in Action
+    Speaker: Patrick Debois (AI Product Engineer - AI Native Dev Advisor)
+    Format: Online Talk
+    Session Title: The 4 Patterns of AI Native Development
+    Description:
+    AI is fundamentally reshaping software development roles and activities. While the change is obvious, understanding the actual shifts taking place on the individual developer remains challenging.
+    
+    In this talk, we introduce the four AI Native Dev patterns that are currently emerging:
+    - From producer to manager: we say what AI needs to do
+    - From implementation to intent: we care less on the how but focus on the why
+    - From delivery to discovery: we experiment and learn
+    - From content creation to knowledge: capture knowhow to get better
+    
+    We backup these patterns by showcasing features in tools that support these shift.
+    
+    The aim of the patterns is to help grasp how to position you and your team members 's career effectively in this changing landscape.
+
+  ------------------------------------
+
+    Session ID: 933688
+    Track: AI in Action
+    Speaker: Zack Proser (Open source hacker. Dev Education at WorkOS)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: AI Pipelines and Agents in Pure TypeScript with Mastra.ai
+    Description:
+    This hands-on workshop introduces Mastra.ai, a TypeScript framework that streamlines the development of agentic AI systems compared to traditional approaches using LangChain and vector databases. Participants will learn to build structured AI workflows with composable tools and reliable control, enabling them to create internal AI assistants that can handle requests like data cleaning, email drafting, and document summarization with minimal code. The session covers Mastra installation, running a local MCP server, defining tools and agents in TypeScript, using the Mastra playground, and implementing practical examples such as RAG setups and tool-chaining agents—all designed to equip attendees with the skills to develop scalable AI-driven internal tools based on sound software engineering principles rather than just experimental prompts.
+
+  ------------------------------------
+
+    Session ID: 933612
+    Track: AI in Action
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 916008
+    Track: AI in Action
+    Speaker: Charlie Guo (Founder & Author)
+    Format: Online Talk
+    Session Title: Analyzing 10,000 Sales Calls with AI in 2 Weeks
+    Description:
+    AKA: The Data Goldmine You’re Probably Ignoring
+    
+    Most companies are sitting on mountains of customer data: sales calls, customer support tickets, product reviews, user feedback, and social media interactions. But the truth is that most of this valuable data remains untouched - or worse, unusable.
+    
+    In this case study, I'll share how our team leveraged Claude to analyze 10,000 sales call transcripts in a handful of days, extracting deep customer insights at scale. We'll cover the AI engineering challenges we faced, including model selection tradeoffs, reducing hallucinations with retrieval-augmented generation (RAG), and optimizing prompt caching to dramatically cut costs and latency (by up to 90% in some cases).
+    
+    This isn't theoretical - it's a practical blueprint with concrete ROI metrics.
+    Perfect for AI engineers, data scientists, and anyone sitting on mountains of unstructured customer data they can't analyze at scale.
+    
+    Read more at https://www.ignorance.ai/
+
+  ------------------------------------
+
+    Session ID: 915928
+    Track: AI in Action
+    Speaker: Ishan Anand (AI Consultant and educator)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: How LLMs work for Web Devs: GPT in 600 lines of Vanilla JS
+    Description:
+    Don't be intimidated. Modern AI can feel like magic, but underneath the hood are principles that web developers can understand, even if you don't have a machine learning background. In this workshop, we'll explore a complete GPT-2 inference implementation built entirely in Vanilla JS. This JavaScript translation of the popular "Spreadsheets-are-all-you-need" approach will let you debug and step through a real LLM line by line without the overhead of learning a new language, framework, or even IDE.
+    
+    All the major LLMs, including ChatGPT, Claude, DeepSeek, and Llama, inherit from GPT-2's architecture, making this exploration a solid foundation to understand modern AI systems and comprehend the latest research.
+    
+    While we won't have time to cover *everything*, you'll gain the essential knowledge to understand the key concepts that matter when building with LLMs, including how they:
+    
+    -Convert raw text into meaningful tokens
+    - Represent semantic meaning through vector embeddings
+    - Train neural networks through gradient descent
+    - Generate text with sampling algorithms like top-k, top-p, and temperature
+    
+    This intense but beginner-friendly workshop is designed specifically for web developers diving into ML and AI for the first time. It’s your "missing AI degree" in just two hours. You'll walk away with an intuitive mental model of how Transformers work that you can apply immediately to your own LLM-powered projects.
+
+  ------------------------------------
+
+    Session ID: 936937
+    Track: AI in Action
+    Speaker: Corey Cooper (Developer Relations Manager @ Circle)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Automating Escrow with USDC and AI
+    Description:
+    This workshop explores how USDC, AI, and smart contracts can streamline escrow by automating fund release based on task or process verification. By using AI to interpret off-chain signals such as document validation, delivery confirmations, or milestone completion, we can trigger secure, programmable USDC payouts without manual intervention. The result is a faster, trust-minimized escrow system ideal for services, trade, and gig economy use cases.
+
+  ------------------------------------
+
+    Session ID: 933575
+    Track: AI in Action
+    Speaker: Beyang Liu (Co-founder and CTO, Sourcegraph)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The emerging skillset of wielding coding agents
+    Description:
+    It's raining coding agents. But while many are saying they're feeling the AGI, others say they're not that useful for serious programming. How much is hype and how much is a skill issue? We'll share empirical observations that help explain the divergence of developer opinion. And we'll cover emergent strategies uncovered by users of Amp, a new coding agent in research preview, that can help you employ agents to complete more complex tasks in production codebases.
+
+  ------------------------------------
+
+    Session ID: 943904
+    Track: AI in Action
+    Speaker: Barr Yaron (Partner at Amplify Partners)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:25 PM
+    Session Title: State of AI Engineering 2025
+    Description:
+    Come hear the results of the 2025 State of AI Engineering.
+
+  ------------------------------------
+
+    Session ID: 916050
+    Track: AI in Action
+    Speaker: Ben Holmes (Product Engineer at Warp)
+    Format: Online Talk
+    Session Title: ChatGPT is poorly designed. So I fixed it
+    Description:
+    Let's fix ChatGPT's greatest design sins. We'll design and build a working app that makes ChatGPT multi-modal and multi-model. And no, you don't need to know what those words mean to use it.
+    
+    Download the source code: https://github.com/bholmesdev/fixgpt
+    
+    References from this video:
+    - Try https://warp.dev to vibe code your own solution
+    - Watch Scott and Mark's podcast episode, "how to not ship the org chart:" https://www.youtube.com/watch?v=Z1yYcUFzH2A
+    - Read "Why is AI marketing so, so bad?" by Evan Armstrong at The Leverage: https://www.gettheleverage.com/p/why-is-ai-marketing-so-so-bad
+    -
+    
+
+  ------------------------------------
+
+    Session ID: 916149
+    Track: AI in Action
+    Speaker: Henry Mao (Founder @ Smithery.ai)
+    Format: Online Talk
+    Session Title: Are MCPs Overhyped? A Rant about MCPs
+    Description:
+    AI agents are becoming smarter but lack the broad capability to take action in practice. At Smithery, we believe the missing link is an AI orchestration layer—a unified interface that gives agents context, action, and a way to learn from real interactions. This talk explores the problem space in the Model Context Protocol (MCP) ecosystem and how we're tackling it at Smithery.
+
+  ------------------------------------
+
+    Session ID: 933626
+    Track: AI in Action
+    Speaker: Philipp Krenn (Code and conference monkey)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:00 PM
+    Session Title: Hope is Not a Strategy: Retrieval Patterns for MCP
+    Description:
+    MCP is a solid integration layer — but how does it hold up when it comes to output quality? Often, not as well as you'd like. Here are some practical retrieval patterns, from basic to advanced, that worked well in my experiments:
+    * Naive: Just plug in plain MCP and hope the LLM gets it right. Sometimes it does. Sometimes you’ll need a miracle.
+    * Semantic: Add more descriptive field names and extra metadata. It helps — but usually just a bit.
+    * Templated: Use a structured template and have the LLM fill it out step by step. More effort, but by far the most reliable results.
+
+  ------------------------------------
+
+    Session ID: 935982
+    Track: AI in Action
+    Speaker: Kent C. Dodds (Software Engineer Educator)
+    Format: Online Talk
+    Session Title: Letting AI Interface with Your App with MCP
+    Description:
+    We are entering a new era of user interaction. It's being built right before our very eyes and changing rapidly. As crazy as it sounds, soon each one of us will get our own Jarvis capable of performing actually useful tasks for us with a completely different user interaction mechanism than we're used to.
+    
+    But someone's gotta give Jarvis the tools to perform these tasks, and that's where we come in.
+    
+    In this talk, Kent will demonstrate an MCP server with an AI assistant to help us catch the vision of what this future could look like and our role in it.
+
+  ------------------------------------
+
+    Session ID: 933646
+    Track: AI in Action
+    Speaker: Jesús Barrasa (AI Field CTO)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: Why Your Agent’s Brain Needs a Playbook: Practical Wins from Using Ontologies
+    Description:
+    You're trying to guide how your agents think and act. Code-orchestrated workflows are too rigid, but LLMs charting their own course feel too chaotic. When you need a middle ground, it’s time to reach for the secret weapon: ontologies. These graph-shaped fragments of actionable knowledge can fill in critical gaps.
+    
+    In this talk, we’ll explore together how ontologies bring structure, semantics, and sanity to GenAI-powered applications. You’ll learn when they’re useful, how to apply them, and what kinds of problems they help solve. Through practical examples, we’ll show how ontologies (1) guide knowledge graph construction, (2) add a semantic layer for more efficient and accurate retrieval (GraphRAG), and (3) encode domain logic you don’t want to leave up to the LLM.
+
+  ------------------------------------
+
+    Session ID: 916107
+    Track: AI in Action
+    Speaker: Jun Yu Tan (Founding Engineer, Tusk)
+    Format: Online Talk
+    Session Title: Designing AI to Scale Human Thought
+    Description:
+    Forget the hype of AI automation replacing jobs. The future lies in human augmentation — revealing blind spots, sparking creativity, and amplifying thoughtful decision-making. In this talk, we’ll explore the principles that distinguish augmentation from automation in AI UX design, covering interaction patterns, design principles, and trust-building feedback loops. Drawing from real-world experiences building AI-powered tools and beyond, we’ll dive into concepts for crafting interfaces that empower users to think smarter, not just work faster. Expect practical insights and a fresh perspective on AI’s role as a collaborative partner.
+    
+    AI Augmentation: https://jytan.net/blog/2025/ai-augmentation/
+    Tusk: https://www.usetusk.ai/
+
+  ------------------------------------
+
+    Session ID: 933632
+    Track: AI in Action
+    Speaker: Numair Baseer (Deployed Engineer, Windsurf)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Agentic Coding with Windsurf
+    Description:
+    Agentic coding marks a new era in software development, where AI agents take on autonomous roles in coding tasks. The Windsurf IDE embodies this shift by integrating intelligent agents like Cascade, which maintain full codebase context to perform multi-file edits, run terminal commands, and suggest changes through tools like Supercomplete and Flows. In this session, we will explore features that allow developers to guide strategy while the AI handles execution, enhancing productivity and enabling more creative, high-level work.
+
+  ------------------------------------
+
+    Session ID: 933568
+    Track: AI in Action
+    Speaker: Lou Bichard (Product Manager, Gitpod)
+    Format: Online Talk
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:30 PM
+    Session Title: The Agent Cockpit: Reimagining Developer UX for Orchestrating AI Fleets
+    Description:
+    Today's development experiences are trapped in a craftsperson paradigm - one human, one agent, one task. But true productivity comes when developers can orchestrate multiple agents working in parallel, just as managers coordinate teams. This talk explores the radical UX transformation needed to support this new "software conductor" workflow. We'll share our discoveries building a multi-modal interface where developers fluidly shift between conversational commands, transient editing, and deep IDE immersion based on task complexity. Learn how notification design, contextual prompting, and background task vizualization enable true parallel development with AI and come together in a command centre like interface.
+
+  ------------------------------------
+
+    Session ID: 902517
+    Track: AI in Action
+    Speaker: Allie Howe (vCISO | Founder of Growth Cyber)
+    Format: Online Talk
+    Session Title: How to Build Trustworthy AI
+    Description:
+    Trust is a multifaceted outcome that results when product and engineering teams work together to build AI that is aligned, explainable, and secure. Learn strategies for how to build trustworthy AI and why trust is paramount for AI systems.
+    
+    Trustworthy AI = AI Security + AI Safety
+    
+    Learn about the differences between AI Security and AI Safety and how the three focus areas of MLSecOps + AI Red Teaming + AI Runtime Security can help you achieve both and ultimately build Trustworthy AI.
+    
+    Trustworthy AI Issues in the news:
+    https://x.com/syddiitwt/status/1923427722241487297
+    https://fingfx.thomsonreuters.com/gfx/legaldocs/egvblxokkvq/Walters%20v%20OpenAI%20-%20order.pdf?ref=claritasgrc.ai
+    
+    MLSecOps Resources
+    Modelscan https://github.com/protectai/modelscan
+    Community: mlsecops.com
+    
+    AI Red Teaming Resources:
+    https://azure.github.io/PyRIT/
+    https://ashy-coast-00aeb501e.6.azurestaticapps.net/MS_AIRT_Lessons_eBook.pdf
+    
+    AI Runtime Security Resources:
+    https://www.pillar.security/solutions#ai-detection
+    https://noma.security/
+    
+    Showcasing Trustworthy AI to Customers/Prospects
+    https://www.vanta.com/collection/trust/what-is-a-trust-center
+
+  ------------------------------------
+
+    Session ID: 933462
+    Track: AI in Action
+    Speaker: Kenneth DuMez (DevRel Lead, Graphite)
+    Format: Workshop
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: The fastest software dev workflow in the world: AI meets stacked diffs
+    Description:
+    Learn the secrets behind the workflows that engineers at the fastest moving companies in the world are using to build software for billions of users worldwide. This workshop will cover a comprehensive overview of how to leverage generative AI to write code, how to stack and submit these pull requests, and finally how to use AI to review them.
+
+  ------------------------------------
+
+    Session ID: 933629
+    Track: AI in Action
+    Speaker: Sam Alba (Co-Founder of Dagger)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: How to trust an agent with software delivery
+    Description:
+    AI-powered agents promise faster, easier software delivery, but their unpredictable behavior often makes engineers hesitant to fully trust them with critical workflows. Sam Alba, Co-founder of Dagger (and previously co-creator of Docker), explains how teams can reliably integrate agents into their delivery pipelines by shifting how they structure and manage automation.
+    
+    He'll share four practical strategies learned from real-world experience:
+    
+    1. Treat agents as workflow participants, not isolated tools.
+    Stop using agents as disconnected scripts or IDE plugins. Treating them as first-class parts of your delivery process simplifies your architecture, reduces hidden complexity, and makes agent outcomes more predictable.
+    
+    2. Use many small agents instead of one big one.
+    Just as software evolved from monoliths to microservices, software delivery benefits from smaller, specialized agents with clearly defined responsibilities. Smaller agents are easier to understand, maintain, and integrate.
+    
+    3. Define clear environments—the real lever for reliability.
+    Instead of chasing perfect prompts or models, focus on clearly defining the tools, resources, and permissions around your agents. Precisely controlling their environments makes agents behave consistently and reliably.
+    
+    4. Design workflows for easy debugging and observability.
+    Agents will sometimes fail unexpectedly. Sam will share simple, effective ways to build clear tracing and observability into your workflows from the start, making debugging quicker and less frustrating.
+    
+    You'll leave with practical, immediately usable techniques that give you the confidence to trust AI agents in your software delivery pipelines.
+
+  ------------------------------------
+
+    Session ID: 933607
+    Track: AI in Action
+    Speaker: Duan Lightfoot (AWS, Sr. Cloud Networking Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Building Agents with Amazon Nova Act and MCP
+    Description:
+    In this 2-hour workshop, participants will gain practical hands-on experience building sophisticated AI agents using Amazon's agent technologies. You'll learn to build agents that can navigate the web like humans, perform complex multi-step tasks, and leverage specialized tools through natural language commands. You’ll explore Amazon Nova Act for reliable web navigation, Model Context Protocol (MCP) for connecting agents to external data sources and APIs, and Amazon Bedrock Agents for orchestrating complex workflows. Through guided exercises, you'll create agents capable of retrieving information and taking action across web applications, all through natural language interactions. By the end of this workshop, you'll have the practical skills to build AI agents that can browse websites, interact with web interfaces, and solve multi-step problems by combining these powerful Amazon technologies.
+
+  ------------------------------------
+
+    Session ID: 933633
+    Track: AI in Action
+    Speaker: Sam  Fertig (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The Eyes Are The (Context) Window to The Soul: How Windsurf Gets to Know You
+    Description:
+    Sometimes it seems like Windsurf knows you a little too well. It's one thing to generate generic code, but to predict your next intent? From matching existing code patterns and styles to tracking how local changes affect the larger codebase, this talk digs into the technical challenges of context awareness and why simply indexing code falls short. Relive our journey tackling the core issue in the AI IDE space : balancing retrieval quality with latency constraints and scaling effectively as codebases grow. For those curious about the infrastructure behind context-aware AI, this talk offers insights into our approach of turning massive codebases into collections of useful context.
+
+  ------------------------------------
+
+    Session ID: 905421
+    Track: AI in Action
+    Speaker: Ofer Mendelevitch (Vectara - the trusted GenAI product platform)
+    Format: Online Talk
+    Session Title: open-rag-eval: RAG Evaluation without "golden" answers.
+    Description:
+    Open-RAG-Eval is an open-source framework that revolutionizes RAG evaluation by harnessing the power of LLM judges for scalable, automated evaluation without the need for golden answers or golden chunks. Building on pioneering research from the University of Waterloo, this framework integrates innovative tools like UMBRELA for reference-free relevance scoring and AutoNuggetizer for automated fact-checking. Designed with a flexible connectors architecture, it seamlessly plugs into any RAG pipeline while delivering fast, transparent, and interpretable metrics on retrieval, generation, and hallucination in RAG.
+
+  ------------------------------------
+
+    Session ID: 916069
+    Track: AI in Action
+    Speaker: Iman  Makaremi (Head of AI Product, Catio building Enterprise Architecture Copilot)
+    Format: Online Talk
+    Session Title: The Multi-agent Orchestration Stack: Building an AI Copilot with Bedrock, Flyte & LangGraph
+    Description:
+    As LLMs move into enterprise workflows, developers face a new kind of architecture challenge: how do you build reliable, interpretable systems powered by agents and reasoning?
+    
+    This talk unpacks how we designed and implemented an AI orchestration framework for enterprise architecture — combining LangGraph for multi-agent workflows, Flyte for distributed execution, and AWS Bedrock for LLM inference using Claude 3. The product: an AI copilot for enterprise architects, deeply rooted in your tech stack context.
+    
+    At the core of this system is a domain-specific **knowledge graph** that acts as long-term memory for the agents. It enables persistent, structured representations of architectural state, system dependencies, and business context — giving the agents the grounding they need to generate accurate recommendations, translate natural language into SQL or code, and maintain continuity across workflows.
+    
+    We’ll also cover how we’ve integrated observability practices — including planned OpenTelemetry instrumentation — to trace and debug autonomous AI systems in production.
+    
+    If you’re a developer or AI engineer thinking beyond the chatbot and looking to embed reasoning into complex system design and data tasks, this talk offers an end-to-end blueprint — from orchestration and grounding to production monitoring.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: AI in Action
+    Speaker: Tejashwa Tiwari (Analytics and Automation Engineer)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+  ------------------------------------
+
+    Session ID: 933716
+    Track: AI in Action
+    Speaker: Charles Frye (Building useful technology out of large neural networks)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: How fast are LLM inference engines anyway?
+    Description:
+    Open weights models and open source inference servers have made massive strides in the year since we last got together at AIE World's Fair.
+    
+    Where once we had only pirated LLaMA 2 weights and Transformers, we now have an embarrassment of riches. In fact, we have too many choices! What's an AI engineer looking to self-host inference to do?
+    
+    In this session, we'll share our benchmarking results from hundreds of runs across models, frameworks, and hardware. We'll also share tips and tricks from working with teams deploying LLM inference at scale.
+
+  ------------------------------------
+
+    Session ID: 939091
+    Track: AI in Action
+    Speaker: Junyang Lin (Alibaba Qwen)
+    Format: Online Talk
+    Session Title: Qwen: Towards a Generalist Model / Agent
+    Description:
+    Since Alibaba launched the Qwen series of large models in 2023, the Qwen series of large language models and multimodal large models have been continuously updated and improved. This presentation will introduce the latest developments in the Qwen series of models, including the large language model Qwen3, vision-language large model Qwen2.5-VL, omni model Qwen2.5-Omni, etc. Additionally, this presentation will also cover the future development directions of the Qwen series.
+
+  ------------------------------------
+
+    Session ID: 939091
+    Track: AI in Action
+    Speaker: Junyang Lin (Alibaba Qwen)
+    Format: Online Talk
+    Session Title: Qwen: Towards a Generalist Model / Agent
+    Description:
+    Since Alibaba launched the Qwen series of large models in 2023, the Qwen series of large language models and multimodal large models have been continuously updated and improved. This presentation will introduce the latest developments in the Qwen series of models, including the large language model Qwen3, vision-language large model Qwen2.5-VL, omni model Qwen2.5-Omni, etc. Additionally, this presentation will also cover the future development directions of the Qwen series.
+
+  ------------------------------------
+
+    Session ID: 933684
+    Track: AI in Action
+    Speaker: Eashan Sinha (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 4 Jun 2025 10:55 AM
+    Session Title: Mastering Engineering Flow with Windsurf
+    Description:
+    As experienced engineers, especially senior and staff engineers, our focus shifts towards complex problem-solving, architectural decisions, and mentoring. While AI tools promise productivity gains, Windsurf offers more than just code completion and chat assistance – it's an agentic IDE built to enhance engineering flow. This talk explores how experienced engineers can leverage Windsurf's deep contextual awareness, structured guidance, and automated workflows to tackle sophisticated and complex tasks. We'll demonstrate practical strategies for accelerating feature development, automating code maintenance and reviews, and ultimately freeing up cognitive load to focus on high-impact engineering challenges. Learn how to move beyond basic AI assistance and truly partner with Windsurf to excel in your role.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI in Action
+    Speaker: Nina Lopatina (Lead Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI in Action
+    Speaker: Rajiv Shah (Chief Evangelist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 933688
+    Track: AI in Action
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: AI Pipelines and Agents in Pure TypeScript with Mastra.ai
+    Description:
+    This hands-on workshop introduces Mastra.ai, a TypeScript framework that streamlines the development of agentic AI systems compared to traditional approaches using LangChain and vector databases. Participants will learn to build structured AI workflows with composable tools and reliable control, enabling them to create internal AI assistants that can handle requests like data cleaning, email drafting, and document summarization with minimal code. The session covers Mastra installation, running a local MCP server, defining tools and agents in TypeScript, using the Mastra playground, and implementing practical examples such as RAG setups and tool-chaining agents—all designed to equip attendees with the skills to develop scalable AI-driven internal tools based on sound software engineering principles rather than just experimental prompts.
+
+  ------------------------------------
+
+    Session ID: 933656
+    Track: AI in Action
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agents, Access, and the Future of Machine Identity
+    Description:
+    AI agents are calling APIs, submitting forms, and sending emails—but how do you control what they’re allowed to do? As agents act on behalf of users or organizations, traditional patterns like OAuth, session tokens, and role-based access often fall short.
+    In this talk, we’ll explore how machine identity is evolving to meet this new landscape. You’ll learn:
+    
+    - How to think about authentication for agents (not just humans)
+    - What it means to authorize an action when the actor is an LLM or headless service
+    - Real-world strategies from WorkOS and Cloudflare for assigning, managing, and revoking agent identity and access
+    
+    By the end, you’ll walk away with practical tools and mental models to build agent-powered systems that are secure, auditable, and scalable.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: AI in Action
+    Speaker: Tejashwa Tiwari (Automation Engineer @ Windsurf)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+  ------------------------------------
+
+    Session ID: 907544
+    Track: AI in Action
+    Speaker: Dan Mason (Principal, Head of AI)
+    Format: Workshop
+    Room: Foothill C: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Case Study + Deep Dive: Telemedicine Support Agents with LangGraph/MCP
+    Description:
+    We've all seen website chat bots which can look up an order or answer a basic question -- but what does it take to build autonomous agents which manage long, delicate processes like multi-day medical treatments?
+    
+    In this workshop, we'll explore a workflow Stride built in partnership with Avila (https://avilascience.com/) that helps patients self-administer medication regimens at home.  The stack includes LangGraph/LangSmith, Claude, MCP, Node.js, React, MongoDB, and Twilio, and rests on a foundation of treatment "blueprints" which LLM-powered agents use to guide patients to good outcomes.
+    
+    You'll learn how to:
+    -Build a hybrid system of code and prompts that leverages LLM decisioning to drive a web application, message queue and database
+    -Design and maintain flexible agentic workflow blueprints, with no special tools (just Google Docs!)
+    -Create an agent evaluation system, which uses LLM-as-a-judge to evaluate the complexity of each interaction and escalate to human support when needed
+    
+    We'll also talk about the prompt engineered guidelines and guardrails which helps agents adhere to protocol as much as possible, while gracefully handling curveballs from the patient.  Please bring questions -- we look forward to sharing our learnings on how to make agentic systems like this work in the real world!
+
+  ------------------------------------
+
+    Session ID: 929790
+    Track: AI in Action
+    Speaker: Danielle Perszyk (Cognitive Scientist, PhD)
+    Format: Keynote
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 12:40 PM
+    Session Title: Useful General Intelligence
+    Description:
+    We’re all hearing that AI agents will enable AGI, but they can’t yet reliably perform even basic computer tasks. It turns out that getting AI to click, type, and scroll is more challenging than getting it to generate code. How can we build general-purpose agents that can do anything we can do on a computer?
+    
+    This is our goal at the Amazon AGI SF Lab. In this talk, I’ll propose a new approach to agents that we call Useful General Intelligence. After describing how we’re solving the biggest challenges in computer use while enabling developers to access our tech in it’s earliest developmental stages, I’ll show real workflows that developers have built with Nova Act, our agentic model and SDK.
+
+  ------------------------------------
+
+    Session ID: 933636
+    Track: AI in Action
+    Speaker: Ado Kukic (Director, Developer Relations)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Everything is changing
+    Description:
+    We believe programming with AI is going through massive changes — again.
+    
+    Turns out the models yearn for the tools and tokens. We hold them back if we make them ask before they can change a file.
+    
+    Give them tools & tokens and everything changes: what we use them for, how we use them, how many we run at the same time, how they talk to each other, how they talk to you, what they even are...
+    
+    It's all going to change.
+    
+    And with Amp, we're embracing it.
+    
+    If you want to find out where this is all going — come with us.
+
+  ------------------------------------
+
+    Session ID: 933707
+    Track: AI in Action
+    Speaker: Apoorva Joshi (Senior AI Developer Advocate, MongoDB)
+    Format: Workshop
+    Room: SOMA: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Building Multimodal AI Agents (From Scratch)
+    Description:
+    In this hands-on workshop, you will build a multimodal AI agent capable of processing mixed-media content—from analyzing charts and diagrams to extracting insights from documents with embedded visuals. Using MongoDB as a vector database and memory store, and Google's Gemini for multimodal reasoning, you will gain hands-on experience with multimodal data processing pipelines and agent orchestration patterns by implementing core components directly, using good ol' Python.
+    
+
+  ------------------------------------
+
+    Session ID: 936006
+    Track: AI in Action
+    Speaker: swyx (Curator)
+    Format: Keynote
+    Session Title: Building AI-Intensive Applications
+    Description:
+    swyx updates the Martin Kleppmann classic. Whether you call it a workflow or an agent, AI engineered applications are seeing user-input:LLM-call ratios go from 1:1 (ChatGPT) to 1:100 (Deep Research, Codex) and even 0:n (Ambient/Proactive agents). How does AI Engineering change as you build increasingly AI intensive applications? Let's call a spade a SPADE.
+
+
+
+======================================================================
+---  Track: AI IN FORTUNE 500 (June 4-5) ---
+======================================================================
+
+    Session ID: 936800
+    Track: AI in Fortune 500
+    Speaker: Asha  Sharma (CVP, Head of Product, Microsoft AI Platform)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 09:20 AM
+    Session Title: Spark to System: Building the Open Agentic Web
+    Description:
+    AI builders no longer ask whether to use agents—but how many and how fast. In this kickoff keynote, Microsoft’s Asha Sharma shows what happens when natural language creation meets an industrial grade backbone.  Watch live demos—to see agents move from idea to production in real time. Walk out with the commands, repos, and open protocols to build your piece of the agentic web.
+
+  ------------------------------------
+
+    Session ID: 903524
+    Track: AI in Fortune 500
+    Speaker: Joel Hron (CTO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: From Copilot to Colleague: Building Trustworthy Productivity Agents for High-Stakes Work
+    Description:
+    This keynote will explore what it takes to move from basic generative assistants to fully agentic AI—systems that don’t just suggest but plan, act, and adapt—all within the structured, high-trust environments where professionals actually work.
+
+  ------------------------------------
+
+    Session ID: 937225
+    Track: AI in Fortune 500
+    Speaker: Harrison Chase (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: 3 ingredients for building reliable enterprise agents
+    Description:
+    It's easy to build a prototype of an agent, but hard to put an agent in production - especially in an enterprise setting. In this section, will talk about three ingredients for building reliable agents in the enterprise.
+
+  ------------------------------------
+
+    Session ID: 932429
+    Track: AI in Fortune 500
+    Speaker: Ben Kus (CTO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Building an Agentic Platform
+    Description:
+    Explore the technical evolution of metadata extraction at Box and how it shaped the foundation of our AI platform. We’ll walk through our transition to an agentic-first design—why it was necessary, how we approached the rebuild, challenges we encountered along the way, and the advantages it unlocked.
+
+  ------------------------------------
+
+    Session ID: 916025
+    Track: AI in Fortune 500
+    Speaker: Hariharan Ganesan (Sr. Solutions Architect)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: CIOs and Industry Leaders: Do You Trust Your AI’s Inferences?
+    Description:
+    Enterprise AI adoption is accelerating, but with it comes a hard question: Do we trust the model’s decisions? In this 18-minute talk, I’ll explore the invisible risks behind automated decision-making in safety-critical and revenue-sensitive environments. Drawing on case studies across manufacturing, telecom, and industrial IoT, I’ll highlight how explainability, traceability, and robust guardrails drive adoption and protect enterprise value.
+    Attendees will walk away with:
+    •	A 3-step framework for operationalizing AI trust
+    •	Real-world lessons from building guardrails in on-prem and hybrid systems
+    •	Tools and techniques for debugging and explaining inferences at scale
+    •	A blueprint for building trust between models, engineers, and executive stakeholders
+
+  ------------------------------------
+
+    Session ID: 916085
+    Track: AI in Fortune 500
+    Speaker: Jaspreet Singh (Senior Staff Software Engineer)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: How Intuit uses LLMs to explain taxes to millions of taxpayers
+    Description:
+    I will talk about how Intuit uses LLMs to explain tax situations to Turbotax users.
+    Users want explanations of their tax situations - this drives confidence in the product. Over the course of last two tax years, Intuit has built out explanations using Anthropic and openAI’s models to develop genAI powered explanations. This includes design a complex system with prompt engineered solutions and both LLM & human powered evaluations to ensure high quality bar that our users expect when filing taxes with us.
+    During the course of my talk, I will talk across GenAI development lifecycle at scale - including development , evaluations and scaling. And security evaluations. We also developed a fine-tuned version of Claude Haiku & shall be covering that in the presentation.
+    We also expanded into tax question and answering powered by RAG, including graphRAG and I would be covering those developments too.
+
+  ------------------------------------
+
+    Session ID: 914890
+    Track: AI in Fortune 500
+    Speaker: Kevin Madura (Director, Advanced Technologies)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: The Billable Hour is Dead; Long Live the Billable Hour?
+    Description:
+    If software was eating the world before, knowledge work will soon be devoured by AI. In corporate America there are thousands of hours spent on rote tasks every day by employees, consultants, and lawyers alike. But is AI really capable of replacing work in the real world yet?
+    Productivity estimates from GenAI range from 1.5% (NBER) to 96% (☝ us! ️). In this talk we'll share war stories of where the answer is yes (and no) and how we reduced human time spent on tasks from days to minutes in high-impact situations.
+    The path from promise to actual product, used in real world settings, from our experience, is still unmapped. Learn what we built, how we built it - with code - and how we got stakeholder buy-in to deploy it.
+
+  ------------------------------------
+
+    Session ID: 916025
+    Track: AI in Fortune 500
+    Speaker: Sahil Yadav (Head of AI Products (Sr. Director, Product Management))
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: CIOs and Industry Leaders: Do You Trust Your AI’s Inferences?
+    Description:
+    Enterprise AI adoption is accelerating, but with it comes a hard question: Do we trust the model’s decisions? In this 18-minute talk, I’ll explore the invisible risks behind automated decision-making in safety-critical and revenue-sensitive environments. Drawing on case studies across manufacturing, telecom, and industrial IoT, I’ll highlight how explainability, traceability, and robust guardrails drive adoption and protect enterprise value.
+    Attendees will walk away with:
+    •	A 3-step framework for operationalizing AI trust
+    •	Real-world lessons from building guardrails in on-prem and hybrid systems
+    •	Tools and techniques for debugging and explaining inferences at scale
+    •	A blueprint for building trust between models, engineers, and executive stakeholders
+
+  ------------------------------------
+
+    Session ID: 925912
+    Track: AI in Fortune 500
+    Speaker: Randall Hunt (CTO at Caylent)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: POC to PROD: Hard Lessons from 200+ Enterprise GenAI Deployments
+    Description:
+    The transition from experimental GenAI demonstrations to robust, production-grade systems involves significant technical and organizational complexities. Humans provide a ceiling on the true ROI of automations. This session synthesizes key patterns and practical strategies gathered from more than 200 GenAI implementations across multiple industries and business sizes.
+    
+    Beyond the general lessons that apply to most products leveraging GenAI, we'll cover detailed observations within three application areas: multimodal understanding and search, enterprise knowledge retrieval, and AI agent architectures. We will share real-world comparative performance data and metrics on embedding models, vector index implementations, and explore various implementation methodologies that balance performance and cost.
+    
+    Additionally, the session addresses organizational insights critical to successful AI deployments, such as the importance of clearly defined evaluation processes and understanding real-world user interaction challenges, highlighted by examples from healthcare environments. Attendees will gain an understanding of decision-making criteria, including the appropriate complexity of prompt engineering versus more elaborate orchestration methods, token/cost management strategies in multilingual settings, and the challenges in driving behavioral change with new UX and application interaction capabilities.
+    
+    Participants will leave equipped with practical, data-supported insights for effectively navigating their own GenAI projects, including benchmarks and criteria for informed technology selection, and techniques to streamline the transition from initial concept to sustainable operational deployment. Please note, we all know this field evolves rapidly and we will mark which lessons we believe are immutable.
+
+  ------------------------------------
+
+    Session ID: 914891
+    Track: AI in Fortune 500
+    Speaker: Adam Behrens (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Machines of Buying & Selling Grace
+    Description:
+    How to go beyond browser automation to truly agentic commerce, where AI can buy, sell and negotiate on behalf of users and merchants.
+
+  ------------------------------------
+
+    Session ID: 933575
+    Track: AI in Fortune 500
+    Speaker: Beyang Liu (Co-founder and CTO, Sourcegraph)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The emerging skillset of wielding coding agents
+    Description:
+    It's raining coding agents. But while many are saying they're feeling the AGI, others say they're not that useful for serious programming. How much is hype and how much is a skill issue? We'll share empirical observations that help explain the divergence of developer opinion. And we'll cover emergent strategies uncovered by users of Amp, a new coding agent in research preview, that can help you employ agents to complete more complex tasks in production codebases.
+
+  ------------------------------------
+
+    Session ID: 933605
+    Track: AI in Fortune 500
+    Speaker: Mani Khanuja (Principal ML Services SA)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Data is Your Differentiator: Building Secure and Tailored AI Systems
+    Description:
+    As  organizations seek to harness their proprietary data while maintaining  security and compliance, Amazon Bedrock provides a comprehensive framework  for building tailored AI applications. Using Amazon Bedrock Knowledge Bases  and Amazon Bedrock Data Automation, organizations can create AI solutions  that truly understand their unique business context, terminology, and  requirements. Combined with Amazon Bedrock Guardrails, these capabilities  enhance the accuracy and relevance of AI-generated responses, while ensuring  that sensitive information remains protected within the organization's  control - enabling businesses to build secure and compliant enterprise-grade  generative AI solutions that accelerate time to value.
+
+  ------------------------------------
+
+    Session ID: 914890
+    Track: AI in Fortune 500
+    Speaker: Mo Bhasin (Director of AI Products)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: The Billable Hour is Dead; Long Live the Billable Hour?
+    Description:
+    If software was eating the world before, knowledge work will soon be devoured by AI. In corporate America there are thousands of hours spent on rote tasks every day by employees, consultants, and lawyers alike. But is AI really capable of replacing work in the real world yet?
+    Productivity estimates from GenAI range from 1.5% (NBER) to 96% (☝ us! ️). In this talk we'll share war stories of where the answer is yes (and no) and how we reduced human time spent on tasks from days to minutes in high-impact situations.
+    The path from promise to actual product, used in real world settings, from our experience, is still unmapped. Learn what we built, how we built it - with code - and how we got stakeholder buy-in to deploy it.
+
+  ------------------------------------
+
+    Session ID: 935969
+    Track: AI in Fortune 500
+    Speaker: Rita  Kozlov (vp developers & ai, cloudflare)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Building Agents (the hard parts!)
+    Description:
+    AI workloads are rapidly shifting from AI being used for augmentation (co-pilots), to AI becoming responsible for full, end-to-end automation (agents). But building effective agents, and even more importantly, agent experiences that boost productivity requires many pieces. In this talk, we'll be covering the building blocks of agents, how to put them together, and what we've learned from top companies building agents along the way.
+
+  ------------------------------------
+
+    Session ID: 933633
+    Track: AI in Fortune 500
+    Speaker: Sam  Fertig (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The Eyes Are The (Context) Window to The Soul: How Windsurf Gets to Know You
+    Description:
+    Sometimes it seems like Windsurf knows you a little too well. It's one thing to generate generic code, but to predict your next intent? From matching existing code patterns and styles to tracking how local changes affect the larger codebase, this talk digs into the technical challenges of context awareness and why simply indexing code falls short. Relive our journey tackling the core issue in the AI IDE space : balancing retrieval quality with latency constraints and scaling effectively as codebases grow. For those curious about the infrastructure behind context-aware AI, this talk offers insights into our approach of turning massive codebases into collections of useful context.
+
+  ------------------------------------
+
+    Session ID: 915616
+    Track: AI in Fortune 500
+    Speaker: Donald Hruska (Engineering lead for Retool Agents)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: How agents will unlock the $500B promise of AI
+    Description:
+    AI agents are on the cusp of revolutionizing work as we know it. The number of use cases software can tackle is set to explode as AI handles tasks requiring real judgment. But to cross the gap between an interesting AI prototype and an essential business tool, you need agents built by developers with real guardrails and security.
+    
+    This means blending AI assistance with traditional coding in a multimodal approach that maximizes efficiency and control. The future isn't about dropping in an LLM — it requires integrating any model, any data, any system to deliver results.
+    
+    Companies utilizing this approach can finally turn their slice of the $500B+ of total AI investment into real business results.
+    
+
+  ------------------------------------
+
+    Session ID: 914049
+    Track: AI in Fortune 500
+    Speaker: Yogi Miraje (Lead AI Engineer)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: How to Build Agents without losing control
+    Description:
+    Planning agents help solve complex tasks by breaking them into steps. They work across enterprise systems where data lives in many places. These agents are powerful but can be hard to control. This session shows how to use blueprints as guardrails for these agents. I will explain techniques to ensure agents follow the right plan. I will cover evaluation methods to verify agents stay aligned with user goals.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: AI in Fortune 500
+    Speaker: Tejashwa Tiwari (Analytics and Automation Engineer)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+  ------------------------------------
+
+    Session ID: 915738
+    Track: AI in Fortune 500
+    Speaker: Christopher Lovejoy (Head of Clinical AI )
+    Format: Talk
+    Room: Foothill G 1&2: Product Management
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Make your LLM app a Domain Expert: How to Build an LLM-Native Expert System
+    Description:
+    Vertical AI is a multi-trillion-dollar opportunity. But you can't build a domain-expert application simply by grabbing the latest LLMs off-the-shelf: you need a system for codifying latent insights from domain experts and using that to drive development of your application.
+    
+    In this talk, we'll describe the system we've built at Anterior which has enabled us to achieve SOTA clinical reasoning and serve health insurance providers covering 50 million American lives. We'll share:
+    - how and why to encode domain-specific failure modes as an ontology
+    - a practical system for converting domain expertise into quantifiable eval metrics
+    - how we structure work and collaboration between our clinicians, engineer and PMs
+    - our eval-driven AI iteration process and how this can be adapted to any industry
+
+  ------------------------------------
+
+    Session ID: 904722
+    Track: AI in Fortune 500
+    Speaker: Infant Vasanth (Senior Director of Engineering)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Accelerating Investment Operations: How BlackRock Builds Custom Knowledge Apps at Scale.
+    Description:
+    Investment Operations teams are the backbone of asset and investment management firms. Their day-to-day work not only enables portfolio managers to respond swiftly to market events but also ensures that complex, unstructured data flows seamlessly across the organization.
+    In this talk, we introduce a modular, Kubernetes-native AI framework purpose-built to scale custom Knowledge Apps across the enterprise. Designed with speed, flexibility, and compliance in mind, the framework empowers teams to launch production-grade document extraction applications in minutes instead of months, unlocking new levels of automation and efficiency for investment management workflows.
+    We’ll also share how this framework has helped BlackRock streamline document extraction processes, generate investment signals, reduce operational overhead, and accelerate the delivery of high-impact business use cases—all while maintaining the robustness and control required in a regulated industry.
+
+  ------------------------------------
+
+    Session ID: 933684
+    Track: AI in Fortune 500
+    Speaker: Eashan Sinha (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 4 Jun 2025 10:55 AM
+    Session Title: Mastering Engineering Flow with Windsurf
+    Description:
+    As experienced engineers, especially senior and staff engineers, our focus shifts towards complex problem-solving, architectural decisions, and mentoring. While AI tools promise productivity gains, Windsurf offers more than just code completion and chat assistance – it's an agentic IDE built to enhance engineering flow. This talk explores how experienced engineers can leverage Windsurf's deep contextual awareness, structured guidance, and automated workflows to tackle sophisticated and complex tasks. We'll demonstrate practical strategies for accelerating feature development, automating code maintenance and reviews, and ultimately freeing up cognitive load to focus on high-impact engineering challenges. Learn how to move beyond basic AI assistance and truly partner with Windsurf to excel in your role.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI in Fortune 500
+    Speaker: Nina Lopatina (Lead Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: AI in Fortune 500
+    Speaker: Rajiv Shah (Chief Evangelist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: AI in Fortune 500
+    Speaker: Tejashwa Tiwari (Automation Engineer @ Windsurf)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+  ------------------------------------
+
+    Session ID: 915990
+    Track: AI in Fortune 500
+    Speaker: Amir Haghighat (CTO)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: The Rise of Open Models in the Enterprise
+    Description:
+    This year kicked off with the DeepSeek-R1 news cycle breaking out of our AI Engineering bubble into the mainstream tech and business world. Leaders at the highest levels of the largest enterprises started asking how open source models could enhance and accelerate their AI strategy.
+    
+    Open source models promise increased ownership of AI systems: control over performance and price, improved uptime and reliability, better compliance, and flexible hosting options. How are these promises playing out after months of implementation? In this talk, I’ll draw on hundreds of conversations with AI leaders at enterprise companies to discuss what has — and hasn’t — changed about enterprise AI strategy in a world where open-source models compete on the frontier of intelligence.
+
+  ------------------------------------
+
+    Session ID: 915431
+    Track: AI in Fortune 500
+    Speaker: Thor 雷神 Schaeff (DX at ElevenLabs)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 11:00 AM
+    Session Title: Build multilingual Conversational AI Agents
+    Description:
+    In this workshop you will learn how to build multilingual Conversational AI agents that can automatically detect your user's spoken language and can seamlessly switch to their preferred language.
+
+  ------------------------------------
+
+    Session ID: 904722
+    Track: AI in Fortune 500
+    Speaker: Vaibhav Page (Principal Engineer )
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Accelerating Investment Operations: How BlackRock Builds Custom Knowledge Apps at Scale.
+    Description:
+    Investment Operations teams are the backbone of asset and investment management firms. Their day-to-day work not only enables portfolio managers to respond swiftly to market events but also ensures that complex, unstructured data flows seamlessly across the organization.
+    In this talk, we introduce a modular, Kubernetes-native AI framework purpose-built to scale custom Knowledge Apps across the enterprise. Designed with speed, flexibility, and compliance in mind, the framework empowers teams to launch production-grade document extraction applications in minutes instead of months, unlocking new levels of automation and efficiency for investment management workflows.
+    We’ll also share how this framework has helped BlackRock streamline document extraction processes, generate investment signals, reduce operational overhead, and accelerate the delivery of high-impact business use cases—all while maintaining the robustness and control required in a regulated industry.
+
+
+
+======================================================================
+---  Track: AGENT RELIABILITY (June 4) ---
+======================================================================
+
+    Session ID: 939640
+    Track: Agent Reliability
+    Speaker: Christian Szegedy (Former co-founder of xAI, discoverer of adversarial examples)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Towards Verified Superintelligence
+    Description:
+    I describe a new paradigm towards open-endedly self-improving intelligence by scaling verification to remove the human data and supervision bottleneck. The objective is to achieve trustless alignment of superintelligence.
+
+  ------------------------------------
+
+    Session ID: 913755
+    Track: Agent Reliability
+    Speaker: Preeti Somal (SVP Engineering)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: Scaling AI agents without breaking reliability
+    Description:
+    As AI agents move from prototypes to production, developers are running into new challenges with orchestration, failure handling, and infrastructure. This session will unpack lessons from teams already building real-world systems and share how to design for reliability from the start.
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Agent Reliability
+    Speaker: Arjun Desai (Co-Founder, Cartesia)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 933612
+    Track: Agent Reliability
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 914015
+    Track: Agent Reliability
+    Speaker: Sam Bhagwat (Co-founder)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Agents vs Workflows: Why Not Both?
+    Description:
+    One current hot debate is should you make your top-level abstraction a ReAct type agent running in a loop? or should you make it a structured workflow graph?
+    
+    OpenAI is launching their new framework and throwing shade on workflow graph approaches
+    
+    TBH we think this whole debate is kinda dumb.
+    
+    We've seen a lot of folks be able to structure the problem in a way that a workflow graph makes a lot of sense.
+    
+    We also see a ton of agents where you need to run the core bit in a loop for a long time.
+    
+    You can also give your agents structured workflow graphs as a tool. You can use structured workflow graphs as a handoff mechanism between agents. What we've seen from the community is frankly that folks need to tinker with multiple approaches and combine primitives in interesting ways
+    
+    We'll share a couple stories where teams ended up with workflow graph based approaches, a couple where teams ended up with agent based approaches, and a couple where a blended approach made sense.
+
+  ------------------------------------
+
+    Session ID: 933575
+    Track: Agent Reliability
+    Speaker: Beyang Liu (Co-founder and CTO, Sourcegraph)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The emerging skillset of wielding coding agents
+    Description:
+    It's raining coding agents. But while many are saying they're feeling the AGI, others say they're not that useful for serious programming. How much is hype and how much is a skill issue? We'll share empirical observations that help explain the divergence of developer opinion. And we'll cover emergent strategies uncovered by users of Amp, a new coding agent in research preview, that can help you employ agents to complete more complex tasks in production codebases.
+
+  ------------------------------------
+
+    Session ID: 933605
+    Track: Agent Reliability
+    Speaker: Mani Khanuja (Principal ML Services SA)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Data is Your Differentiator: Building Secure and Tailored AI Systems
+    Description:
+    As  organizations seek to harness their proprietary data while maintaining  security and compliance, Amazon Bedrock provides a comprehensive framework  for building tailored AI applications. Using Amazon Bedrock Knowledge Bases  and Amazon Bedrock Data Automation, organizations can create AI solutions  that truly understand their unique business context, terminology, and  requirements. Combined with Amazon Bedrock Guardrails, these capabilities  enhance the accuracy and relevance of AI-generated responses, while ensuring  that sensitive information remains protected within the organization's  control - enabling businesses to build secure and compliant enterprise-grade  generative AI solutions that accelerate time to value.
+
+  ------------------------------------
+
+    Session ID: 933621
+    Track: Agent Reliability
+    Speaker: Laurie Voss (VP Developer Relations, LlamaIndex)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Effective agent design patterns in production
+    Description:
+    At LlamaIndex we see a lot of agents built every day, and we've got a sense of what works and what doesn't. We've distilled those learnings down into a series of patterns and best practices for building real-world, production agents, and we're here to share them. You'll learn patterns for applying structure and guidance to famously nondeterministic LLMs and get concrete instruction on how to implement them.
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Agent Reliability
+    Speaker: Rohit Talluri (Senior Worldwide Generative AI Specialist BD - Foundation Model Training & Inference)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 933474
+    Track: Agent Reliability
+    Speaker: Kenneth DuMez (DevRel Lead, Graphite)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: Cattle, not genies: building AI agents from first principles
+    Description:
+    As magical as they may seem, AI agents should be treated like any other software system. This talk will cover the best practices in designing and building AI systems including observability, security hardening, and proper UX.
+
+  ------------------------------------
+
+    Session ID: 916117
+    Track: Agent Reliability
+    Speaker: Tanmai Gopal (CEO, Co-founder)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: AI Automation that actually works: $100M, messy data, zero surprises
+    Description:
+    We will review the different kinds of automation use-cases, and the approach we used, that will drive over a $100M of expected annual impact by deploying AI for business critical initiatives.
+    
+    We will discuss what kinds of automation initiatives become possible because of Gen AI. These were not tenable before because of the amount of customization required per customer or per scenario, and the kind of data involved in these workflows. Previously, these workflows were driven manually which were both error prone and required expensive training.
+    
+    To replace or augment these manual business critical processes, automation _has_ to cross a very high bar of reliability.
+    
+    We will share how we addressed the inherent non-determinism of Gen AI to create a predictable system that doesn’t have any surprising failure modes. We’ll also discuss how we worked with our existing data that was spread across various systems without an expensive centralisation and clean up effort.
+
+  ------------------------------------
+
+    Session ID: 933610
+    Track: Agent Reliability
+    Speaker: Mike Chambers (AI/ML Specialist DA AWS)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Ship it! Building Production-Ready Agents
+    Description:
+    Explore the practical challenges and solutions for deploying AI agents in real-world production environments. Through detailed technical analysis and practical examples, we'll examine strategies for building and orchestrating agent systems at scale. We'll cover critical infrastructure decisions, scalability frameworks, and best practices for creating robust, production-ready agent architectures.
+
+  ------------------------------------
+
+    Session ID: 933629
+    Track: Agent Reliability
+    Speaker: Sam Alba (Co-Founder of Dagger)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: How to trust an agent with software delivery
+    Description:
+    AI-powered agents promise faster, easier software delivery, but their unpredictable behavior often makes engineers hesitant to fully trust them with critical workflows. Sam Alba, Co-founder of Dagger (and previously co-creator of Docker), explains how teams can reliably integrate agents into their delivery pipelines by shifting how they structure and manage automation.
+    
+    He'll share four practical strategies learned from real-world experience:
+    
+    1. Treat agents as workflow participants, not isolated tools.
+    Stop using agents as disconnected scripts or IDE plugins. Treating them as first-class parts of your delivery process simplifies your architecture, reduces hidden complexity, and makes agent outcomes more predictable.
+    
+    2. Use many small agents instead of one big one.
+    Just as software evolved from monoliths to microservices, software delivery benefits from smaller, specialized agents with clearly defined responsibilities. Smaller agents are easier to understand, maintain, and integrate.
+    
+    3. Define clear environments—the real lever for reliability.
+    Instead of chasing perfect prompts or models, focus on clearly defining the tools, resources, and permissions around your agents. Precisely controlling their environments makes agents behave consistently and reliably.
+    
+    4. Design workflows for easy debugging and observability.
+    Agents will sometimes fail unexpectedly. Sam will share simple, effective ways to build clear tracing and observability into your workflows from the start, making debugging quicker and less frustrating.
+    
+    You'll leave with practical, immediately usable techniques that give you the confidence to trust AI agents in your software delivery pipelines.
+
+  ------------------------------------
+
+    Session ID: 914080
+    Track: Agent Reliability
+    Speaker: Dexter Horthy (Founder)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: 12 Factor Agents - Principles of Reliable LLM Applications
+    Description:
+    Hi, I'm Dex. I've been hacking on AI agents for a while.
+    
+    I've tried every agent framework out there, from the plug-and-play crew/langchains to the "minimalist" smolagents of the world to the "production grade" langraph, griptape, etc.
+    
+    I've talked to a lot of really strong founders who are all building really impressive things with AI. Most of them are rolling the stack themselves. I don't see a lot of frameworks in production customer-facing agents.
+    
+    I've been surprised to find that most of the products out there billing themselves as "AI Agents" are not all that agentic. A lot of them are mostly deterministic code, with LLM steps sprinkled in at just the right points to make the experience truly magical.
+    
+    Agents, at least the good ones, don't follow the "here's your prompt, here's a bag of tools, loop until you hit the goal" pattern. Rather, they are comprised of mostly just software.
+    
+    So, I set out to answer:
+    
+    What are the principles we can use to build LLM-powered software that is actually good enough to put in the hands of production customers?
+    
+
+  ------------------------------------
+
+    Session ID: 933692
+    Track: Agent Reliability
+    Speaker: Richmond Alake (Staff Developer Advocate, AI/ML at MongoDB)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 10:40 AM
+    Session Title: Architecting Agent Memory: Principles, Patterns, and Best Practices
+    Description:
+    In the rapidly evolving landscape of agentic systems, memory management has emerged as a key pillar for building intelligent, context-aware AI Agents. Inspired by the complexity of human memory systems—such as episodic, working, semantic, and procedural memory—this talk unpacks how AI agents can achieve believability, reliability, and capability by retaining and reasoning over past experiences.
+    We’ll begin by establishing a conceptual framework based on real-world implementations from memory management libraries and system architectures:
+    Memory Components representing various structured memory types (e.g., conversation, workflow, episodic, persona)
+    Memory Modes reflecting operational strategies for short-term, long-term, and dynamic memory handling
+    Next, the talk transitions to practical implementation patterns critical for effective memory lifecycle management:
+    Maintaining rich conversation history and contextual awareness
+    Persistence strategies leveraging vector databases and hybrid search
+    Memory augmentation using embeddings, relevance scoring, and semantic retrieval
+    Production-ready practices for scaling memory in multi-agent ecosystems
+    We’ll also examine advanced memory strategies within agentic systems:
+    Memory cascading and selective deletion
+    Integration of tool use and persona memory
+    Optimizing performance around memory retrieval and LLM context window limits
+    Whether you're developing autonomous agents, chatbots, or complex workflow orchestration systems, this talk offers knowledge and tactical insights for building AI that can remember, adapt, and improve over time.
+    This session is ideal for:
+    AI engineers and agent framework developers
+    Architects designing Agentic RAG or multi-agent systems
+    Practitioners building contextual, personalized AI experiences
+    By the end of the session, you’ll understand how to leverage memory as a strategic asset in agentic design—and walk away ready to build agents that not only act and reason but also remember.
+
+  ------------------------------------
+
+    Session ID: 933669
+    Track: Agent Reliability
+    Speaker: Anushrut Gupta (Applied AI Lead, PromptQL)
+    Format: Talk
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 01:30 PM
+    Session Title: "Data readiness" is a myth: Make AI Reliabile with an Agentic Semantic Layer
+    Description:
+    The rapid progress in LLM capability has not translated to increased reliability for business critical AI use cases. The root-cause? Data is "not ready".
+    Conversational analytics doesn't go beyond the analyst team because it's hard to verify if the generated queries are actually doing what they are supposed to.
+    RAG based systems often fail to handle the breadth and depth of real world use-cases because it requires a prohibitive amount of preparation & maintenance of an underlying knowledge graph.
+    
+    Agentic AI systems need to hard-code specific workflows to work reliably and end up looking more like software engineering with LLM calls instead of delivering on the promise of truly agentic workflows.
+    
+    In all of these failure modes, the common culprit is that the planning or reasoning done by the LLM fails to accurately capture the user's intent or the domain's context aka the lack of a well prepared semantic data layer.
+    
+    Enterprise data is silo-ed and vastly varying levels of quality and the perfect "semantic layer" and "metadata" is a moving target. New data is continuously being created and business definitions are rapidly changing and often entirely on-demand.
+    In this talk we'll share how you can build and maintain a semantic data layer that is maintained entirely by AI, and show (with live examples) how that dramatically improves reliability of the AI system that needs dynamic access to data.
+    We'll demonstrate how this sufficiently augments existing RAG, text-to-SQL and tool calling techniques and starts opening the door to reliable AI deployments.
+    
+
+  ------------------------------------
+
+    Session ID: 933702
+    Track: Agent Reliability
+    Speaker: Mikiko Bazeley (Staff Developer Advocate, MongoDB)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Smarter Together: Designing Multi-Agent Systems with Shared, Evolving Memory
+    Description:
+    In today’s most advanced AI systems, intelligence is no longer confined to a single model or agent—it emerges from coordination. But coordination requires memory: short-term, long-term, and shared. In this talk, we’ll break down how agent systems can store, retrieve, and evolve shared memory to become smarter over time. You'll learn what it takes to architect these continuously learning systems, how to track and improve memory quality, and why robust, flexible infrastructure is the foundation of it all. Stick around to see how this works in practice—live.
+
+  ------------------------------------
+
+    Session ID: 941906
+    Track: Agent Reliability
+    Speaker: Alex Atallah (CEO OpenRouter, co-founder of OpenSea)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:35 PM
+    Session Title: fun stories from building OpenRouter and where all this is going
+    Description:
+    How the first LLM aggregator got started, some of the weird moments in its early growth, architecture challenges, and where we'll be taking it down the road
+
+
+
+======================================================================
+---  Track: AUTONOMY+ROBOTICS (TBA) ---
+======================================================================
+
+    Session ID: 938258
+    Track: Autonomy+Robotics
+    Speaker: Quan Vuong (Cofounder)
+    Format: Keynote
+    Session Title: Physical AGI (tbc)
+    Description:
+    Quan Vuong (Cofounder) and Jost Tobias Springenberg (Research Scientist) from Physical Intelligence discuss the advancements and future of Physical AGI in the Autonomy/Robotics track.
+
+  ------------------------------------
+
+    Session ID: 938258
+    Track: Autonomy+Robotics
+    Speaker: Jost Tobias Springenberg (Research Scientist)
+    Format: Keynote
+    Session Title: Physical AGI (tbc)
+    Description:
+    Quan Vuong (Cofounder) and Jost Tobias Springenberg (Research Scientist) from Physical Intelligence discuss the advancements and future of Physical AGI in the Autonomy+Robotics track.
+
+  ------------------------------------
+
+    Session ID: 915934
+    Track: Autonomy+Robotics
+    Speaker: Jyh-Jing Hwang (Research Scientist & TLM )
+    Format: Talk
+    Room: Foothill E: Autonomy + Robotics
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: Teaching Cars to Think: Language Models and Autonomous Vehicles
+    Description:
+    This session explores Waymo's latest research on the End-to-End Multimodal Model for Autonomous Driving (EMMA) and advanced sensor simulation techniques. Jyh-Jing Hwang will demonstrate how multimodal large language models like Gemini could improve autonomous driving through unified end-to-end architectures that process raw sensor data directly into driving decisions.
+    
+    The presentation will showcase EMMA's state-of-the-art performance in trajectory planning, 3D object detection, and road graph understanding, as well as another Drive&Gen research approach to sensor simulation for evaluating an end-to-end motion planning model. Attendees will gain insights into the benefits of co-training across multiple autonomous driving tasks and the potential of controlled video generation for testing under various environmental conditions.
+    
+    More on EMMA here: https://waymo.com/blog/2024/10/introducing-emma
+    
+
+  ------------------------------------
+
+    Session ID: 916103
+    Track: Autonomy+Robotics
+    Speaker: Annika Brundyn (GenAI Architect)
+    Format: Talk
+    Room: Foothill E: Autonomy + Robotics
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: What Is a Humanoid Foundation Model? An Introduction to GR00T N1
+    Description:
+    Foundation models don’t just write or draw anymore—they’re starting to move.
+    
+    GR00T N1 is NVIDIA’s open Vision-Language-Action (VLA) foundation model for humanoid robots. Built with a dual-system architecture, it combines a System 2 module for high-level reasoning with a System 1 module for real-time, fluid motor control. It’s trained end-to-end on a an impressive mix of data—from human videos to robot trajectories to synthetic simulations—and deployed on a full-sized humanoid robot performing bimanual manipulation tasks in the real world.
+    This talk is a high-level, beginner-friendly overview of GR00T N1:
+    - What makes a robot foundation model different from an LLM or vision model
+    - How GR00T’s architecture is inspired by cognitive systems
+    - Why grounding language, vision, and action together unlocks new generalist capabilities
+    
+    If you’ve ever wondered how large-scale AI is crossing over into the physical world, this session will get you up to speed—no robotics PhD required.
+
+  ------------------------------------
+
+    Session ID: 916103
+    Track: Autonomy+Robotics
+    Speaker: Aastha Jhunjhunwala (Solutions Architect)
+    Format: Talk
+    Room: Foothill E: Autonomy + Robotics
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: What Is a Humanoid Foundation Model? An Introduction to GR00T N1
+    Description:
+    Foundation models don’t just write or draw anymore—they’re starting to move.
+    
+    GR00T N1 is NVIDIA’s open Vision-Language-Action (VLA) foundation model for humanoid robots. Built with a dual-system architecture, it combines a System 2 module for high-level reasoning with a System 1 module for real-time, fluid motor control. It’s trained end-to-end on a an impressive mix of data—from human videos to robot trajectories to synthetic simulations—and deployed on a full-sized humanoid robot performing bimanual manipulation tasks in the real world.
+    This talk is a high-level, beginner-friendly overview of GR00T N1:
+    - What makes a robot foundation model different from an LLM or vision model
+    - How GR00T’s architecture is inspired by cognitive systems
+    - Why grounding language, vision, and action together unlocks new generalist capabilities
+    
+    If you’ve ever wondered how large-scale AI is crossing over into the physical world, this session will get you up to speed—no robotics PhD required.
+
+  ------------------------------------
+
+    Session ID: 945538
+    Track: Autonomy+Robotics
+    Speaker: Nikhil Abraham (CEO)
+    Format: Talk
+    Room: Foothill E: Autonomy + Robotics
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: General purpose robots as professional Chefs
+    Description:
+    How we converted a bimanual robot into a professional chef that works in novel kitchens and learn new recipes from a single demonstration.
+
+  ------------------------------------
+
+    Session ID: 916140
+    Track: Autonomy+Robotics
+    Speaker: Stefania Druga (AI Research Scientist )
+    Format: Talk
+    Room: Foothill E: Autonomy + Robotics
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Real-time Experiments with an AI Co-Scientist
+    Description:
+    The sheer volume of data and complexity of modern scientific challenges necessitate tools that go beyond mere analysis. The vision of an "AI Co-scientist" – a true collaborative partner in the lab – requires sophisticated engineering to bridge the gap between powerful AI reasoning and the dynamic reality of physical experiments. This talk dives into the engineering required to build robust AI Co-scientists for hands-on research. We will explore scalable architectures, such as multi-agent systems leveraging foundation models like Gemini for complex reasoning, hypothesis refinement (inspired by the "generate, debate, evolve" paradigm described in recent AI Co-scientist research), and intelligent tool use. The core focus will be on the engineering challenges and solutions for integrating diverse, real-time empirical data streams – visual data from cameras, quantitative readings from sensors, positional feedback from actuators, and instrument outputs – directly into the AI's reasoning loop. I will illustrate this with concrete, technically detailed examples in chemistry (adaptive reaction monitoring), robotics (vision-guided assembly with SO Arm 100 and LeRobot library), and synthetic biology (real-time bacterial growth monitoring & interpretation). We'll discuss engineering strategies for handling data heterogeneity, latency, noise, and enabling the AI to interpret, correlate, and act upon live experimental feedback. Finally, we will touch upon how thoughtful engineering of these AI Co-scientists can contribute to democratizing access to advanced scientific capabilities.
+    
+
+
+
+======================================================================
+---  Track: DESIGN ENGINEERING (TBA) ---
+======================================================================
+
+    Session ID: 915428
+    Track: Design Engineering
+    Speaker: Maximillian Piras (Product Designer)
+    Format: Online Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: The Bitter Layout or: How I Learned to Love the Model Picker
+    Description:
+    Are conversational interfaces the future or, as many designers have suggested, a lazy solution that is bottlenecking AI-HCI? Despite well-documented usability issues, the design of many AI applications defaults to an input field, turn-by-turn flow, and an endless model picker — I call this “The Bitter Layout”.
+    
+    In this talk, we’ll explore how Clay Christensen’s theory of commoditization from the early PC industry can explain why scaling laws require AI interfaces to remain modular until models fully commoditize. The killer feature of conversational interfaces may not be that they’re natural, but that they’re conformable. Learn how to evolve interfaces as inference scales, spot shifts in the basis of competition, and stop worrying about the next model update steamrolling your design decisions.
+
+  ------------------------------------
+
+    Session ID: 914027
+    Track: Design Engineering
+    Speaker: Victor Dibia (Principal Research Engineer)
+    Format: Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: UX Design Principles for (Semi) Autonomous Multi-Agent Systems
+    Description:
+    Autonomous or semi-autonomous multi-agent systems (MAS) involve exponentially complex configurations (system config, agent configs, task management and delegation, etc.). These present unique interface design challenges for both developer tooling and end-user experiences.
+    In this session, I'll explore UX design principles for multi-agent systems, addressing critical questions: What is the true configuration space for autonomous MAS? How can users arrive at the correct mental model of an MAS's capabilities, if at all? How can we improve trust and safety through techniques like cost-aware action delegation? What makes agent actions observable? How do we enable seamless interruptibility? Attendees will gain actionable insights to create more transparent, trustworthy, and user-centered multi-agent applications, illustrated through real-world implementations in AutoGen Studio - a low code developer tool built on AutoGen (44k stars on GitHub, MIT license) and similar tools.
+
+  ------------------------------------
+
+    Session ID: 914361
+    Track: Design Engineering
+    Speaker: Shafik Quoraishee (AI Game Engineer)
+    Format: Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: AI and Game Theory: A Case Study on NYT's Connections
+    Description:
+    This session will examine the interplay between human intuition and artificial intelligence in puzzle-solving, using the popular New York Times Connections game as a practical case study.
+    
+    We'll investigate how gameplay can be systematically evaluated through AI algorithms, exploring machine learning strategies such as clustering, semantic mapping, and natural language processing.
+    
+    Attendees will gain insights into building AI-driven puzzle solvers, learn methods for quantitatively assessing gameplay complexity, and discuss the potential impacts of AI on puzzle game design and player engagement.
+
+  ------------------------------------
+
+    Session ID: 915389
+    Track: Design Engineering
+    Speaker: Christopher Chedeau (Frenchy Front-end Engineer)
+    Format: Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: AI and Human Whiteboarding Partnership
+    Description:
+    Covid sent everybody home and created the space of virtual whiteboards. At first the experience reused the physical constraints but soon it became better than a physical whiteboard thanks to using virtual native concepts like copy-paste and using keyboard input.
+    The next step in this evolution is to integrate AI into the workflow. We've tried a lot of things with Excalidraw and ended up landing on turning prompt into diagram. Come to the talk to understand how it fits into the workflow and how we implemented it.
+
+  ------------------------------------
+
+    Session ID: 916050
+    Track: Design Engineering
+    Speaker: Ben Holmes (Product Engineer at Warp)
+    Format: Online Talk
+    Session Title: ChatGPT is poorly designed. So I fixed it
+    Description:
+    Let's fix ChatGPT's greatest design sins. We'll design and build a working app that makes ChatGPT multi-modal and multi-model. And no, you don't need to know what those words mean to use it.
+    
+    Download the source code: https://github.com/bholmesdev/fixgpt
+    
+    References from this video:
+    - Try https://warp.dev to vibe code your own solution
+    - Watch Scott and Mark's podcast episode, "how to not ship the org chart:" https://www.youtube.com/watch?v=Z1yYcUFzH2A
+    - Read "Why is AI marketing so, so bad?" by Evan Armstrong at The Leverage: https://www.gettheleverage.com/p/why-is-ai-marketing-so-so-bad
+    -
+    
+
+  ------------------------------------
+
+    Session ID: 933474
+    Track: Design Engineering
+    Speaker: Kenneth DuMez (DevRel Lead, Graphite)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: Cattle, not genies: building AI agents from first principles
+    Description:
+    As magical as they may seem, AI agents should be treated like any other software system. This talk will cover the best practices in designing and building AI systems including observability, security hardening, and proper UX.
+
+  ------------------------------------
+
+    Session ID: 914845
+    Track: Design Engineering
+    Speaker: John Pham (Head of Design )
+    Format: Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Good design hasn’t changed with AI
+    Description:
+    Bad designs are still bad. AI doesn’t make it good. The novelty of AI makes the bad things tolerable, for a short time. Building great designs and experiences with AI have the same first principles pre-AI. When people use software, they want it to feel responsive, safe, accessible and delightful. We’ll go over the big and small details that goes into software that people want to use, not forced to use.
+
+  ------------------------------------
+
+    Session ID: 915783
+    Track: Design Engineering
+    Speaker: Craig Wattrus (AI Design Engineer)
+    Format: Talk
+    Room: Foothill G 1&2: Design Engineering
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Form factors for your new AI coworkers
+    Description:
+    Designing user experiences for AI means moving beyond traditional interfaces.
+    
+    Designers are grappling with how to create intuitive and effective interactions for these new AI capabilities, while growing their practice to include philosophy, ethics and coding.
+    
+    What if AI interactions could be reimagined as new 'coworkers'? This talk explores AI systems as your new coworkers. Covering novel UX patterns we’ve implemented and are researching at Flatfile as well as a state of the union on emergent patterns we’re seeing and using from the industry.
+    
+    Attendees will get a peek into explorations into AI Cursors, observation and mimicry, forward-leaning chat paradigms, the 'instruct for transform' model, and the concept of 'human as tool' within AI interactions. We will discuss both work thats in production today at some of our biggest customers as well as thought-provoking demos, offering a vision for the future of AI UX.
+
+
+
+======================================================================
+---  Track: EVALS (June 5) ---
+======================================================================
+
+    Session ID: 936564
+    Track: Evals
+    Speaker: Micah Hill-Smith (CEO)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:00 PM
+    Session Title: Trends Across the AI Frontier
+    Description:
+    The entire AI stack is developing faster than ever - from chips to infrastructure to models. How do you sort the signal from the noise? Artificial Analysis an independent benchmarking and insights company dedicated to helping developers and companies pick the right models and technologies for building applications. This talk will walk through the state of the frontier across the AI stack.
+
+  ------------------------------------
+
+    Session ID: 939130
+    Track: Evals
+    Speaker: Ankur Goyal (CEO, Braintrust)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: [Evals Keynote] tba
+    Description:
+    tbc
+
+  ------------------------------------
+
+    Session ID: 943899
+    Track: Evals
+    Speaker: Ankur Goyal (CEO, Braintrust)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:20 PM
+    Session Title: Evals Closing Keynote
+    Description:
+    The final word on Evals
+
+  ------------------------------------
+
+    Session ID: 915684
+    Track: Evals
+    Speaker: Taylor Jordan Smith (Senior Developer Advocate)
+    Format: Workshop
+    Room: Nobhill A&B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Beyond Benchmarks: Strategies for Evaluating LLMs in Production
+    Description:
+    Accuracy scores and leaderboard metrics look impressive—but production-grade AI requires evals that reflect real-world performance, reliability, and user happiness. Traditional benchmarks rarely help you understand how your LLM will perform when embedded in complex workflows or agentic systems. How can you realistically and adequately measure reasoning quality, agent consistency, MCP integration, and user-focused outcomes?
+    
+    In this practical, example-driven talk, we'll go beyond standard benchmarks and dive into tangible evaluation strategies using various open-source frameworks like GuideLLM and lm-eval-harness. You'll see concrete examples of how to create custom eval suites tailored to your use case, integrate human-in-the-loop feedback effectively, and implement agent reliability checks that reflect production conditions. Walk away with actionable insights and best practices for evaluating and improving your LLMs, ensuring they meet real-world expectations—not just leaderboard positions!
+
+  ------------------------------------
+
+    Session ID: 936156
+    Track: Evals
+    Speaker: Omar Khattab (Databricks Research Scientist)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: On Engineering AI Systems that Endure The Bitter Lesson
+    Description:
+    Will discuss the principles for building AI software that underpin DSPy, highlighting the differences between conventional prompting (or finetuning/RL) versus the design and programming of truly modular AI systems.
+
+  ------------------------------------
+
+    Session ID: 930540
+    Track: Evals
+    Speaker: Ilan Bigio (Developer Experience)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Model-Maxxing: RFT, DPO, SFT (Fine-tuning with OpenAI)
+    Description:
+    Covering all forms of fine-tuning and prompt engineering, like SFT, DPO, RFT, prompt engineering / optimization, and agent scaffolding.
+
+  ------------------------------------
+
+    Session ID: 942803
+    Track: Evals
+    Speaker: Doug Guthrie (Solutions Engineer, Braintrust)
+    Format: Workshop
+    Room: Golden Gate Ballroom C: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Mastering AI Evaluation: From Playground to Production with Braintrust
+    Description:
+    This hands-on workshop will guide participants through the complete AI evaluation lifecycle using Braintrust, from initial prompt testing to production monitoring. Attendees will learn to build evaluation frameworks that ensure their AI applications perform reliably in real-world scenarios. Topics covered include both offline and online evaluation strategies, logging and feedback systems, and human review processes.
+
+  ------------------------------------
+
+    Session ID: 933603
+    Track: Evals
+    Speaker: Suman Debnath (Principal Developer Advocate, AI/ML, AWS)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: Introducing Strands Agents, an Open Source AI Agents SDK
+    Description:
+    Building AI agents used to require complex orchestration, extensive scaffolding, and months of tuning. With Strands Agents, an open source SDK from AWS. You can now build, test, and deploy intelligent agents in just a few lines of code. This session introduces the model-driven approach behind Strands, where a model, a prompt, and a set of tools are all you need to create powerful, production-ready agents. Learn how Strands leverages modern foundation models to handle reasoning, tool use, and reflection, reducing development time from months to days.
+
+  ------------------------------------
+
+    Session ID: 933676
+    Track: Evals
+    Speaker: Samuel Colvin (Founder of Pydantic)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:00 PM
+    Session Title: Human-seeded Evals
+    Description:
+    In this talk I'll introduce the concept of Human-seeded Evals, explain the principle and demo them with Pydantic Logfire.
+
+  ------------------------------------
+
+    Session ID: 933712
+    Track: Evals
+    Speaker: Nir Gazit (CEO @ Traceloop, OpenLLMetry co-creator)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Prompt Engineering is Dead
+    Description:
+    Manual prompt crafting doesn't scale. In this session, we'll explore how to replace it with a test-driven, automated approach. You'll see how to define output evaluators, write minimal prompts, and let agents iterate toward optimal performance—all without manual tweaking. If you're still hand-tuning prompts, you're doing it wrong.
+
+  ------------------------------------
+
+    Session ID: 916104
+    Track: Evals
+    Speaker: Jeff Huber (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: How to look at your data; what to look for, how to measure
+    Description:
+    By the end of this talk, you'll understand what it takes to apply clustering techniques and data analysis to understand what is the valuable work that your AI application is doing through analyzing conversation histories and how to create generative evals to benchmark your newly discovered superpowers.
+
+  ------------------------------------
+
+    Session ID: 936133
+    Track: Evals
+    Speaker: Rafal Wilinski (AI Agents Lead)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Turning Fails into Features: Zapier’s Hard-Won Eval Lessons
+    Description:
+    Every agent failure can be a roadmap to your next breakthrough. This talk reveals how Zapier's evaluation system transforms frustrating user experiences into targeted improvements, creating a data flywheel that continuously strengthens our agents. You'll learn practical approaches for building the data flywheel, detecting implicit feedback signals, building solid evals, prioritizing metrics that actually matter, and why your most reliable evals might secretly be sabotaging your performance.
+
+  ------------------------------------
+
+    Session ID: 942167
+    Track: Evals
+    Speaker: Manu Goyal (Founding Engineer, Braintrust)
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 09:45 AM
+    Session Title: Why should anyone care about Evals?
+    Description:
+    An introduction to the evals track
+
+  ------------------------------------
+
+    Session ID: 916104
+    Track: Evals
+    Speaker: Jason Liu (Principal)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: How to look at your data; what to look for, how to measure
+    Description:
+    By the end of this talk, you'll understand what it takes to apply clustering techniques and data analysis to understand what is the valuable work that your AI application is doing through analyzing conversation histories and how to create generative evals to benchmark your newly discovered superpowers.
+
+  ------------------------------------
+
+    Session ID: 939231
+    Track: Evals
+    Speaker: Ido Pesok (AI Engineer, v0)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Evals Are Not Unit Tests
+    Description:
+    How to think about evaluating a non-deterministic system — and how to actually succeed at it.
+
+  ------------------------------------
+
+    Session ID: 936564
+    Track: Evals
+    Speaker: George Cameron (CPO)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:00 PM
+    Session Title: Trends Across the AI Frontier
+    Description:
+    The entire AI stack is developing faster than ever - from chips to infrastructure to models. How do you sort the signal from the noise? Artificial Analysis an independent benchmarking and insights company dedicated to helping developers and companies pick the right models and technologies for building applications. This talk will walk through the state of the frontier across the AI stack.
+
+  ------------------------------------
+
+    Session ID: 915059
+    Track: Evals
+    Speaker: John Dickerson (CEO, Mozilla AI)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: 2025 is the Year of Evals!  Just like 2024, and 2023, and …
+    Description:
+    AI is getting deployed without guardrails, without governance, without due diligence.  Surely this is the year we’ll see a Fortune 500 CEO fired because of a preventable AI incident.  Surely this is the year we’ll see enterprises wake up to pre-deployment evaluation and post-deployment monitoring being an urgent need.  This story hasn’t changed for a decade, but surely this is the year it will.
+    
+    In this talk, I’ll cover what enterprise-level AI/ML evaluation has looked like for the last decade - what’s changed, what hasn’t, what sells, what doesn’t, and where I see things going from here on out.  Evaluation matters - we all know this - but using my experience in the trenches over the last decade or so I hope to bridge the gap between what practitioners need and what the C-suite pays for in the space of AI evaluations.
+    
+
+  ------------------------------------
+
+    Session ID: 942858
+    Track: Evals
+    Speaker: Carlos  Esteban (Solutions Engineer, Braintrust)
+    Format: Workshop
+    Room: Golden Gate Ballroom C: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: How to build world-class AI products (featuring Sarah Sachs, AI lead @ Notion)
+    Description:
+    Join us for a hands-on workshop where you'll learn practical strategies to evaluate AI applications throughout their lifecycle—from initial testing of prompts to ongoing monitoring in production. We’re excited to host Sarah Sachs, AI Lead at Notion, who will share insights into how Notion built their acclaimed Notion AI.
+
+  ------------------------------------
+
+    Session ID: 907684
+    Track: Evals
+    Speaker: David Karam (CEO)
+    Format: Workshop
+    Room: Foothill G1&2: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Solving for the hardest Eval challenge: Building Metrics that actually work
+    Description:
+    One of the biggest challenges in building evals you can trust is building metrics that reliably measure goodness in your application; metrics that are highly accurate, rapid fast, and tunable to ground truth rater and user behavior. This workshop is inspired by decades of AI and machine learning development in Google Search, reinvented for the modern LLM stack by the Pi team over the past year.
+    
+    In this workshop you will learn how to:
+    1) Brainstorm and design custom metrics tailored to your specific application needs.
+    2) Identify which types of signals (natural language, code, other models) work best for your use case through rapid trial and error.
+    3) Combine & calibrate your metrics against ground truth data using real examples from your domain.
+    4) Use simple tools like Google Sheets for visualizing and analyzing your inputs and outputs with those metrics.
+    5) Integrate your scoring models into both online workflows like agent control and offline ones like model comparison and training evaluation.
+    
+    
+
+  ------------------------------------
+
+    Session ID: 936133
+    Track: Evals
+    Speaker: Vitor Balocco (Staff AI Engineer)
+    Format: Talk
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Turning Fails into Features: Zapier’s Hard-Won Eval Lessons
+    Description:
+    Every agent failure can be a roadmap to your next breakthrough. This talk reveals how Zapier's evaluation system transforms frustrating user experiences into targeted improvements, creating a data flywheel that continuously strengthens our agents. You'll learn practical approaches for building the data flywheel, detecting implicit feedback signals, building solid evals, prioritizing metrics that actually matter, and why your most reliable evals might secretly be sabotaging your performance.
+
+  ------------------------------------
+
+    Session ID: 933702
+    Track: Evals
+    Speaker: Mikiko Bazeley (Staff Developer Advocate, MongoDB)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Smarter Together: Designing Multi-Agent Systems with Shared, Evolving Memory
+    Description:
+    In today’s most advanced AI systems, intelligence is no longer confined to a single model or agent—it emerges from coordination. But coordination requires memory: short-term, long-term, and shared. In this talk, we’ll break down how agent systems can store, retrieve, and evolve shared memory to become smarter over time. You'll learn what it takes to architect these continuously learning systems, how to track and improve memory quality, and why robust, flexible infrastructure is the foundation of it all. Stick around to see how this works in practice—live.
+
+  ------------------------------------
+
+    Session ID: 915826
+    Track: Evals
+    Speaker: Nathan Sobo (CEO & Co-founder of Zed, co-creator of Atom and Electron)
+    Format: Online Talk
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: CI in the Era of AI: From Unit Tests to Stochastic Evals
+    Description:
+    Software engineers have long understood that high-quality code requires comprehensive automated testing. For decades, our industry has relied on deterministic tests with clear pass/fail outcomes to ensure reliability.
+    
+    High-quality software depends on automated testing. That's certainly true at Zed, where we're building a next-generation native IDE in Rust. Zed runs at 120 frames per second, but it would also crash once a second if we didn't maintain and run a comprehensive suite of unit tests on every change.
+    
+    But what happens when AI enters the equation?
+    
+    In this talk, we'll explore how continuous integration evolves when working with AI components. "Evals" - parlance from the machine learning field - are fundamentally a continuation of the software testing tradition, but with a critical difference: they're inherently stochastic.
+    
+    Zed's traditional CI goes to extreme lengths to eliminate non-determinism, as nobody likes having their pull requests blocked by flaky builds. We've even fully simulated network interactions with a deterministic random scheduler. AI components, however, forced us to confront a fundamental paradigm shift—uncertainty isn't a bug but an intrinsic feature of these systems, compelling us to embrace what we couldn't avoid.
+    
+    We'll share our journey of reconceptualizing evals as "stochastic unit tests" - still verifying system behavior, but without binary pass/fail grades.
+    
+    We'll discuss practical approaches to:
+    - Thoughtfully building test suites for AI components
+    - Shifting from red/green outcomes to "shades of gray"
+    - Replacing build gates with trend analysis and performance monitoring
+    - Maintaining engineering confidence despite statistical variance
+    
+    Whether you're incorporating AI into existing systems or building new AI-powered tools, this talk will provide practical insights into maintaining quality when determinism gives way to probability.
+
+
+
+======================================================================
+---  Track: GENERATIVE MEDIA (June 5) ---
+======================================================================
+
+    Session ID: 910197
+    Track: Generative Media
+    Speaker: Kelvin Ma (Software Engineer )
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Magic Editor Under the Hood: Weaving Generative AI into a Billion-User App
+    Description:
+    Go behind the scenes of Google Photos' Magic Editor. Explore the engineering feats required to integrate complex CV and cutting-edge generative AI models into a seamless mobile experience. We'll discuss optimizing massive models for latency/size, the crucial interplay with graphics rendering (OpenGL/Halide), and the practicalities of turning research concepts into polished features people actually use.
+
+  ------------------------------------
+
+    Session ID: 943296
+    Track: Generative Media
+    Speaker: Zeke Sikelianos (Founding Designer)
+    Format: Workshop
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Small, sharp tools in the era of generative AI
+    Description:
+    Replicate makes it easy to run thousands of AI models in the cloud without any machine learning expertise. In this session, we'll show how to make those models available to LLMs as tools that can be combined and chained together, and things start to get really interesting.
+
+  ------------------------------------
+
+    Session ID: 910158
+    Track: Generative Media
+    Speaker: Gorkem Yurtseven (CTO )
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: The State of Generative Media Today
+    Description:
+    Generative AI is reshaping the creative landscape, enabling the production of images, audio, and video with unprecedented speed and sophistication. This session offers an in-depth exploration of the current state of generative media, highlighting cutting-edge models, platforms, and tools that are transforming the industry.
+
+  ------------------------------------
+
+    Session ID: 914081
+    Track: Generative Media
+    Speaker: Keegan McCallum (Head of ML infrastructure at Luma AI)
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: General Intelligence is Multimodal
+    Description:
+    Talking about Luma AI, our mission, and how our ML infrastructure enables SOTA multimodal model development
+
+  ------------------------------------
+
+    Session ID: 943701
+    Track: Generative Media
+    Speaker: Paige Bailey (Engineering Lead - Developer Relations @ Google DeepMind)
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Veo 3 for developers
+    Description:
+    This talk will briefly trace the history of video generation models before diving into Veo 3, Google DeepMind's latest state-of-the-art model that marks a significant leap by generating video with synchronized audio—including dialogue, sound effects, and music—all from text and image prompts. We'll show how it can understanding intricate details, maintain coherence over longer sequences, and simulate realistic physics and camera movements.
+    
+    For developers, Veo 3, accessible via Vertex AI (preview), unlocks many new capabilities. We'll discuss how its advanced capabilities, such as semantic context rendering and cinematic control, can empower innovation in filmmaking, game development, education, and more. This session will cover how developers can integrate Veo 3 into their workflows, or test it out today in the Gemini App, Flow, and via the Gemini APIs on Google Cloud.
+
+  ------------------------------------
+
+    Session ID: 947929
+    Track: Generative Media
+    Speaker: Sharif Shameem (Lexica Founder)
+    Format: Talk
+    Room: Foothill F: Generative Media
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: Good demos are important
+    Description:
+    Creating and sharing demos is the easiest way to influence the future. It gets people to think about what's possible. A good tech demo doesn't have to be fully fleshed out. It doesn't even have to be fully functional. The purpose of a demo is to inspire. A good demo makes you feel like someone jumped into the future and pulled back an idea to the present.
+
+  ------------------------------------
+
+    Session ID: 933493
+    Track: Generative Media
+    Speaker: Chad Bailey (Senior Voice Bots Engineer, Daily)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 10:40 AM
+    Session Title: Realtime conversational video with Pipecat and Tavus
+    Description:
+    Tavus shipped the world's first realtime video avatar platform last year. Developers use Tavus' conversational video APIs to create education, social, and customer support agents. The Tavus team built their innovative product using the Pipecat open source framework and Daily's global WebRTC infrastructure. Join us for a technical deep dive into conversational video.
+
+  ------------------------------------
+
+    Session ID: 933493
+    Track: Generative Media
+    Speaker: Brian Johnson (Staff Engineer, Tavus)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 10:40 AM
+    Session Title: Realtime conversational video with Pipecat and Tavus
+    Description:
+    Tavus shipped the world's first realtime video avatar platform last year. Developers use Tavus' conversational video APIs to create education, social, and customer support agents. The Tavus team built their innovative product using the Pipecat open source framework and Daily's global WebRTC infrastructure. Join us for a technical deep dive into conversational video.
+
+  ------------------------------------
+
+    Session ID: 947560
+    Track: Generative Media
+    Speaker: Comfy Anonymous (Original creator of ComfyUI)
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: ComfyUI
+    Description:
+    Quick introduction to ComfyUI and what's new followed by a QA session.
+
+
+
+======================================================================
+---  Track: GRAPHRAG (June 4) ---
+======================================================================
+
+    Session ID: 932429
+    Track: GraphRAG
+    Speaker: Ben Kus (CTO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Building an Agentic Platform
+    Description:
+    Explore the technical evolution of metadata extraction at Box and how it shaped the foundation of our AI platform. We’ll walk through our transition to an agentic-first design—why it was necessary, how we approached the rebuild, challenges we encountered along the way, and the advantages it unlocked.
+
+  ------------------------------------
+
+    Session ID: 915992
+    Track: GraphRAG
+    Speaker: Mitesh Patel (Developer Advocate Manager)
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: HybridRAG: A Fusion of Graph and Vector Retrieval to Enhance Data Interpretation
+    Description:
+    Interpreting complex information from unstructured text data poses significant challenges to Large Language Models (LLM), with difficulties often arising from specialized terminology and the multifaceted relationships between entities in document architectures. Conventional Retrieval Augmented Generation (RAG) methods face limitations in capturing these nuanced interactions, leading to suboptimal performance. In our talk, we introduce a novel approach integrating Knowledge Graph-based RAG (GraphRAG) with VectorRAG, designed to refine question-answering (Q&A) systems for more effective information extraction from complex texts. Our approach employs a dual retrieval strategy that harnesses both knowledge graphs and vector databases, enabling the generation of precise and contextually appropriate answers, thereby setting a new standard for LLMs in processing sophisticated data.
+
+  ------------------------------------
+
+    Session ID: 933671
+    Track: GraphRAG
+    Speaker: Zach Blumenfeld (AI/ML Product Specialist)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agentic GraphRAG: Simplifying Retrieval Across Structured & Unstructured Data
+    Description:
+    Agentic workflows often become complex, brittle, and hard to maintain when they need to retrieve and reason across both structured data (typically requiring precise query execution) and unstructured data (commonly handled via vector search in RAG). In this talk, we’ll explore how mapping key information into a knowledge graph can simplify these workflows and improve retrieval quality. You’ll learn core concepts behind GraphRAG, how to integrate it into agent tools, and get access to end-to-end code examples so you can start building right away.
+
+  ------------------------------------
+
+    Session ID: 921229
+    Track: GraphRAG
+    Speaker: Andreas Kollegger (GenAI Lead)
+    Format: Workshop
+    Room: Golden Gate Ballroom C: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Graph Intelligence: Enhance Reasoning and Retrieval Using Graph Analytics
+    Description:
+    Advanced GraphRAG techniques apply graph ML and algorithms, wrapped into tidy notebooks.
+
+  ------------------------------------
+
+    Session ID: 933714
+    Track: GraphRAG
+    Speaker: Zach Blumenfeld (Graph Data Science & AI Specialist, Neo4j)
+    Format: Workshop
+    Room: Golden Gate Ballroom C: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Intro to GraphRAG
+    Description:
+    Learn the foundations of GraphRAG, starting with knowledge graph construction and then common retrieval patterns.
+
+  ------------------------------------
+
+    Session ID: 915740
+    Track: GraphRAG
+    Speaker: Jesús Barrasa (AI Field CTO)
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Practical GraphRAG - Making LLMs smarter with Knowledge Graphs
+    Description:
+    RAG has become one standard architecture component for GenAI applications to address hallucinations and integrate factual knowledge. While vector search over text is common, knowledge graphs represent a proven advancement by leveraging advanced RAG patterns to access and integrate interconnected factual information, complementing the language skills of LLMs. This talk explores GraphRAG challenges, implementation patterns, and real-world agentic examples with Google's ADK, demonstrating how this approach delivers more trustworthy and explainable GenAI solutions with enhanced reasoning capabilities.
+
+  ------------------------------------
+
+    Session ID: 933646
+    Track: GraphRAG
+    Speaker: Jesús Barrasa (AI Field CTO)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: Why Your Agent’s Brain Needs a Playbook: Practical Wins from Using Ontologies
+    Description:
+    You're trying to guide how your agents think and act. Code-orchestrated workflows are too rigid, but LLMs charting their own course feel too chaotic. When you need a middle ground, it’s time to reach for the secret weapon: ontologies. These graph-shaped fragments of actionable knowledge can fill in critical gaps.
+    
+    In this talk, we’ll explore together how ontologies bring structure, semantics, and sanity to GenAI-powered applications. You’ll learn when they’re useful, how to apply them, and what kinds of problems they help solve. Through practical examples, we’ll show how ontologies (1) guide knowledge graph construction, (2) add a semantic layer for more efficient and accurate retrieval (GraphRAG), and (3) encode domain logic you don’t want to leave up to the LLM.
+
+  ------------------------------------
+
+    Session ID: 914548
+    Track: GraphRAG
+    Speaker: Chin Keong Lam (AI Engineer & Co-Founder )
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Wisdom Discovery at Scale: Code Less KAG with n8n MultiAI Agents
+    Description:
+    "Wisdom Discovery at Scale: Code Less KAG with n8n MultiAI Agents"
+
+  ------------------------------------
+
+    Session ID: 933706
+    Track: GraphRAG
+    Speaker: Thibaut  Gourdel (Senior Technical Product Marketing Manager, MongoDB)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 11:00 AM
+    Session Title: GraphRAG: Integrating LLMs with Knowledge Graphs
+    Description:
+    While traditional RAG is effective, it can struggle with complex relationships and reasoning across large knowledge bases. GraphRAG, an advanced variant, addresses these challenges by leveraging knowledge graphs to enable deeper understanding and improved response accuracy. Learn how LLMs extract key entities and relationships from your data to construct a graph structure, and how the system uses graph traversal to find related entities and enrich prompts. Stay for a live demo showcasing these concepts in action.
+
+  ------------------------------------
+
+    Session ID: 915740
+    Track: GraphRAG
+    Speaker: Michael Hunger (VP of Product Innovation)
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Practical GraphRAG - Making LLMs smarter with Knowledge Graphs
+    Description:
+    RAG has become one standard architecture component for GenAI applications to address hallucinations and integrate factual knowledge. While vector search over text is common, knowledge graphs represent a proven advancement by leveraging advanced RAG patterns to access and integrate interconnected factual information, complementing the language skills of LLMs. This talk explores GraphRAG challenges, implementation patterns, and real-world agentic examples with Google's ADK, demonstrating how this approach delivers more trustworthy and explainable GenAI solutions with enhanced reasoning capabilities.
+
+  ------------------------------------
+
+    Session ID: 916063
+    Track: GraphRAG
+    Speaker: Ola  Mabadeje (Product Leader)
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Multi-Agent AI and Network Knowledge Graphs for Change Management and Network Testing
+    Description:
+    Traditional ticketing and testing workflows for change management and network operations often operate independently and lack critical real-world context and adaptive decision making capabilities. This fragmented approach results in delayed resolutions, repeated incidents, escalations, and dissatisfied stakeholders.
+    
+    This session explores an innovative solution leveraging the synergy of natural language processing from IT Service Management (ITSM) systems, Multi-agent reasoning, and dynamic context derived from live knowledge network graphs. Attendees will gain insights into an end-to-end architecture where natural language intents from ITSM tickets seamlessly integrate with experts AI agents for complex workflow tasks, supported by continuous network knowledge graph ingestion pipelines.
+    
+    Through a detailed production case study, we will demonstrate how Agentic reasoning combined with dynamic network knowledge graph contexts significantly improves critical validation and workflow interactions. The showcased results will highlight dramatic improvements in ticket resolution efficiency, accuracy of network testing, and overall execution quality, delivering tangible value to both technical teams and business stakeholders.
+
+  ------------------------------------
+
+    Session ID: 915023
+    Track: GraphRAG
+    Speaker: Daniel Chalef (Founder, Zep AI)
+    Format: Online Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Stop Using RAG as Memory
+    Description:
+    RAG is great for static knowledge retrieval—but terrible at memory. Vectorstore-based systems sold as memory lack relational and temporal awareness, leading agents astray with outdated or ambiguous information.
+    
+    Discover how temporally-aware knowledge graphs—built by the open-source Graphiti framework—solve these limitations. You’ll learn practical strategies to maintain precise, context-rich memory, enabling agents to reason accurately about historical context and knowledge provenance.
+
+  ------------------------------------
+
+    Session ID: 912811
+    Track: GraphRAG
+    Speaker: Sam Julien (Director of Developer Relations )
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: When Vectors Break Down: Graph-Based RAG for Dense Enterprise Knowledge
+    Description:
+    Enterprise knowledge bases are filled with "dense mapping," thousands of documents where similar terms appear repeatedly, causing traditional vector retrieval to return the wrong version or irrelevant information. When our customers kept hitting this wall with their RAG systems, we knew we needed a fundamentally different approach.
+    
+    In this talk, I'll share Writer's journey developing a graph-based RAG architecture that achieved 86.31% accuracy on the RobustQA benchmark while maintaining sub-second response times, significantly outperforming vector approaches.
+    
+    I'll survey the key techniques behind this performance leap and why graph-based approaches excel with complex enterprise information structures like product documentation, financial documents, and technical specifications that challenge traditional RAG systems. You'll learn about using specialized LLMs to build semantic relationships, how compression techniques efficiently handle concentrated enterprise data patterns, and how infusing key data points in the memory layer of the LLM lowers hallucination.
+    
+    The presentation will provide practical insights into identifying when graph-based approaches make sense for your organization's specific data challenges, helping you make informed architectural decisions for your next enterprise RAG system.
+
+  ------------------------------------
+
+    Session ID: 921229
+    Track: GraphRAG
+    Speaker: Alison Cossette (Data Science Strategist, Advocate, Educator)
+    Format: Workshop
+    Room: Golden Gate Ballroom C: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Graph Intelligence: Enhance Reasoning and Retrieval Using Graph Analytics
+    Description:
+    Advanced GraphRAG techniques apply graph ML and algorithms, wrapped into tidy notebooks.
+
+  ------------------------------------
+
+    Session ID: 933549
+    Track: GraphRAG
+    Speaker: Stephen Chin (VP of Developer Relations)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 01:30 PM
+    Session Title: Agentic GraphRAG: AI’s Logical Edge
+    Description:
+    AI models are getting tasked to do increasingly complex and industry specific tasks where different retrieval approaches provide distinct advantages in accuracy, explainability, and cost to execute. GraphRAG retrieval models have become a powerful tool to solve domain specific problems where answers require logical reasoning and correlation that can be aided by graph relationships and proximity algorithms. We will demonstrate how an agent architecture combining RAG and GraphRAG retrieval patterns can bridge the gap in data analysis, strategic planning, and retrieval to solve complex domain specific problems.
+
+  ------------------------------------
+
+    Session ID: 915740
+    Track: GraphRAG
+    Speaker: Stephen Chin (VP of Developer Relations)
+    Format: Talk
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Practical GraphRAG - Making LLMs smarter with Knowledge Graphs
+    Description:
+    RAG has become one standard architecture component for GenAI applications to address hallucinations and integrate factual knowledge. While vector search over text is common, knowledge graphs represent a proven advancement by leveraging advanced RAG patterns to access and integrate interconnected factual information, complementing the language skills of LLMs. This talk explores GraphRAG challenges, implementation patterns, and real-world agentic examples with Google's ADK, demonstrating how this approach delivers more trustworthy and explainable GenAI solutions with enhanced reasoning capabilities.
+
+  ------------------------------------
+
+    Session ID: 916143
+    Track: GraphRAG
+    Speaker: Mark Bain (Founder & Research Scientist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Make Your AI Agents Remember What They Do!
+    Description:
+    Are you ready to give your AI agents a memory upgrade?
+    Join us for a hands-on, fast-paced workshop where we explore how memory can transform your agents.
+    
+    What You'll Do:
+    Set Up Leading Memory Solutions: Get practical, side-by-side experience with open-source tools including AIUS, Cognee, LangMem, MemGPT, Mem0, and Zep.
+    
+    Explore Memory Types: Learn the theory behind agent memory, including long-term, short-term, episodic, semantic, and other memory types.
+    
+    Run Experiments: Test how memory improves recall, contextual awareness, and reasoning in autonomous agents.
+    
+    Compare Implementations: Get a snapshot of how different solutions implement memory—what’s built-in, what’s flexible, and what’s experimental.
+    
+    Whether you’re working on AI copilots, agentic workflows, or research prototypes—this workshop will help you embed real memory into your AI stack.
+
+  ------------------------------------
+
+    Session ID: 900332
+    Track: GraphRAG
+    Speaker: Tom Smoker (Technical Founder )
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Beyond Documents: Implementing Knowledge Graphs in Legal Agents
+    Description:
+    Structured Representations are pretty important in the law, where the relationships between clauses, documents, entities, and multiple parties matter. Structured Representation means Structured Context Injection. Better Context, Less Hallucinations. We walk through a couple of case studies of systems that we’ve built in production for legal use-cases - from recursive contractual clause retrieval, to HITL legal reasoning news agents.
+    
+    You'll gain insights into how structured representations significantly improve the effectiveness and reliability of legal agents.
+    
+
+
+
+======================================================================
+---  Track: INFRASTRUCTURE (June 4) ---
+======================================================================
+
+    Session ID: 916189
+    Track: Infrastructure
+    Speaker: Jesse Han (Founder)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 10:10 AM
+    Session Title: The infrastructure for the singularity
+    Description:
+    We're at an inflection point where AI agents are transitioning from experimental tools to practical coworkers. This new world will demand new infrastructure for RL training, test-time scaling, and deployment. This is why Morph Labs developed Infinibranch last year, and we are excited to finally unveil what's next.
+
+  ------------------------------------
+
+    Session ID: 932429
+    Track: Infrastructure
+    Speaker: Ben Kus (CTO)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Building an Agentic Platform
+    Description:
+    Explore the technical evolution of metadata extraction at Box and how it shaped the foundation of our AI platform. We’ll walk through our transition to an agentic-first design—why it was necessary, how we approached the rebuild, challenges we encountered along the way, and the advantages it unlocked.
+
+  ------------------------------------
+
+    Session ID: 916116
+    Track: Infrastructure
+    Speaker: Solomon Hykes (CEO & Co-founder of Dagger, creator of Docker)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 09:50 AM
+    Session Title: Containing Agent Chaos
+    Description:
+    AI agents promise breakthroughs but often deliver operational chaos. Building reliable, deployable systems with unpredictable LLMs feels like wrestling fog – testing outputs alone is insufficient when the underlying workflow is opaque and flaky. How do we move beyond fragile prototypes?
+    
+    This talk, from the creator of Docker, argues the solution lies *outside* the model: engineering **reproducible execution workflows** built on rigorous architectural discipline. Learn how **containerization**, applied not just to deployment but to *each individual step* of an agent's workflow, provides the essential **isolation and environmental consistency** needed.
+    
+    Discover how combining this granular container approach with patterns like immutable state management allows us to **contain agent chaos**, unlock effective testing, simplify debugging, and bring essential control and predictability back to building powerful AI agents you can actually ship with confidence.
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Infrastructure
+    Speaker: Arjun Desai (Co-Founder, Cartesia)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 905305
+    Track: Infrastructure
+    Speaker: Dr. Jasper Zhang, PhD (CEO)
+    Format: Talk
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Why We Don’t Need More Data Centers
+    Description:
+    AI infrastructure today is caught in an endless cycle: build more data centers, deploy more GPUs, repeat.
+    
+    But this approach is fundamentally flawed—expensive, inefficient, and environmentally unsustainable.
+    
+    In this talk, we will unpack why continuously expanding data centers masks deeper infrastructure inefficiencies, and why leveraging a GPU marketplace to dynamically allocate existing resources is essential.
+    
+    We will explore practical use-cases where companies scale GPU capacity flexibly, startups gain affordable compute, and idle GPUs are monetized, enabling a future of sustainable and democratized AI infrastructure.
+
+  ------------------------------------
+
+    Session ID: 914934
+    Track: Infrastructure
+    Speaker: Paul Klein IV (Founder)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: The Web Browser Is All You Need
+    Description:
+    With the rise of MCP servers, A2A, and our trusty friend, OpenAPI, it turns out the web browser may be the default MCP server for the rest of the internet.
+    
+    In this talk, we'll walk through how a web browsing tool is probably the only tool you'll need to enable production AI Agents.
+
+  ------------------------------------
+
+    Session ID: 933612
+    Track: Infrastructure
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 933652
+    Track: Infrastructure
+    Speaker: Mason Egger (Sr. Developer Advocate - Temporal )
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Events are the Wrong Abstraction for Your AI Agents
+    Description:
+    AI Agents are distributed systems. Agents need to connect and communicate with tools, data repositories, other agents, etc., all over a network. Event-Driven Architecture is a common pattern for facilitating this connectivity, using Events as the communication abstraction. However, this pattern introduces complexities as well, such as fragmented logic, increased latency, decreased observability, and more. But what if there were a way to get the benefits of Event-Driven Architecture without the complexities? Enter Durable Execution. In this talk, we'll discuss the pitfalls of Event-Driven Architecture, how Durable Execution solves these issues, and why Durable Execution, not Events, is the correct abstraction for building AI Agents.
+
+  ------------------------------------
+
+    Session ID: 928676
+    Track: Infrastructure
+    Speaker: Dylan Patel (Chief Analyst)
+    Format: Talk
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: [Infra Keynote] Geopolitics of AI Infrastructure
+    Description:
+    As AI reshapes the global balance of power, the infrastructure behind it—chips, data centers, power, and supply chains—has become a new arena for geopolitical competition. This talk explores how nations are racing to secure critical AI hardware, control compute capacity, and assert influence over the technologies and talent that define the future.
+
+  ------------------------------------
+
+    Session ID: 933641
+    Track: Infrastructure
+    Speaker: Kshitij  Grover (Co-Founder & CTO, Orb Inc.)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 01:15 PM
+    Session Title: Revenue Engineering: How to Price (and Reprice) Your AI Product
+    Description:
+    You’ve trained the model—now it’s time to train the business. This talk dives into the engineering behind pricing systems that can evolve as fast as your AI stack.
+    
+    Orb CTO Kshitij Grover will walk through how leading AI companies design infrastructure to support experimentation, scale, and real-world monetization constraints.
+    
+    Topics include:
+    - How to meter usage and map it to pricing with accuracy and auditability
+    - Factoring in margins and underlying costs when designing pricing strategy
+    - Handling complexity across motions: self-serve vs. enterprise, pay-as-you-go vs. committed contracts
+    - How to test pricing changes safely (and roll them back when needed)
+    
+    Whether you’re bootstrapping a pricing system from scratch or replacing a brittle V1, you’ll leave with architectural patterns and mental models to make pricing a first-class engineering concern.
+    
+
+  ------------------------------------
+
+    Session ID: 916066
+    Track: Infrastructure
+    Speaker: Yineng Zhang (Inference lead at SGLang)
+    Format: Workshop
+    Room: SOMA: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Introduction to LLM serving with SGLang
+    Description:
+    Do you want to learn how to serve models like DeepSeek and Qwen with SOTA speeds on launch day? SGLang is an open-source fast serving framework for LLMs and VLMs that generates trillions of tokens per day at companies like xAI, AMD, and Meituan. This workshop guides AI engineers who are familiar with serving models using frameworks like vLLM, Ollama, and TensorRT-LLM through deploying and optimizing their first model with SGLang, as well as providing guidance on when SGLang is the appropriate tool for LLM workloads.
+
+  ------------------------------------
+
+    Session ID: 933605
+    Track: Infrastructure
+    Speaker: Mani Khanuja (Principal ML Services SA)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Data is Your Differentiator: Building Secure and Tailored AI Systems
+    Description:
+    As  organizations seek to harness their proprietary data while maintaining  security and compliance, Amazon Bedrock provides a comprehensive framework  for building tailored AI applications. Using Amazon Bedrock Knowledge Bases  and Amazon Bedrock Data Automation, organizations can create AI solutions  that truly understand their unique business context, terminology, and  requirements. Combined with Amazon Bedrock Guardrails, these capabilities  enhance the accuracy and relevance of AI-generated responses, while ensuring  that sensitive information remains protected within the organization's  control - enabling businesses to build secure and compliant enterprise-grade  generative AI solutions that accelerate time to value.
+
+  ------------------------------------
+
+    Session ID: 933625
+    Track: Infrastructure
+    Speaker: Philipp Krenn (Code and conference monkey)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 03:15 PM
+    Session Title: Vector Search Benchmark[eting]
+    Description:
+    Every vector database out there is both faster and slower than any other competitor — if you believe all the benchmarketing out there.
+    Let's turn the marketing into useful benchmarks that actually help you:
+    1. How not to benchmark (spoiler: don’t trust the glossy charts).
+    2. What’s uniquely tricky about benchmarking vector search.
+    3. How to build meaningful benchmarks tailored to your use case.
+    
+    PS: Yes, you will have to get your hands dirty. Never believe a benchmark that you haven't tweaked yourself.
+
+  ------------------------------------
+
+    Session ID: 915471
+    Track: Infrastructure
+    Speaker: Kyle Kranen US (Engineering Manager - Deep Learning Algorithms )
+    Format: Talk
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Hacking the Inference Pareto Frontier for Cheaper and Faster Tokens Without Breaking SLAs
+    Description:
+    Your model works! It aces the evals! It even passes the vibe check! All that’s required is inference, right? Oops, you’ve just stepped into a minefield:
+    
+    -Not low-latency enough? Choppy experience. Users churn from your app.
+    -Not cheap enough? You’re losing money on every query.
+    -Not high enough output quality? Your system can’t be used for that application.
+    
+    A model and the inference system around it form a “token factory” associated with a Pareto frontier— a curve representing the best possible trade-offs between cost, throughput, latency and quality, outside of which your LLM system cannot be applied successfully.
+    
+    Outside of the Pareto frontier? You’re back to square one.
+    That is, unless you’re able to change the shape of the Pareto frontier.
+    
+    In this session, we’ll introduce NVIDIA Dynamo, a datacenter-scale distributed inference framework as well as the bleeding-edge techniques it enables to hack the Pareto frontier of your inference systems, including:
+    
+    -Disaggregation - separating phases of LLM generation to make them more efficient
+    -Speculation - predicting multiple tokens per cycle
+    -KV routing, storage, and manipulation - ensuring that we don’t redo work that has already been done
+    -Pipelining improvements for agents - accelerating our workflows using information about the agent
+    
+    By the end of the talk, we’ll understand how the Pareto frontier limits where models can be applied, the intuition behind how inference techniques can be used to modify it, as well as the mechanics of how these techniques work.
+    
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Infrastructure
+    Speaker: Rohit Talluri (Senior Worldwide Generative AI Specialist BD - Foundation Model Training & Inference)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 933610
+    Track: Infrastructure
+    Speaker: Mike Chambers (AI/ML Specialist DA AWS)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Ship it! Building Production-Ready Agents
+    Description:
+    Explore the practical challenges and solutions for deploying AI agents in real-world production environments. Through detailed technical analysis and practical examples, we'll examine strategies for building and orchestrating agent systems at scale. We'll cover critical infrastructure decisions, scalability frameworks, and best practices for creating robust, production-ready agent architectures.
+
+  ------------------------------------
+
+    Session ID: 912986
+    Track: Infrastructure
+    Speaker: Robert  Wachen (Co-founder of Etched )
+    Format: Talk
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Flipping the Inference Stack: Why GPUs Bottleneck Real-Time AI at Scale
+    Description:
+    AI inference today is stuck in a loop: throw more GPUs at the problem, scale horizontally, rinse and repeat. But that playbook is hitting a wall. Latency, cost, and energy grids are all suffering, and the capability for real-time AI at scale looks further and further away. In this talk, AI hardware expert and founder Gavin Uberti will break down why the current approach to inference is masking deep inefficiencies, and how rethinking the hardware stack from the ground up (starting with inference-first chips) is the only way to unlock real-time AI at scale.
+
+  ------------------------------------
+
+    Session ID: 942943
+    Track: Infrastructure
+    Speaker: John Welsh (Member of technical staff, Anthropic)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: What we learned from shipping remote MCP support at Anthropic
+    Description:
+    We recently released remote MCP support for both claude.ai and the Anthropic API. This talk will cover architectural decisions we made in our implementation, remote MCP authentication, supporting engineers who are building out agentic AI tools, implementing custom internal transports, and whatever else we can fit into 18 minutes of your time.
+
+  ------------------------------------
+
+    Session ID: 933719
+    Track: Infrastructure
+    Speaker: Charles Frye (Developer Advocate, Modal Labs)
+    Format: Workshop
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: What every AI engineer needs to know about GPUs
+    Description:
+    Every programmer needs to know a few things about hardware, like processors, memory, and disks. Due to AI systems' extreme demand for mathematical processing power, AI engineers need to know a few things about GPUs -- the world's most popular high-throughput mathematical co-processor.
+    
+    In this talk, I will explain the fundamental engineering constraints and design decisions that shape GPUs and trace those up to some counter-intuitive facts about the performance characteristics of AI systems, with actionable insights for their deployers and consumers.
+
+  ------------------------------------
+
+    Session ID: 933656
+    Track: Infrastructure
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agents, Access, and the Future of Machine Identity
+    Description:
+    AI agents are calling APIs, submitting forms, and sending emails—but how do you control what they’re allowed to do? As agents act on behalf of users or organizations, traditional patterns like OAuth, session tokens, and role-based access often fall short.
+    In this talk, we’ll explore how machine identity is evolving to meet this new landscape. You’ll learn:
+    
+    - How to think about authentication for agents (not just humans)
+    - What it means to authorize an action when the actor is an LLM or headless service
+    - Real-world strategies from WorkOS and Cloudflare for assigning, managing, and revoking agent identity and access
+    
+    By the end, you’ll walk away with practical tools and mental models to build agent-powered systems that are secure, auditable, and scalable.
+
+  ------------------------------------
+
+    Session ID: 916066
+    Track: Infrastructure
+    Speaker: Philip Kiely (Head of Developer Relations)
+    Format: Workshop
+    Room: SOMA: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Introduction to LLM serving with SGLang
+    Description:
+    Do you want to learn how to serve models like DeepSeek and Qwen with SOTA speeds on launch day? SGLang is an open-source fast serving framework for LLMs and VLMs that generates trillions of tokens per day at companies like xAI, AMD, and Meituan. This workshop guides AI engineers who are familiar with serving models using frameworks like vLLM, Ollama, and TensorRT-LLM through deploying and optimizing their first model with SGLang, as well as providing guidance on when SGLang is the appropriate tool for LLM workloads.
+
+  ------------------------------------
+
+    Session ID: 937137
+    Track: Infrastructure
+    Speaker: Alex Cheema (Co-Founder)
+    Format: Talk
+    Room: Foothill F: Infrastructure
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: Large Scale AI on Apple Silicon using EXO
+    Description:
+    The hardware lottery: when a research idea wins because it is better suited to current hardware and software, and not because it is universally superior.
+    
+    Machine learning researchers often treat hardware as a fixed constraint and stop exploring beyond it. Yet historically, breakthroughs have come from algorithms that best align with the dominant hardware-software stack - neural networks being a classic example.
+    
+    In this talk, EXO Labs co-founder Alex Cheema will share recent algorithmic improvements for running large scale AI workloads on Apple Silicon.
+    
+    Alex will demonstrate how the EXO Framework enables inference, fine-tuning, and training of large ML models on Apple Silicon, from the scale of one MacBook locally to clusters of colocated M3 Ultra Mac Studios.
+
+
+
+======================================================================
+---  Track: MCP (June 4) ---
+======================================================================
+
+    Session ID: 911821
+    Track: MCP
+    Speaker: Damien Murphy (Founding Engineer)
+    Format: Workshop
+    Room: Foothill G1&2: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: A2A & MCP: Automating Business Processes with LLMs
+    Description:
+    Ever wished your webhooks could think for themselves? Join us to discover how A2A agents can transform passive webhook endpoints into intelligent workflow processors.
+    
+    In this session, we'll show you how to build a system that automatically spawns AI Agents to handle incoming webhooks.
+    
+    Using Google's Agent-to-Agent framework and MCP, you'll learn how to create dynamic AI agents that respond to events, communicate with external services, and make decisions based on content analysis.
+    
+    See the future of workflow automation where webhooks don't just trigger actions—they trigger intelligence!
+
+  ------------------------------------
+
+    Session ID: 933688
+    Track: MCP
+    Speaker: Zack Proser (Open source hacker. Dev Education at WorkOS)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: AI Pipelines and Agents in Pure TypeScript with Mastra.ai
+    Description:
+    This hands-on workshop introduces Mastra.ai, a TypeScript framework that streamlines the development of agentic AI systems compared to traditional approaches using LangChain and vector databases. Participants will learn to build structured AI workflows with composable tools and reliable control, enabling them to create internal AI assistants that can handle requests like data cleaning, email drafting, and document summarization with minimal code. The session covers Mastra installation, running a local MCP server, defining tools and agents in TypeScript, using the Mastra playground, and implementing practical examples such as RAG setups and tool-chaining agents—all designed to equip attendees with the skills to develop scalable AI-driven internal tools based on sound software engineering principles rather than just experimental prompts.
+
+  ------------------------------------
+
+    Session ID: 933612
+    Track: MCP
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 947995
+    Track: MCP
+    Speaker: David Cramer (Founder, Sentry)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: MCP isn’t good, yet.
+    Description:
+    You’ve heard a lot about MCP, probably been given an AI mandate or two, and are trying to figure out what’s real and what’s make believe.
+    
+    This session will give practical advice for how you should be thinking about MCP, the implementation pit falls, and where the speaker thinks things are going.
+
+  ------------------------------------
+
+    Session ID: 947165
+    Track: MCP
+    Speaker: Theodora Chu (Product Manager for MCP @ Anthropic)
+    Format: Keynote
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: MCP Origins & RFS
+    Description:
+    Learn more about the latest updates on MCP and get ideas for what startups to build.
+
+  ------------------------------------
+
+    Session ID: 911925
+    Track: MCP
+    Speaker: Samuel Colvin (Founder of Pydantic)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: MCP is all you need
+    Description:
+    Everyone is talking about agents, and right after that, they’re talking about agent-to-agent communications. Not surprisingly, various nascent, competing protocols are popping up to handle it.
+    
+    But maybe all we need is MCP — the OG of GenAI communication protocols (it's from way back in 2024!).
+    
+    Last year, Jason Liu gave the second most watched AIE talk — “Pydantic is all you need”.
+    
+    This year, I (the creator of Pydantic) am continuing the tradition by arguing that MCP might be all we need for agent-to-agent communications.
+    
+    What I’ll cover:
+    
+    - Misusing Common Patterns: MCP was designed for desktop/IDE applications like Claude Code and Cursor. How can we adapt MCP for autonomous agents?
+    - Many Common Problems: MCP is great, but what can go wrong? How can you work around it? Can the protocol be extended to solve these issues?
+    - Monitoring Complex Phenomena: How does observability work (and not work) with MCP?
+    - Multiple Competing Protocols: A quick run-through of other agent communication protocols like A2A and AGNTCY, and probably a few more by June 😴
+    - Massive Crustaceans Party: What might success look like if everything goes to plan?
+
+  ------------------------------------
+
+    Session ID: 914489
+    Track: MCP
+    Speaker: Harald Kirschner (VS Code Team Member)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: Full Spectrum MCP: Uncovering Hidden Servers and Clients Capabilities
+    Description:
+    The true power of Model Context Protocol emerges when clients and servers collaborate across the full spectrum of the specification. This talk presents practical examples of how VS Code's comprehensive implementation of MCP transforms the capabilities of AI assistants, making them more contextual, efficient, and user-friendly. We'll showcase advanced features like dynamic tool discovery and workspace-aware roots, demonstrating how they create experiences impossible with standard tools integrations while confronting the reality gap between MCP's theoretical potential and practical implementation challenges.
+
+  ------------------------------------
+
+    Session ID: 916149
+    Track: MCP
+    Speaker: Henry Mao (Founder @ Smithery.ai)
+    Format: Online Talk
+    Session Title: Are MCPs Overhyped? A Rant about MCPs
+    Description:
+    AI agents are becoming smarter but lack the broad capability to take action in practice. At Smithery, we believe the missing link is an AI orchestration layer—a unified interface that gives agents context, action, and a way to learn from real interactions. This talk explores the problem space in the Model Context Protocol (MCP) ecosystem and how we're tackling it at Smithery.
+
+  ------------------------------------
+
+    Session ID: 933626
+    Track: MCP
+    Speaker: Philipp Krenn (Code and conference monkey)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:00 PM
+    Session Title: Hope is Not a Strategy: Retrieval Patterns for MCP
+    Description:
+    MCP is a solid integration layer — but how does it hold up when it comes to output quality? Often, not as well as you'd like. Here are some practical retrieval patterns, from basic to advanced, that worked well in my experiments:
+    * Naive: Just plug in plain MCP and hope the LLM gets it right. Sometimes it does. Sometimes you’ll need a miracle.
+    * Semantic: Add more descriptive field names and extra metadata. It helps — but usually just a bit.
+    * Templated: Use a structured template and have the LLM fill it out step by step. More effort, but by far the most reliable results.
+
+  ------------------------------------
+
+    Session ID: 935982
+    Track: MCP
+    Speaker: Kent C. Dodds (Software Engineer Educator)
+    Format: Online Talk
+    Session Title: Letting AI Interface with Your App with MCP
+    Description:
+    We are entering a new era of user interaction. It's being built right before our very eyes and changing rapidly. As crazy as it sounds, soon each one of us will get our own Jarvis capable of performing actually useful tasks for us with a completely different user interaction mechanism than we're used to.
+    
+    But someone's gotta give Jarvis the tools to perform these tasks, and that's where we come in.
+    
+    In this talk, Kent will demonstrate an MCP server with an AI assistant to help us catch the vision of what this future could look like and our role in it.
+
+  ------------------------------------
+
+    Session ID: 915013
+    Track: MCP
+    Speaker: Alex Volkov (AI Evangelist)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Observable tools - the state of MCP observability
+    Description:
+    AI Engineers deserve observable tools!
+    
+    MCP getting adoption means that less and less of your agents code is running under your control, and this has DX and observability challenges, let's fix that!
+    
+    Join Alex Volkov from Weights & Biases and Steve Manual from mcp.run on this recap of the current state of MCP observability, including the observable.tools initiative, a recap of where the field stands and what to look forward to + a practical example of MCP tool usage evaluation framework from mcp.run!
+
+  ------------------------------------
+
+    Session ID: 926313
+    Track: MCP
+    Speaker: Jan Curn (CEO)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: The rise of the agentic economy on the shoulders of MCP
+    Description:
+    Thanks to MCP and all the MCP server directories, agents can now autonomously discover new tools and other agents. This lays down the foundation for the future agentic economy, where businesses will sell to autonomous agents (B2A) and eventually agents will sell to other agents (A2A).
+    
+    But one key part is still missing: agents do not have a standard way to subscribe to external services and pay for them.
+    
+    In this talk, we’ll show how to give agents full autonomy to discover and pay for new external MCP-enabled services, even if those services don’t support it, using a little-known MCP server nesting capability. We’ll also cover how to monetize AI agents and the B2A/A2A business models.
+    
+
+  ------------------------------------
+
+    Session ID: 933686
+    Track: MCP
+    Speaker: Michael Grinich (Founder & CEO, WorkOS )
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: CIAM for AI: Who Are Your Agents and What Can They Do?
+    Description:
+    AI agents are changing the way modern SaaS products operate. Whether automating workflows, integrating with APIs, or acting on behalf of users, AI-driven assistants and autonomous systems are becoming core product features. But securing these agents presents a fundamental challenge: How do you authenticate AI agents? How do you control what they can access? How do you ensure they act within the right permissions? This talk will explore these concepts and more while highlighting current research and best practices.
+
+  ------------------------------------
+
+    Session ID: 933610
+    Track: MCP
+    Speaker: Mike Chambers (AI/ML Specialist DA AWS)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Ship it! Building Production-Ready Agents
+    Description:
+    Explore the practical challenges and solutions for deploying AI agents in real-world production environments. Through detailed technical analysis and practical examples, we'll examine strategies for building and orchestrating agent systems at scale. We'll cover critical infrastructure decisions, scalability frameworks, and best practices for creating robust, production-ready agent architectures.
+
+  ------------------------------------
+
+    Session ID: 936816
+    Track: MCP
+    Speaker: Den Delimarsky (DEVDIV) (Principal Product Engineer)
+    Format: Talk
+    Room: Nobhill C&D: Microsoft
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Building Protected MCP Servers
+    Description:
+    Join us to see how VS Code and GitHub Copilot's expanding suite of AI features can match or even surpasses the benefits of other popular AI developer tools.  We'll focus on practical scenarios to ensure immediate applicability and work through live demos of Copilot features such as: Code generation using Edits, Planning/problem solving using Chat, Inline terminal command generation, Boilerplate code generation using Agent mode, Improving boilerplate with custom instructions and then refactoring using Agent mode and Edits, Improving test generation and code reviews with custom instructions, as well as an Introduction to MCP.
+    
+
+  ------------------------------------
+
+    Session ID: 915013
+    Track: MCP
+    Speaker: Benjamin Eckel (Co-Founder of Dylibso)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Observable tools - the state of MCP observability
+    Description:
+    AI Engineers deserve observable tools!
+    
+    MCP getting adoption means that less and less of your agents code is running under your control, and this has DX and observability challenges, let's fix that!
+    
+    Join Alex Volkov from Weights & Biases and Steve Manual from mcp.run on this recap of the current state of MCP observability, including the observable.tools initiative, a recap of where the field stands and what to look forward to + a practical example of MCP tool usage evaluation framework from mcp.run!
+
+  ------------------------------------
+
+    Session ID: 933607
+    Track: MCP
+    Speaker: Duan Lightfoot (AWS, Sr. Cloud Networking Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Building Agents with Amazon Nova Act and MCP
+    Description:
+    In this 2-hour workshop, participants will gain practical hands-on experience building sophisticated AI agents using Amazon's agent technologies. You'll learn to build agents that can navigate the web like humans, perform complex multi-step tasks, and leverage specialized tools through natural language commands. You’ll explore Amazon Nova Act for reliable web navigation, Model Context Protocol (MCP) for connecting agents to external data sources and APIs, and Amazon Bedrock Agents for orchestrating complex workflows. Through guided exercises, you'll create agents capable of retrieving information and taking action across web applications, all through natural language interactions. By the end of this workshop, you'll have the practical skills to build AI agents that can browse websites, interact with web interfaces, and solve multi-step problems by combining these powerful Amazon technologies.
+
+  ------------------------------------
+
+    Session ID: 915013
+    Track: MCP
+    Speaker: Steve Manuel (CEO)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Observable tools - the state of MCP observability
+    Description:
+    AI Engineers deserve observable tools!
+    
+    MCP getting adoption means that less and less of your agents code is running under your control, and this has DX and observability challenges, let's fix that!
+    
+    Join Alex Volkov from Weights & Biases and Steve Manual from mcp.run on this recap of the current state of MCP observability, including the observable.tools initiative, a recap of where the field stands and what to look forward to + a practical example of MCP tool usage evaluation framework from mcp.run!
+
+  ------------------------------------
+
+    Session ID: 942943
+    Track: MCP
+    Speaker: John Welsh (Member of technical staff, Anthropic)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 7-8: MCP
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: What we learned from shipping remote MCP support at Anthropic
+    Description:
+    We recently released remote MCP support for both claude.ai and the Anthropic API. This talk will cover architectural decisions we made in our implementation, remote MCP authentication, supporting engineers who are building out agentic AI tools, implementing custom internal transports, and whatever else we can fit into 18 minutes of your time.
+
+  ------------------------------------
+
+    Session ID: 933688
+    Track: MCP
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: AI Pipelines and Agents in Pure TypeScript with Mastra.ai
+    Description:
+    This hands-on workshop introduces Mastra.ai, a TypeScript framework that streamlines the development of agentic AI systems compared to traditional approaches using LangChain and vector databases. Participants will learn to build structured AI workflows with composable tools and reliable control, enabling them to create internal AI assistants that can handle requests like data cleaning, email drafting, and document summarization with minimal code. The session covers Mastra installation, running a local MCP server, defining tools and agents in TypeScript, using the Mastra playground, and implementing practical examples such as RAG setups and tool-chaining agents—all designed to equip attendees with the skills to develop scalable AI-driven internal tools based on sound software engineering principles rather than just experimental prompts.
+
+  ------------------------------------
+
+    Session ID: 933656
+    Track: MCP
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agents, Access, and the Future of Machine Identity
+    Description:
+    AI agents are calling APIs, submitting forms, and sending emails—but how do you control what they’re allowed to do? As agents act on behalf of users or organizations, traditional patterns like OAuth, session tokens, and role-based access often fall short.
+    In this talk, we’ll explore how machine identity is evolving to meet this new landscape. You’ll learn:
+    
+    - How to think about authentication for agents (not just humans)
+    - What it means to authorize an action when the actor is an LLM or headless service
+    - Real-world strategies from WorkOS and Cloudflare for assigning, managing, and revoking agent identity and access
+    
+    By the end, you’ll walk away with practical tools and mental models to build agent-powered systems that are secure, auditable, and scalable.
+
+  ------------------------------------
+
+    Session ID: 933709
+    Track: MCP
+    Speaker: Tobin  South (Secure AI Agents & MCP, WorkOS)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 10:55 AM
+    Session Title: What does Enterprise Ready MCP mean?
+    Description:
+    Everyone is building MCP servers: from Slack integrations to personal data tools. They're good demos, but not ready to turn into production. So, what does it take to make MCP *enterprise-ready?*
+    
+    We're going to cover the end-to-end process of getting a hacky MCP server authenticated, permissioned, and secure. We'll talk about registries, SSO, audit logs, agent identifiers, autonomy for agents, and oversight. Oh and we'll use MCP to buy some stuff.
+    
+    Come learn the stack needed to scale your MCP to the enterprise and some fun hacks along the way.
+
+
+
+======================================================================
+---  Track: REASONING+RL (TBA) ---
+======================================================================
+
+    Session ID: 947233
+    Track: Reasoning+RL
+    Speaker: Jack Rae (Principal Research Scientist)
+    Format: Keynote
+    Session Title: (tbc) Gemini Thinking and the Future of Reasoning
+    Description:
+    Jack Rae, Principal Research Scientist at Google DeepMind, will keynote on Gemini Thinking and the future of reasoning in AI: advances, challenges, and what’s next for reasoning capabilities in next-gen foundation models.
+
+  ------------------------------------
+
+    Session ID: 916189
+    Track: Reasoning+RL
+    Speaker: Jesse Han (Founder)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 10:10 AM
+    Session Title: The infrastructure for the singularity
+    Description:
+    We're at an inflection point where AI agents are transitioning from experimental tools to practical coworkers. This new world will demand new infrastructure for RL training, test-time scaling, and deployment. This is why Morph Labs developed Infinibranch last year, and we are excited to finally unveil what's next.
+
+  ------------------------------------
+
+    Session ID: 929509
+    Track: Reasoning+RL
+    Speaker: Daniel Han (CEO)
+    Format: Workshop
+    Room: Foothill C: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Advanced: Reinforcement Learning, Kernels, Reasoning, Quantization & Agents
+    Description:
+    Why is Reinforcement Learning (RL) suddenly everywhere, and is it truly effective? Have LLMs hit a plateau in terms of intelligence and capabilities, or is RL the breakthrough they need?
+    
+    In this workshop, we'll dive into the fundamentals of RL, what makes a good reward function, and how RL can help create agents.
+    
+    We'll also talk about kernels, are they still worth your time and what you should focus on. And finally, we’ll explore how LLMs like DeepSeek-R1 can be quantized down to 1.58-bits and still perform well, along with techniques to maintain accuracy.
+
+  ------------------------------------
+
+    Session ID: 935461
+    Track: Reasoning+RL
+    Speaker: Logan Kilpatrick (Product, Google Deepmind)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 09:05 AM
+    Session Title: A year of Gemini progress + what comes next
+    Description:
+    Over the last year, Google and Gemini models have shown rapid progress across all dimensions (model, product, etc). Let's highlight all the work that has happened, how we got the worlds best models, and where we are going next (across both the model landscape and out AI products).
+
+  ------------------------------------
+
+    Session ID: 939640
+    Track: Reasoning+RL
+    Speaker: Christian Szegedy (Former co-founder of xAI, discoverer of adversarial examples)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Towards Verified Superintelligence
+    Description:
+    I describe a new paradigm towards open-endedly self-improving intelligence by scaling verification to remove the human data and supervision bottleneck. The objective is to achieve trustless alignment of superintelligence.
+
+  ------------------------------------
+
+    Session ID: 914856
+    Track: Reasoning+RL
+    Speaker: Will Brown (Research Engineering Lead)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: Training Agentic Reasoners
+    Description:
+    This talk will be a technical deep dive into RL for agentic reasoning via multi-turn tool calling, similar to OpenAI's o3 and Deep Research. In particular, we'll cover:
+    - When, why, and how
+    - GRPO vs PPO vs etc
+    - Designing environments and rewards
+    - Survey of recent research highlights
+    - Results on example tasks
+    - Overview of open-source ecosystem (libraries, compute requirements, tradeoffs, etc.)
+
+  ------------------------------------
+
+    Session ID: 916074
+    Track: Reasoning+RL
+    Speaker: Ryan Marten (Founding Engineer at Bespoke Labs)
+    Format: Online Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: OpenThinker - Unreasonably Effective Reasoning Distillation at Scale
+    Description:
+    Peel back the curtain on state of the art model post-training through the story of OpenThinker, a SOTA small reasoning model (outperforming DeepSeek distill), built in the open. Learn about the dataset recipe used to build the strongest reasoning models which you can apply to your own domain-specific specialized reasoning models. Hear about the strategies that scale (and that don't) based on our rigorous experimentation on the journey from thousands of data points (Bespoke-Stratos) to millions of data (OpenThinker3). Build upon our open source engineering solutions for large-scale synthetic data generation, training on multiple supercomputing clusters, and building out fast reliable evaluations.
+
+  ------------------------------------
+
+    Session ID: 930540
+    Track: Reasoning+RL
+    Speaker: Ilan Bigio (Developer Experience)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Model-Maxxing: RFT, DPO, SFT (Fine-tuning with OpenAI)
+    Description:
+    Covering all forms of fine-tuning and prompt engineering, like SFT, DPO, RFT, prompt engineering / optimization, and agent scaffolding.
+
+  ------------------------------------
+
+    Session ID: 914533
+    Track: Reasoning+RL
+    Speaker: Kyle Corbitt (CEO )
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: How to Train Your Agent: Building Reliable Agents with RL
+    Description:
+    Have you ever launched an awesome agentic demo, only to realize no amount of prompting will make it reliable enough to deploy in production? Agent reliability is a famously difficult problem to solve!
+    
+    In this talk we’ll learn how to use GRPO to help your agent learn from its successes and failures and improve over time. We’ve seen dramatic results with this technique, such as an email assistant agent that whose success rate jumped from 74% to 94% after replacing o4-mini with an open source model optimized using GRPO.
+    
+    We’ll share case studies as well as practical lessons learned around the types of problems this works well for and the unexpected pitfalls to avoid.
+
+  ------------------------------------
+
+    Session ID: 914786
+    Track: Reasoning+RL
+    Speaker: Greg Kamradt (President)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Measuring AGI: Interactive Reasoning Benchmarks
+    Description:
+    ARC Prize Foundation is building the North Star for AGI—rigorous, open benchmarks that track reasoning progress in modern AI. We'll show why static AGI evaluations are useful, but fall short when comparing models to human intelligence. Sneak peak preview of ARC-AGI-3: a dynamic, game-like benchmark launching Q1 '26.
+
+  ------------------------------------
+
+    Session ID: 926721
+    Track: Reasoning+RL
+    Speaker: Nathan Lambert (Research Lead)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: A taxonomy for next-generation  reasoning models
+    Description:
+    Current AI models are extremely skilled, which was seen as the step change in evaluation scores across the industry in the first half of 2025, but often fail when presented with even medium time-horizon tasks. This talk presents a taxonomy of 4 traits of reasoning models -- skills, calibration, strategy, and abstraction -- that will be crucial to creating the next generation of AI applications.  With this, we focus on the latter two, strategy and abstraction, and discuss how these traits will enable long-horizon and reliable agents. The talk concludes with a scenario where these agentic behaviors are the foundation for RL continuing to scale in the coming years and post-training techniques reaching compute parity with pretraining methors sooner than later.
+
+  ------------------------------------
+
+    Session ID: 939091
+    Track: Reasoning+RL
+    Speaker: Junyang Lin (Alibaba Qwen)
+    Format: Online Talk
+    Session Title: Qwen: Towards a Generalist Model / Agent
+    Description:
+    Since Alibaba launched the Qwen series of large models in 2023, the Qwen series of large language models and multimodal large models have been continuously updated and improved. This presentation will introduce the latest developments in the Qwen series of models, including the large language model Qwen3, vision-language large model Qwen2.5-VL, omni model Qwen2.5-Omni, etc. Additionally, this presentation will also cover the future development directions of the Qwen series.
+
+
+
+======================================================================
+---  Track: RECSYS (TBA) ---
+======================================================================
+
+    Session ID: 906567
+    Track: RecSys
+    Speaker: Devansh Tandon (Principal Product Manager )
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Teaching Gemini to Speak YouTube: Adapting LLMs for Video Recommendations to 2B+ DAU
+    Description:
+    YouTube recommendations drive the majority of video watch time for billions of daily users. Traditionally powered by large embedding models (LEMs), we're undertaking a fundamental shift: rebuilding our recommendation stack using foundation models like Gemini. This talk dives into our engineering journey adapting general-purpose LLMs (Gemini) for the highly specialized, dynamic, and massive-scale task of YouTube recommendations.
+    
+    We'll start with a critical first step: creating a "language" for YouTube videos. Learn how we developed 'SemanticID', a novel tokenization scheme that distills multimodal video features (text, audio, frames) into discrete tokens representable by an LLM. Our paper (Better Generalization with Semantic IDs: A Case Study in Ranking for Recommendations) is a landmark work in this space.
+    
+    We then adapt the base Gemini checkpoint to understand sequences of these video tokens alongside natural language, effectively teaching it the grammar of user watch behavior. A key insight: unlike static LLM training, YouTube's corpus evolves so rapidly (millions of new videos daily) that daily retraining is non-negotiable to maintain recommendation quality.
+    
+    Now we can prompt LRM with user history and context to generate personalized candidate recommendations.
+    
+    There’s a lot of attention on the LLM-led transformation of Search (with AI Overviews, Perplexity, ChatGPT-Search etc). However, across large consumer apps, it’s the recommendation systems & feeds that drive most consumer engagement, not just search. This talk is about the LLM-led transformation of recommendations & feeds – building a recommendation engine on top of Gemini.
+    
+
+  ------------------------------------
+
+    Session ID: 929231
+    Track: RecSys
+    Speaker: Tejaswi Tenneti (Director of Machine Learning)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Instacart’s LLM-driven approach to Search and Discovery
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 932583
+    Track: RecSys
+    Speaker: Yesu Feng (Netflix, Staff Research Scientist)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: One model to rule recommendations: Netflix's Big Bet
+    Description:
+    Discuss the foundation model strategy for personalization at Netflix based on this post https://netflixtechblog.com/foundation-model-for-personalized-recommendation-1a0bd8e02d39 and recent developments.
+
+  ------------------------------------
+
+    Session ID: 932498
+    Track: RecSys
+    Speaker: Mukuntha Narayanan (Machine Learning Engineer)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: What We Learned from Using LLMs in Pinterest Search
+    Description:
+    Pinterest Search integrates Large Language Models (LLMs) to enhance relevance scoring by combining search queries with rich multimodal content, including visual captions, link-based text, and user curation signals. A semi-supervised learning framework enables scaling to large and multilingual datasets, going beyond English and limited human labels. These LLM-driven models are distilled into efficient architectures for real-time serving, with experimental validation and large-scale deployment demonstrating substantial improvements in search relevance for Pinterest users worldwide.
+
+  ------------------------------------
+
+    Session ID: 936205
+    Track: RecSys
+    Speaker: Maziar Sanjabi (LinkedIn AI, Principal Scientist)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: 360Brew LLM-based Foundation Model for Personalized Ranking and Recommendation
+    Description:
+    We will give a talk about our journey of building a foundation model for solving ranking and recommendation tasks across LinkedIn platform
+
+  ------------------------------------
+
+    Session ID: 936205
+    Track: RecSys
+    Speaker: Hamed Firooz (Principal Scientist -- LinkedIn Core AI)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: 360Brew LLM-based Foundation Model for Personalized Ranking and Recommendation
+    Description:
+    We will give a talk about our journey of building a foundation model for solving ranking and recommendation tasks across LinkedIn platform
+
+  ------------------------------------
+
+    Session ID: 929337
+    Track: RecSys
+    Speaker: Eugene Yan (Principal Applied Scientist)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: Recsys Keynote: Improving Recommendation Systems & Search in the Age of LLMs
+    Description:
+    Recommendation systems and search have long adopted advances in language modeling, from early adoption of Word2vec for embedding-based retrieval to the transformative impact of GRUs, Transformers, and BERT on predicting user interactions. Now, the rise of large language models (LLMs) is inspiring innovations in model architecture, scalable system designs, and richer customer experiences.
+    
+    In this keynote, we'll dive into cutting-edge industry applications of LLMs in recommendation and search systems, exploring real-world implementations and measurable outcomes. Join us for an look at current trends and an exciting vision of how LLM-driven techniques will shape the future of content discovery and intelligent search.
+
+  ------------------------------------
+
+    Session ID: 929231
+    Track: RecSys
+    Speaker: Vinesh Gudla (Staff Machine Learning Engineer, Instacart)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Instacart’s LLM-driven approach to Search and Discovery
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 932498
+    Track: RecSys
+    Speaker: Han Wang (Machine Learning Engineer)
+    Format: Talk
+    Room: Golden Gate Ballroom A: LLM RecSys
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: What We Learned from Using LLMs in Pinterest Search
+    Description:
+    Pinterest Search integrates Large Language Models (LLMs) to enhance relevance scoring by combining search queries with rich multimodal content, including visual captions, link-based text, and user curation signals. A semi-supervised learning framework enables scaling to large and multilingual datasets, going beyond English and limited human labels. These LLM-driven models are distilled into efficient architectures for real-time serving, with experimental validation and large-scale deployment demonstrating substantial improvements in search relevance for Pinterest users worldwide.
+
+
+
+======================================================================
+---  Track: RETRIEVAL+SEARCH (TBA) ---
+======================================================================
+
+    Session ID: 913839
+    Track: Retrieval+Search
+    Speaker: Julia Neagu (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Evaluating AI Search: A Practical Framework for Augmented AI Systems
+    Description:
+    AI search is becoming the front door to information, whether through Retrieval-Augmented Generation (RAG), Search-Augmented Generation (SAG), or custom agents that synthesize answers on top of indexed content. As users rely more heavily on these systems, evaluating their quality becomes mission-critical. But traditional metrics like precision and recall don’t capture the full picture.
+    
+    In this talk, we introduce a practical evaluation framework for AI-powered search, across three dimensions:
+    - Are the retrieved sources relevant to the query?
+    - And is the final answer complete?
+    - Are the sources faithfully used in the generated answer?
+    
+    We’ll share lessons from working with search companies and present early findings from a new benchmark evaluating popular augmented AI systems across these dimensions. Rather than ranking winners and losers, we explore where different systems excel or break down, and how these tradeoffs inform product decisions.
+    
+    This talk is for AI engineers and product teams who want to build trusted, high-quality AI search experiences, and need a way to measure if it’s actually working.
+
+  ------------------------------------
+
+    Session ID: 903966
+    Track: Retrieval+Search
+    Speaker: Chang She (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Scaling Enterprise-Grade RAG Systems: Lessons from the Legal Frontier
+    Description:
+    In domains like law, compliance, and tax, building enterprise-grade RAG means very large scale, spikey workloads, a focus on accuracy, and non-negotiable privacy.
+    In this talk, we'll share war stories and battle scars of how Harvey has built the world's most advanced AI agents for the legal profession on top of a highly optimized retrieval architecture. We'll cover how to get better retrieval via both sparse and dense retrieval methods, why domain-specific reranking is essential, and how to handle ambiguity in real-world queries.
+    We'll also touch on how LanceDB's search engine enables this architecture by delivering low-latency, high-throughput retrieval across millions of documents of varying sizes without compromising privacy. This solid foundation enables Harvey to build a product that brings highly accurate answers to hundreds of law firms and professional services firms across 45 countries.
+
+  ------------------------------------
+
+    Session ID: 913839
+    Track: Retrieval+Search
+    Speaker: Deanna Emery (Founding AI Researcher)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Evaluating AI Search: A Practical Framework for Augmented AI Systems
+    Description:
+    AI search is becoming the front door to information, whether through Retrieval-Augmented Generation (RAG), Search-Augmented Generation (SAG), or custom agents that synthesize answers on top of indexed content. As users rely more heavily on these systems, evaluating their quality becomes mission-critical. But traditional metrics like precision and recall don’t capture the full picture.
+    
+    In this talk, we introduce a practical evaluation framework for AI-powered search, across three dimensions:
+    - Are the retrieved sources relevant to the query?
+    - And is the final answer complete?
+    - Are the sources faithfully used in the generated answer?
+    
+    We’ll share lessons from working with search companies and present early findings from a new benchmark evaluating popular augmented AI systems across these dimensions. Rather than ranking winners and losers, we explore where different systems excel or break down, and how these tradeoffs inform product decisions.
+    
+    This talk is for AI engineers and product teams who want to build trusted, high-quality AI search experiences, and need a way to measure if it’s actually working.
+
+  ------------------------------------
+
+    Session ID: 933721
+    Track: Retrieval+Search
+    Speaker: Suman Debnath (Principal Developer Advocate, AI/ML, AWS)
+    Format: Workshop
+    Room: Foothill G1&2: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: VoiceVision RAG - Integrating Visual Document Intelligence with Voice Response
+    Description:
+    In this workshop we will explore the integration of Colpali, a cutting-edge Vision based Retrieval Model, with voice synthesis for next-generation RAG systems. We'll demonstrate how Colpali's ability to generate multi-vector embeddings directly from document images bypasses traditional OCR and complex preprocessing, while adding voice output creates a more intuitive and accessible user experience. Attendees will see how this combination handles documents with mixed textual and visual information, leading to more efficient and accurate information retrieval with natural voice responses.
+
+  ------------------------------------
+
+    Session ID: 933603
+    Track: Retrieval+Search
+    Speaker: Suman Debnath (Principal Developer Advocate, AI/ML, AWS)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: Introducing Strands Agents, an Open Source AI Agents SDK
+    Description:
+    Building AI agents used to require complex orchestration, extensive scaffolding, and months of tuning. With Strands Agents, an open source SDK from AWS. You can now build, test, and deploy intelligent agents in just a few lines of code. This session introduces the model-driven approach behind Strands, where a model, a prompt, and a set of tools are all you need to create powerful, production-ready agents. Learn how Strands leverages modern foundation models to handle reasoning, tool use, and reflection, reducing development time from months to days.
+
+  ------------------------------------
+
+    Session ID: 915338
+    Track: Retrieval+Search
+    Speaker: Chau Tran (AI engineer at Glean)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: How to build Enterprise-aware agents
+    Description:
+    While LLMs demonstrated impressive reasoning capabilities, their out-of-the-box reasoning is akin to hiring a brilliant but brand-new employee who doesn’t have the enterprise context of “how things are done at this company”. In this talk, I'll introduce “Workflow Search” as a paradigm to build enterprise-aware agents that can balance predictability on common tasks, and flexibility on unforeseen tasks.
+    
+
+  ------------------------------------
+
+    Session ID: 933671
+    Track: Retrieval+Search
+    Speaker: Zach Blumenfeld (AI/ML Product Specialist)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agentic GraphRAG: Simplifying Retrieval Across Structured & Unstructured Data
+    Description:
+    Agentic workflows often become complex, brittle, and hard to maintain when they need to retrieve and reason across both structured data (typically requiring precise query execution) and unstructured data (commonly handled via vector search in RAG). In this talk, we’ll explore how mapping key information into a knowledge graph can simplify these workflows and improve retrieval quality. You’ll learn core concepts behind GraphRAG, how to integrate it into agent tools, and get access to end-to-end code examples so you can start building right away.
+
+  ------------------------------------
+
+    Session ID: 915338
+    Track: Retrieval+Search
+    Speaker: Chau Tran (Technical Lead Delete)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: How to build Enterprise-aware agents
+    Description:
+    While LLMs demonstrated impressive reasoning capabilities, their out-of-the-box reasoning is akin to hiring a brilliant but brand-new employee who doesn’t have the enterprise context of “how things are done at this company”. In this talk, I'll introduce “Workflow Search” as a paradigm to build enterprise-aware agents that can balance predictability on common tasks, and flexibility on unforeseen tasks.
+    
+
+  ------------------------------------
+
+    Session ID: 914024
+    Track: Retrieval+Search
+    Speaker: Will Bryk (CEO & Co-founder, building perfect search at Exa)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: Building a Smarter AI Agent with Neural RAG
+    Description:
+    RAG quality for AI agents is critical, and traditional keyword-based search engines consistently underperform in agentic or multi-step tasks, where semantic grounding and contextual nuance matter most.
+    
+    In this talk, Will Bryk, CEO of Exa will live code two AI agent applications–one using traditional keyword search RAG and one using neural network RAG via vector search. He’ll then evaluate both applications based on task performance, relevance, and latency. With a live demo (no theory or pre-baked applications), the audience will get a firsthand look at the practical differences between keyword and semantic systems in production, and learn embedding strategies, indexing trade-offs, hybrid retrieval techniques, prompt tuning, and more.
+
+  ------------------------------------
+
+    Session ID: 903966
+    Track: Retrieval+Search
+    Speaker: Calvin Qi (Tech Lead Manager)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Scaling Enterprise-Grade RAG Systems: Lessons from the Legal Frontier
+    Description:
+    In domains like law, compliance, and tax, building enterprise-grade RAG means very large scale, spikey workloads, a focus on accuracy, and non-negotiable privacy.
+    In this talk, we'll share war stories and battle scars of how Harvey has built the world's most advanced AI agents for the legal profession on top of a highly optimized retrieval architecture. We'll cover how to get better retrieval via both sparse and dense retrieval methods, why domain-specific reranking is essential, and how to handle ambiguity in real-world queries.
+    We'll also touch on how LanceDB's search engine enables this architecture by delivering low-latency, high-throughput retrieval across millions of documents of varying sizes without compromising privacy. This solid foundation enables Harvey to build a product that brings highly accurate answers to hundreds of law firms and professional services firms across 45 countries.
+
+  ------------------------------------
+
+    Session ID: 925259
+    Track: Retrieval+Search
+    Speaker: Jerry Liu (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: Building AI Agents that actually automate Knowledge Work
+    Description:
+    Agents are all the rage in 2025, and every single b2b SaaS startup/incumbent promises AI agents that can "automate work" in some way.
+    
+    But how do you actually build this? The answer is two fold:
+    1. really really good tools
+    2. carefully tailored agent reasoning over these tools that range from assistant-to-automation based UXs.
+    
+    The main goal of this talk is to a practical overview of agent architectures that can automate real-world work, with a focus on document-centric tasks. Learn the core building blocks of best-in-class "tools" around processing, manipulating, and indexing/retrieving PDFs to Excel spreadsheets. Also learn the range of agent architectures suited for different tasks, from chat assistant-based UXs with high human-in-the-loop, to automation UXs that rely on encoding a business process into an end-to-end task solver. These architectures have to be generalizable but also highly accurate as agents get increasingly better at reasoning and code-writing.
+
+  ------------------------------------
+
+    Session ID: 933605
+    Track: Retrieval+Search
+    Speaker: Mani Khanuja (Principal ML Services SA)
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Data is Your Differentiator: Building Secure and Tailored AI Systems
+    Description:
+    As  organizations seek to harness their proprietary data while maintaining  security and compliance, Amazon Bedrock provides a comprehensive framework  for building tailored AI applications. Using Amazon Bedrock Knowledge Bases  and Amazon Bedrock Data Automation, organizations can create AI solutions  that truly understand their unique business context, terminology, and  requirements. Combined with Amazon Bedrock Guardrails, these capabilities  enhance the accuracy and relevance of AI-generated responses, while ensuring  that sensitive information remains protected within the organization's  control - enabling businesses to build secure and compliant enterprise-grade  generative AI solutions that accelerate time to value.
+
+  ------------------------------------
+
+    Session ID: 916214
+    Track: Retrieval+Search
+    Speaker: Philipp Krenn (Code and conference monkey)
+    Format: Workshop
+    Room: Foothill G1&2: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Information Retrieval from the Ground Up
+    Description:
+    Vector search is only a feature. Search engines and information retrieval have retaken their position as the foundation of RAG. This workshop takes you through decades of research, what has been working for a long time, and how it got better with Machine Learning.
+
+  ------------------------------------
+
+    Session ID: 933646
+    Track: Retrieval+Search
+    Speaker: Jesús Barrasa (AI Field CTO)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: Why Your Agent’s Brain Needs a Playbook: Practical Wins from Using Ontologies
+    Description:
+    You're trying to guide how your agents think and act. Code-orchestrated workflows are too rigid, but LLMs charting their own course feel too chaotic. When you need a middle ground, it’s time to reach for the secret weapon: ontologies. These graph-shaped fragments of actionable knowledge can fill in critical gaps.
+    
+    In this talk, we’ll explore together how ontologies bring structure, semantics, and sanity to GenAI-powered applications. You’ll learn when they’re useful, how to apply them, and what kinds of problems they help solve. Through practical examples, we’ll show how ontologies (1) guide knowledge graph construction, (2) add a semantic layer for more efficient and accurate retrieval (GraphRAG), and (3) encode domain logic you don’t want to leave up to the LLM.
+
+  ------------------------------------
+
+    Session ID: 933706
+    Track: Retrieval+Search
+    Speaker: Thibaut  Gourdel (Senior Technical Product Marketing Manager, MongoDB)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 11:00 AM
+    Session Title: GraphRAG: Integrating LLMs with Knowledge Graphs
+    Description:
+    While traditional RAG is effective, it can struggle with complex relationships and reasoning across large knowledge bases. GraphRAG, an advanced variant, addresses these challenges by leveraging knowledge graphs to enable deeper understanding and improved response accuracy. Learn how LLMs extract key entities and relationships from your data to construct a graph structure, and how the system uses graph traversal to find related entities and enrich prompts. Stay for a live demo showcasing these concepts in action.
+
+  ------------------------------------
+
+    Session ID: 933678
+    Track: Retrieval+Search
+    Speaker: Tengyu Ma (Chief AI Scientist, MongoDB)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: RAG in 2025: State of the Art and the Road Forward
+    Description:
+    The talk will have three parts
+    1.Roadmap debate: RAG vs. finetuning vs. long-context
+    2.RAG today: benefits, challenges, and current solutions
+    3.RAG tomorrow: AI models do more work
+
+  ------------------------------------
+
+    Session ID: 907695
+    Track: Retrieval+Search
+    Speaker: David Karam (CEO)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Layering every technique in RAG, one query at a time
+    Description:
+    Start with the simplest Search - in-memory embeddings with relevance ranking. End with the most complex planet-scale Search - 70+ corpus mix of token, embeddings, and knowledge graphs, all jointly retrieved, custom ranked, joint re-ranked, and then LLM-processed, at 160,000 queries per second in under 200msec.
+    
+    This talk will be a fun “one query at a time” survey of all techniques in RAG in incremental complexity, showing the limits of each technique and what the next layered one opens up in terms of capabilities to handle ever-more complex queries in RAG. You’ll learn why queries like [falafel] are notoriously hard to Search over, why chunking your documents can be disastrous, how you can sometimes can get away with a simple bm25, and how some Search problems are so hard to solve that you’re better off punting the problem to the LLM or the UX. Brought to you by the team that worked on 50+ Search products, in the context of Google.com and custom Enterprise Search.
+
+  ------------------------------------
+
+    Session ID: 933692
+    Track: Retrieval+Search
+    Speaker: Richmond Alake (Staff Developer Advocate, AI/ML at MongoDB)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 10:40 AM
+    Session Title: Architecting Agent Memory: Principles, Patterns, and Best Practices
+    Description:
+    In the rapidly evolving landscape of agentic systems, memory management has emerged as a key pillar for building intelligent, context-aware AI Agents. Inspired by the complexity of human memory systems—such as episodic, working, semantic, and procedural memory—this talk unpacks how AI agents can achieve believability, reliability, and capability by retaining and reasoning over past experiences.
+    We’ll begin by establishing a conceptual framework based on real-world implementations from memory management libraries and system architectures:
+    Memory Components representing various structured memory types (e.g., conversation, workflow, episodic, persona)
+    Memory Modes reflecting operational strategies for short-term, long-term, and dynamic memory handling
+    Next, the talk transitions to practical implementation patterns critical for effective memory lifecycle management:
+    Maintaining rich conversation history and contextual awareness
+    Persistence strategies leveraging vector databases and hybrid search
+    Memory augmentation using embeddings, relevance scoring, and semantic retrieval
+    Production-ready practices for scaling memory in multi-agent ecosystems
+    We’ll also examine advanced memory strategies within agentic systems:
+    Memory cascading and selective deletion
+    Integration of tool use and persona memory
+    Optimizing performance around memory retrieval and LLM context window limits
+    Whether you're developing autonomous agents, chatbots, or complex workflow orchestration systems, this talk offers knowledge and tactical insights for building AI that can remember, adapt, and improve over time.
+    This session is ideal for:
+    AI engineers and agent framework developers
+    Architects designing Agentic RAG or multi-agent systems
+    Practitioners building contextual, personalized AI experiences
+    By the end of the session, you’ll understand how to leverage memory as a strategic asset in agentic design—and walk away ready to build agents that not only act and reason but also remember.
+
+  ------------------------------------
+
+    Session ID: 916215
+    Track: Retrieval+Search
+    Speaker: Satwik Singh (Member of Technical Staff )
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: Building Alice’s Brain: How We Built an AI Sales Rep that Learns Like a Human
+    Description:
+    AI agents are becoming essential tools for teams of all sizes and industries - but training them to become experts in your product, business, and customerbase remains a challenge.
+    
+    What if onboarding a digital worker was as simple as uploading your pitch deck? At 11x, we built Alice, an AI SDR that writes outbound emails with the nuance and context of a top-performing human sales rep - because she learns like one too!
+    
+    In this talk, we'll share how we built a knowledge base that allows 11x customers to "train" Alice on their internal materials: PDFs, websites, call recordings, and more. We'll talk through the ingestion pipeline in detail, discuss storage/retrieval technologies and their tradeoffs, and explain how Alice uses the knowledge base to drive high-performance email outreach at scale.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: Retrieval+Search
+    Speaker: Nina Lopatina (Lead Developer Advocate)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 933689
+    Track: Retrieval+Search
+    Speaker: Frank Liu (Staff Product Manager, MongoDB)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 11:00 AM
+    Session Title: The State of AI-Powered Search and Retrieval
+    Description:
+    In this talk, we examine the state-of-the-art in AI-powered search and retrieval. We detail techniques for enhancing performance beyond base embedding models, including hybrid search, reranking strategies, query decomposition and document enrichment, the use of domain-specific and fine-tuned embeddings, custom data processing pipelines (ETL), and contextualized chunking methods.
+
+  ------------------------------------
+
+    Session ID: 936933
+    Track: Retrieval+Search
+    Speaker: Rajiv Shah (Chief Evangelist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 09:00 AM
+    Session Title: Forget RAG Pipelines—Build Production-Ready AI Agents in 15 Minutes
+    Description:
+    Want to take advantage of your data, but don't want to reinvent RAG infrastructure? Join our workshop and see how you can deploy Agentic RAG in minutes using Contextual AI's managed RAG solution. We'll explore how Contextual handles intelligent parsing and chunking of your data, retrieves information with state of the art accuracy, and generates responses with a multi layered set of guardrails against hallucinations. Together, we'll build an end-to-end Agentic RAG pipeline and demonstrate its integration with Claude Desktop via MCP, so you can see how this could plug into your existing ecosystem.
+    
+    By the end of this session, you'll have a functioning Agentic RAG prototype that you can easily customize and deploy to production for your specific use cases, even with complex, unstructured documents.
+
+  ------------------------------------
+
+    Session ID: 916143
+    Track: Retrieval+Search
+    Speaker: Mark Bain (Founder & Research Scientist)
+    Format: Workshop
+    Room: Golden Gate Ballroom B: GraphRAG
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Make Your AI Agents Remember What They Do!
+    Description:
+    Are you ready to give your AI agents a memory upgrade?
+    Join us for a hands-on, fast-paced workshop where we explore how memory can transform your agents.
+    
+    What You'll Do:
+    Set Up Leading Memory Solutions: Get practical, side-by-side experience with open-source tools including AIUS, Cognee, LangMem, MemGPT, Mem0, and Zep.
+    
+    Explore Memory Types: Learn the theory behind agent memory, including long-term, short-term, episodic, semantic, and other memory types.
+    
+    Run Experiments: Test how memory improves recall, contextual awareness, and reasoning in autonomous agents.
+    
+    Compare Implementations: Get a snapshot of how different solutions implement memory—what’s built-in, what’s flexible, and what’s experimental.
+    
+    Whether you’re working on AI copilots, agentic workflows, or research prototypes—this workshop will help you embed real memory into your AI stack.
+
+  ------------------------------------
+
+    Session ID: 916215
+    Track: Retrieval+Search
+    Speaker: Sherwood Callaway (Tech Lead, Alice )
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: Building Alice’s Brain: How We Built an AI Sales Rep that Learns Like a Human
+    Description:
+    AI agents are becoming essential tools for teams of all sizes and industries - but training them to become experts in your product, business, and customerbase remains a challenge.
+    
+    What if onboarding a digital worker was as simple as uploading your pitch deck? At 11x, we built Alice, an AI SDR that writes outbound emails with the nuance and context of a top-performing human sales rep - because she learns like one too!
+    
+    In this talk, we'll share how we built a knowledge base that allows 11x customers to "train" Alice on their internal materials: PDFs, websites, call recordings, and more. We'll talk through the ingestion pipeline in detail, discuss storage/retrieval technologies and their tradeoffs, and explain how Alice uses the knowledge base to drive high-performance email outreach at scale.
+
+  ------------------------------------
+
+    Session ID: 933702
+    Track: Retrieval+Search
+    Speaker: Mikiko Bazeley (Staff Developer Advocate, MongoDB)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Smarter Together: Designing Multi-Agent Systems with Shared, Evolving Memory
+    Description:
+    In today’s most advanced AI systems, intelligence is no longer confined to a single model or agent—it emerges from coordination. But coordination requires memory: short-term, long-term, and shared. In this talk, we’ll break down how agent systems can store, retrieve, and evolve shared memory to become smarter over time. You'll learn what it takes to architect these continuously learning systems, how to track and improve memory quality, and why robust, flexible infrastructure is the foundation of it all. Stick around to see how this works in practice—live.
+
+  ------------------------------------
+
+    Session ID: 913839
+    Track: Retrieval+Search
+    Speaker: Maitar Asher (Head of Engineering)
+    Format: Talk
+    Room: Golden Gate Ballroom A: Retrieval + Search
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Evaluating AI Search: A Practical Framework for Augmented AI Systems
+    Description:
+    AI search is becoming the front door to information, whether through Retrieval-Augmented Generation (RAG), Search-Augmented Generation (SAG), or custom agents that synthesize answers on top of indexed content. As users rely more heavily on these systems, evaluating their quality becomes mission-critical. But traditional metrics like precision and recall don’t capture the full picture.
+    
+    In this talk, we introduce a practical evaluation framework for AI-powered search, across three dimensions:
+    - Are the retrieved sources relevant to the query?
+    - And is the final answer complete?
+    - Are the sources faithfully used in the generated answer?
+    
+    We’ll share lessons from working with search companies and present early findings from a new benchmark evaluating popular augmented AI systems across these dimensions. Rather than ranking winners and losers, we explore where different systems excel or break down, and how these tradeoffs inform product decisions.
+    
+    This talk is for AI engineers and product teams who want to build trusted, high-quality AI search experiences, and need a way to measure if it’s actually working.
+
+
+
+======================================================================
+---  Track: SWE AGENTS (TBA) ---
+======================================================================
+
+    Session ID: 929855
+    Track: SWE Agents
+    Speaker: Scott Wu (CEO, Cognition AI)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: Devin 2.0 and the Future of SWE
+    Description:
+    A talk on the future of software engineering with Scott Wu of Cognition AI, the makers of Devin.
+
+  ------------------------------------
+
+    Session ID: 939640
+    Track: SWE Agents
+    Speaker: Christian Szegedy (Former co-founder of xAI, discoverer of adversarial examples)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Towards Verified Superintelligence
+    Description:
+    I describe a new paradigm towards open-endedly self-improving intelligence by scaling verification to remove the human data and supervision bottleneck. The objective is to achieve trustless alignment of superintelligence.
+
+  ------------------------------------
+
+    Session ID: 939942
+    Track: SWE Agents
+    Speaker: Boris Cherny (Member of Technical Staff & Creator of Claude Code)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: Introducing Claude Code
+    Description:
+    Hear about Claude Code directly from its creator: origin story, getting your team set up, and practical tips for getting more out of Code.
+
+  ------------------------------------
+
+    Session ID: 914012
+    Track: SWE Agents
+    Speaker: Rustin Banks (Product Manager, AI Coding )
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: Your Coding Agent Just Got Cloned And Your Brain Isn't Ready
+    Description:
+    Will the future engineer code alongside a single coding agent, or will they spend their day orchestrating many agents? Traditional development rewards synchronous focus. This session dives into the significant mindshift required to move from sequential coding to orchestrating parallel agents. We are the builders of "Jules", Google's massively parallel asynchronous coding agent (to be opened up in May). We'll share real-world insights from building Jules and explore how to rewire your brain for this powerful new "post-IDE" development paradigm.
+
+  ------------------------------------
+
+    Session ID: 915961
+    Track: SWE Agents
+    Speaker: Jeremy Adams (Head of Ecosystem)
+    Format: Workshop
+    Room: Nobhill A&B: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Ship Agents that Ship: A Hands-On Workshop for SWE Agent Builders
+    Description:
+    Coding agents are transforming how software gets built, tested, and deployed, but engineering teams face a critical challenge: how to embrace this automation wave without sacrificing trust, control, or reliability.
+    In this 80 minute workshop, you’ll go beyond toy demos and build production-minded AI agents using Dagger, the programmable delivery engine designed for real CI/CD and AI-native workflows. Whether you're debugging failures, triaging pull requests, generating tests, or shipping features, you'll learn how to orchestrate autonomous agents that live in and around your codebase: from your laptop to your CI platform.
+    We’ll guide you through:
+    
+    Building real-world agents with Dagger and popular LLMs (GPT, Claude, etc.)
+    
+    Programming agent environments using real languages (Go, Python, TypeScript)
+    
+    Executing agent workflows locally and in GitHub Actions, so you can bring them to production
+    
+    Using a composable runtime that ensures isolation, determinism, traceability, and repeatability
+    
+    Designing agents that automate and enhance debugging, test generation, code review, bug fixing, and feature implementation
+    
+    
+    By the end of the workshop, you’ll walk away ready to build your own army of autonomous agents, working collaboratively across your codebase, locally and in CI, accelerating development without ceding control. Let’s build agents that don’t just talk, they ship!
+
+  ------------------------------------
+
+    Session ID: 915312
+    Track: SWE Agents
+    Speaker: Raaz Dwivedi (Chief Scientist)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Production software keeps breaking and it will only get worse.  Here’s how Traversal is fixing it.
+    Description:
+    Software is eating the world. AI is eating software. AI-powered SWE means a whole lot more software is going to be written that powers mission critical systems in the coming years, with hardly any of it written by humans. Hence, when these software systems inevitably break, it’s going to be next to impossible to troubleshoot them. Towards addressing this issue, we’ll do a product launch of Traversal’s AI, a significant step towards self-healing software systems. We will showcase how it is already used to autonomously troubleshoot production incidents in some of the most complex enterprise environments.
+
+  ------------------------------------
+
+    Session ID: 915961
+    Track: SWE Agents
+    Speaker: Kyle Penfound (Solutions Engineer at Dagger)
+    Format: Workshop
+    Room: Nobhill A&B: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Ship Agents that Ship: A Hands-On Workshop for SWE Agent Builders
+    Description:
+    Coding agents are transforming how software gets built, tested, and deployed, but engineering teams face a critical challenge: how to embrace this automation wave without sacrificing trust, control, or reliability.
+    In this 80 minute workshop, you’ll go beyond toy demos and build production-minded AI agents using Dagger, the programmable delivery engine designed for real CI/CD and AI-native workflows. Whether you're debugging failures, triaging pull requests, generating tests, or shipping features, you'll learn how to orchestrate autonomous agents that live in and around your codebase: from your laptop to your CI platform.
+    We’ll guide you through:
+    
+    Building real-world agents with Dagger and popular LLMs (GPT, Claude, etc.)
+    
+    Programming agent environments using real languages (Go, Python, TypeScript)
+    
+    Executing agent workflows locally and in GitHub Actions, so you can bring them to production
+    
+    Using a composable runtime that ensures isolation, determinism, traceability, and repeatability
+    
+    Designing agents that automate and enhance debugging, test generation, code review, bug fixing, and feature implementation
+    
+    
+    By the end of the workshop, you’ll walk away ready to build your own army of autonomous agents, working collaboratively across your codebase, locally and in CI, accelerating development without ceding control. Let’s build agents that don’t just talk, they ship!
+
+  ------------------------------------
+
+    Session ID: 936299
+    Track: SWE Agents
+    Speaker: Chris Kelly (All Things Developer @ Augment Code)
+    Format: Talk
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 10:55 AM
+    Session Title: Vibe Coding in Production
+    Description:
+    What's the role of vibe coding in a production-grade applications? Join Augment Code's Matt McClernan as he speaks to engineering leaders about building with AI.
+
+  ------------------------------------
+
+    Session ID: 914017
+    Track: SWE Agents
+    Speaker: Josh Albrecht (CTO and Co-founder)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: Beyond the Prototype: Using AI to Write High-Quality Code
+    Description:
+    In this case study-based keynote, Josh Albrecht, CTO of Imbue, examines the critical engineering challenges in building AI coding systems that create more than just prototypes. Drawing from Imbue's research developing Sculptor, an experimental coding agent environment, Josh shares key insights into the fundamental technical obstacles encountered when evolving AI-assisted coding from toy applications to more robust software systems.
+    
+    The session will explore approaches to core challenges like safely executing code, managing context across large codebases, automating test generation, and creating systems that can identify potential pitfalls in AI-generated code. Attendees will gain practical insights into the technical underpinnings of next-generation coding agents that aim to handle complex software engineering challenges architecting larger systems, increasing meaningful test coverage and designing systems that are easy to debug—moving us closer to AI systems that can help create maintainable software.
+    
+
+  ------------------------------------
+
+    Session ID: 933560
+    Track: SWE Agents
+    Speaker: Forrest Brazeal (Speaker and Workshop Organizer)
+    Format: Workshop
+    Room: Foothill C: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Navigating deep context in legacy code with Augment Agent
+    Description:
+    Attendees will learn to use an AI coding agent as a fast and intuitive part of navigating and working with complex, production-grade legacy code bases. We will drop directly into the code–written in assembly–that landed the1969 Apollo 11 astronauts on the moon and, through a series of challenges, locate parts of the code tied to key functionality. Using the agent to convert a key guidance computer algorithm into a more modern programming language, attendees will then compete to see whose code has what it takes to land on the moon.
+
+  ------------------------------------
+
+    Session ID: 936298
+    Track: SWE Agents
+    Speaker: Forrest Brazeal (Speaker and Workshop Organizer)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: To the moon! Navigating deep context in legacy code with Augment Agent
+    Description:
+    Shortened presentation-only version of our Apollo 11 workshop
+
+  ------------------------------------
+
+    Session ID: 904751
+    Track: SWE Agents
+    Speaker: Eno Reyes (CTO)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 03:00 PM
+    Session Title: Ship Production Software in Minutes, Not Months
+    Description:
+    Planning, coding, testing, monitoring—the endless cycle that spans 10+ tools that fragment our focus and slows delivery to a crawl. Vibe coding doesn't work when you've got 10TB of code. If you just sighed, you're one of many professional software engineers trapped in the traditional software development lifecycle (SDLC) that was designed before AI could parallelize your entire workflow.
+    
+    But what if you could orchestrate multiple AI agents on tasks beyond just generating code, while you focus on the creative decisions that matter?
+    
+    In this talk, I'll demonstrate how real enterprise organizations are changing their entire SDLC—going from understanding, planning, coding, and testing all the way to incident response—using AI agents. You'll witness the next evolution of software engineering—where AI doesn't just generate code, but orchestrates the entire development lifecycle.
+
+  ------------------------------------
+
+    Session ID: 936298
+    Track: SWE Agents
+    Speaker: Matt Ball (Empowering Developers with AI )
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 03:15 PM
+    Session Title: To the moon! Navigating deep context in legacy code with Augment Agent
+    Description:
+    Shortened presentation-only version of our Apollo 11 workshop
+
+  ------------------------------------
+
+    Session ID: 944044
+    Track: SWE Agents
+    Speaker: Jonathon Belotti (Member of Technical Staff @ Modal)
+    Format: Talk
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:15 PM
+    Session Title: Run 1000 branches of code with sandbox snapshotting
+    Description:
+    A peek under the hood of how we built container checkpoints and restores to enable massively parallel agentic workflows.
+    
+    No one wants to wait on infrastructure. In this short talk we’ll go through a demo and system design of container checkpoint/restore, which supports both burst autoscaling and agent branching for Modal's serverless Functions and Sandboxes.
+    
+    Can you save a live container to a file? Can you save a live GPU? Come by the Modal booth to find out!
+
+  ------------------------------------
+
+    Session ID: 915312
+    Track: SWE Agents
+    Speaker: Matthew Schoenbauer (Founding Engineer)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Production software keeps breaking and it will only get worse.  Here’s how Traversal is fixing it.
+    Description:
+    Software is eating the world. AI is eating software. AI-powered SWE means a whole lot more software is going to be written that powers mission critical systems in the coming years, with hardly any of it written by humans. Hence, when these software systems inevitably break, it’s going to be next to impossible to troubleshoot them. Towards addressing this issue, we’ll do a product launch of Traversal’s AI, a significant step towards self-healing software systems. We will showcase how it is already used to autonomously troubleshoot production incidents in some of the most complex enterprise environments.
+
+  ------------------------------------
+
+    Session ID: 933632
+    Track: SWE Agents
+    Speaker: Numair Baseer (Deployed Engineer, Windsurf)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Agentic Coding with Windsurf
+    Description:
+    Agentic coding marks a new era in software development, where AI agents take on autonomous roles in coding tasks. The Windsurf IDE embodies this shift by integrating intelligent agents like Cascade, which maintain full codebase context to perform multi-file edits, run terminal commands, and suggest changes through tools like Supercomplete and Flows. In this session, we will explore features that allow developers to guide strategy while the AI handles execution, enhancing productivity and enabling more creative, high-level work.
+
+  ------------------------------------
+
+    Session ID: 933462
+    Track: SWE Agents
+    Speaker: Kenneth DuMez (DevRel Lead, Graphite)
+    Format: Workshop
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 10:45 AM
+    Session Title: The fastest software dev workflow in the world: AI meets stacked diffs
+    Description:
+    Learn the secrets behind the workflows that engineers at the fastest moving companies in the world are using to build software for billions of users worldwide. This workshop will cover a comprehensive overview of how to leverage generative AI to write code, how to stack and submit these pull requests, and finally how to use AI to review them.
+
+  ------------------------------------
+
+    Session ID: 915312
+    Track: SWE Agents
+    Speaker: Raj Agrawal (CTO,  Cofounder)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Production software keeps breaking and it will only get worse.  Here’s how Traversal is fixing it.
+    Description:
+    Software is eating the world. AI is eating software. AI-powered SWE means a whole lot more software is going to be written that powers mission critical systems in the coming years, with hardly any of it written by humans. Hence, when these software systems inevitably break, it’s going to be next to impossible to troubleshoot them. Towards addressing this issue, we’ll do a product launch of Traversal’s AI, a significant step towards self-healing software systems. We will showcase how it is already used to autonomously troubleshoot production incidents in some of the most complex enterprise environments.
+
+  ------------------------------------
+
+    Session ID: 915312
+    Track: SWE Agents
+    Speaker: Anish Agarwal (CEO and Co-founder)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Production software keeps breaking and it will only get worse.  Here’s how Traversal is fixing it.
+    Description:
+    Software is eating the world. AI is eating software. AI-powered SWE means a whole lot more software is going to be written that powers mission critical systems in the coming years, with hardly any of it written by humans. Hence, when these software systems inevitably break, it’s going to be next to impossible to troubleshoot them. Towards addressing this issue, we’ll do a product launch of Traversal’s AI, a significant step towards self-healing software systems. We will showcase how it is already used to autonomously troubleshoot production incidents in some of the most complex enterprise environments.
+
+  ------------------------------------
+
+    Session ID: 915745
+    Track: SWE Agents
+    Speaker: Misha  Laskin (CEO & co-founder)
+    Format: Talk
+    Room: Yerba Buena Ballroom 2-6: Reasoning + RL
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Post-Training Open Models with RL for Autonomous Coding
+    Description:
+    The models and techniques to build fully autonomous coding agents - not just coding copilots - are already here. In this talk, former Google DeepMind staff research scientist, now CEO of Reflection Misha Laskin will present new research on post-training open weight LLMs for autonomous SWE tasks. He’ll focus on how scaling LLMs with Reinforcement Learning improves the autonomous coding capabilities of LLMs, and provide insight on the technical challenges required to train such systems at scale.
+
+  ------------------------------------
+
+    Session ID: 933629
+    Track: SWE Agents
+    Speaker: Sam Alba (Co-Founder of Dagger)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: How to trust an agent with software delivery
+    Description:
+    AI-powered agents promise faster, easier software delivery, but their unpredictable behavior often makes engineers hesitant to fully trust them with critical workflows. Sam Alba, Co-founder of Dagger (and previously co-creator of Docker), explains how teams can reliably integrate agents into their delivery pipelines by shifting how they structure and manage automation.
+    
+    He'll share four practical strategies learned from real-world experience:
+    
+    1. Treat agents as workflow participants, not isolated tools.
+    Stop using agents as disconnected scripts or IDE plugins. Treating them as first-class parts of your delivery process simplifies your architecture, reduces hidden complexity, and makes agent outcomes more predictable.
+    
+    2. Use many small agents instead of one big one.
+    Just as software evolved from monoliths to microservices, software delivery benefits from smaller, specialized agents with clearly defined responsibilities. Smaller agents are easier to understand, maintain, and integrate.
+    
+    3. Define clear environments—the real lever for reliability.
+    Instead of chasing perfect prompts or models, focus on clearly defining the tools, resources, and permissions around your agents. Precisely controlling their environments makes agents behave consistently and reliably.
+    
+    4. Design workflows for easy debugging and observability.
+    Agents will sometimes fail unexpectedly. Sam will share simple, effective ways to build clear tracing and observability into your workflows from the start, making debugging quicker and less frustrating.
+    
+    You'll leave with practical, immediately usable techniques that give you the confidence to trust AI agents in your software delivery pipelines.
+
+  ------------------------------------
+
+    Session ID: 915387
+    Track: SWE Agents
+    Speaker: Robert Brennan (CEO)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: Software Development Agents: What Works and What Doesn't
+    Description:
+    The adoption of AI into software development has been bumpy. While autocomplete tools like Copilot have gone mainstream, autonomous agents like Devin and OpenHands have generated both enthusiasm and skepticism. Some engineers claim they generate a 10x productivity boost; others that they just create noise and tech debt.
+    
+    The difference between the enthusiasts and the skeptics is that the enthusiasts have reasonable expectations for what these agents can do, and have both practical and intuitive knowledge for how to use them effectively.
+    
+    In this session, we'll talk about what tasks are appropriate for today's software agents, what tasks they might start to succeed at in 2025, and what tasks are best left to humans no matter how good they get.
+    
+    Session Outline:
+    Learn how to use software development agents like OpenHands (fka OpenDevin) effectively, without creating noise and tech debt.
+
+  ------------------------------------
+
+    Session ID: 933633
+    Track: SWE Agents
+    Speaker: Sam  Fertig (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: The Eyes Are The (Context) Window to The Soul: How Windsurf Gets to Know You
+    Description:
+    Sometimes it seems like Windsurf knows you a little too well. It's one thing to generate generic code, but to predict your next intent? From matching existing code patterns and styles to tracking how local changes affect the larger codebase, this talk digs into the technical challenges of context awareness and why simply indexing code falls short. Relive our journey tackling the core issue in the AI IDE space : balancing retrieval quality with latency constraints and scaling effectively as codebases grow. For those curious about the infrastructure behind context-aware AI, this talk offers insights into our approach of turning massive codebases into collections of useful context.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: SWE Agents
+    Speaker: Tejashwa Tiwari (Analytics and Automation Engineer)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+  ------------------------------------
+
+    Session ID: 933545
+    Track: SWE Agents
+    Speaker: Eric Hou (Member of Technical Staff, Augment Code)
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Mentoring the Machine
+    Description:
+    You’d never let a swarm of fresh interns ship to prod on day one—same deal with AI agents. Mentoring the Machine dives into how acting like a tech lead (not just a user) turns those bots into real leverage. In this talk, Eric will deliver practical advice for working with AI agents in the SDLC. He'll also preview how effective use of AI agents changes the calculus of software engineering at both a micro and macro level.
+    
+
+  ------------------------------------
+
+    Session ID: 933684
+    Track: SWE Agents
+    Speaker: Eashan Sinha (Deployed Engineer, Windsurf)
+    Format: Talk
+    Room: Nobhill A&B: Expo Sessions
+    Time: 4 Jun 2025 10:55 AM
+    Session Title: Mastering Engineering Flow with Windsurf
+    Description:
+    As experienced engineers, especially senior and staff engineers, our focus shifts towards complex problem-solving, architectural decisions, and mentoring. While AI tools promise productivity gains, Windsurf offers more than just code completion and chat assistance – it's an agentic IDE built to enhance engineering flow. This talk explores how experienced engineers can leverage Windsurf's deep contextual awareness, structured guidance, and automated workflows to tackle sophisticated and complex tasks. We'll demonstrate practical strategies for accelerating feature development, automating code maintenance and reviews, and ultimately freeing up cognitive load to focus on high-impact engineering challenges. Learn how to move beyond basic AI assistance and truly partner with Windsurf to excel in your role.
+
+  ------------------------------------
+
+    Session ID: 916115
+    Track: SWE Agents
+    Speaker: Itamar Friedman (CEO)
+    Format: Talk
+    Room: Foothill C: Agent Reliability
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Vibe Coding, with Confidence
+    Description:
+    Everyone wants to do Vibe Code, even large Enterprises. But how can we ensure that the generated code is well-grounded with the dev team's code and software development standards? In this talk, Itamar will present how to use various tools and agents, including MCP and A2A, to achieve precisely that.
+
+  ------------------------------------
+
+    Session ID: 933560
+    Track: SWE Agents
+    Speaker: Matt Ball (Empowering Developers with AI )
+    Format: Workshop
+    Room: Foothill C: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Navigating deep context in legacy code with Augment Agent
+    Description:
+    Attendees will learn to use an AI coding agent as a fast and intuitive part of navigating and working with complex, production-grade legacy code bases. We will drop directly into the code–written in assembly–that landed the1969 Apollo 11 astronauts on the moon and, through a series of challenges, locate parts of the code tied to key functionality. Using the agent to convert a key guidance computer algorithm into a more modern programming language, attendees will then compete to see whose code has what it takes to land on the moon.
+
+  ------------------------------------
+
+    Session ID: 933685
+    Track: SWE Agents
+    Speaker: Tejashwa Tiwari (Automation Engineer @ Windsurf)
+    Room: Salons 9-15: Expo Hall
+    Time: 4 Jun 2025 01:45 PM
+    Session Title: Windsurf & Wonders
+    Description:
+    Come learn about why Windsurf is the premiere choice for engineers and enterprises alike in applications of AI for development.
+
+
+
+======================================================================
+---  Track: SECURITY (June 5) ---
+======================================================================
+
+    Session ID: 933612
+    Track: Security
+    Speaker: Antje Barth (Principal Developer Advocate)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:05 PM
+    Session Title: Building  Agents at Cloud-Scale
+    Description:
+    Let's explore  practical strategies for building and scaling agents in production. Discover  how to move from local MCP implementations to cloud-scale architectures and  how engineering teams leverage these patterns to develop sophisticated agent  systems. Expect a mix of demos, use case discussions, and a glimpse into the  future of agentic services!
+
+  ------------------------------------
+
+    Session ID: 947798
+    Track: Security
+    Speaker: Sander Schulhoff (CEO)
+    Format: Workshop
+    Room: SOMA: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Prompt Engineering & AI Red Teaming
+    Description:
+    Learn from the creator of Learn Prompting, the internet's 1st Prompt Engineering guide (released 2 months before ChatGPT), and HackAPrompt, the World's 1st AI Red Teaming competition.
+    
+    My talk will cover topics ranging from the history of prompt engineering to the most advanced research-backed prompt engineering techniques.
+    
+    I will also discuss the origins of prompt injection and AI red teaming, as well as the current state of industry and the need for agentic red teaming.
+    
+    Finally, we will have an interactive competition where you will be able to hone your prompt hacking skills and win prizes from swyx!
+    
+    https://www.hackaprompt.com
+
+  ------------------------------------
+
+    Session ID: 936795
+    Track: Security
+    Speaker: Kam Sween (Auth0, Staff Engineer, AIFS)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Securing Agents with Open Standards
+    Description:
+    Shipping AI agents that are safe for production means solving some tough identity and authorization challenges that are not always obvious at the prototype stage. In practice, this comes down to a handful of deeply technical questions:
+    - How do you make sure agents are only acting for the right user?
+    - How do you prevent over-broad API access or data leaks?
+    - How do you handle user approvals when there is no UI, or you need a human in the loop?
+    - And how do you avoid the usual pain points like manual credential sharing, stale keys, or unpredictable scopes without writing a lot of brittle, custom code?
+    
+    This talk digs into the real technical trade-offs behind building secure, user-aware AI agents. We will go beyond what to do and explain why, sharing the architectural decisions, open standards, and hard lessons learned from integrating OAuth, OIDC, RAR, and async authorization into agent-driven workflows.
+    
+    You will see a hands-on demo using an open-source Node.js agent and open protocols, with a focus on practical integration and no magic. The session will show how these solutions have shaped our approach to identity in GenAI and where we see the field heading next.
+    
+    If you are an engineer building AI apps that need real guardrails, not just a happy-path demo, we hope to leave you with some practical patterns, design rationale, and a clear view of the trade-offs for making your own agents production ready.
+
+  ------------------------------------
+
+    Session ID: 913351
+    Track: Security
+    Speaker: David Mytton (Founder)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: How to defend your sites from AI bots
+    Description:
+    Constantly seeing CAPTCHAs? It used to be easy to detect the humans from the droids, but what else can we do when synthetic clients make up nearly half of all web requests. Rotating IPs, spoofed browsers, and agents acting on behalf of real users - are we doomed to forever be solving puzzles?
+    
+    In this talk, we’ll explore user agents, HTTP fingerprints, and IP reputation signals that make humans and agents stand out from scrapers, build a realistic threat model, and dig into the behaviors that reveal the LLM-mimicry. Leave with AX- and UX-safe code, benchmarks, and tools to help you take back control.
+
+  ------------------------------------
+
+    Session ID: 915873
+    Track: Security
+    Speaker: Rene Brandel (CEO)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 02:40 PM
+    Session Title: How we hacked YC Spring 2025 batch’s AI agents
+    Description:
+    We hacked 7 of the16 publicly-accessible YC X25 AI agents. This allowed us to leak user data, execute code remotely, and take over databases. All within 30 minutes each. In this session, we'll walk through the common mistakes these companies made and how you can mitigate these security concerns before your agents put your business at risk.
+
+  ------------------------------------
+
+    Session ID: 933569
+    Track: Security
+    Speaker: Lou Bichard (Product Manager, Gitpod)
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Building CISO-approved agent fleet architecture
+    Description:
+    Security is the biggest blocker for agent orchestration adoption in regulated industries for SWE agents. Gitpod's agent orchestration went from an originally self-hosted kubernetes architecture to the current 'bring your own cloud' model that enables deployment our SWE agent orchestration platform in secure environments. The architecture allows customers to securely connect their foundational models and agent memory solutions and comes with features like auto-suspend and resume for agent fleets. In this talk we deep dive into the architecture to share our years of learnings in how to secure agent workloads at scale in secure and regulated environments.
+
+  ------------------------------------
+
+    Session ID: 909905
+    Track: Security
+    Speaker: Jonathan Mortensen (CEO)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 11:35 AM
+    Session Title: The Unofficial Guide to Apple’s Private Cloud Compute
+    Description:
+    In October 2024, Apple released a new private AI technology onto millions of devices called “Private Cloud Compute”. It brings the same level of privacy and security a local device offers but on an “untrusted" remote server. This talk discusses how Private Cloud Compute represents a paradigm shift in confidential computing and explores the core advancements that made it possible to become mainstream. We’ll explore its novel architecture that allows developers to run sensitive, multi-tenant workloads with cryptographically-provably privacy guarantees at scale and at reasonable cost. Attendees will leave with an understanding of how to leverage this technology for data and AI applications where privacy and security is paramount.
+
+  ------------------------------------
+
+    Session ID: 936795
+    Track: Security
+    Speaker: Bobby Tiernay (Auth0, Principal Architect)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Securing Agents with Open Standards
+    Description:
+    Shipping AI agents that are safe for production means solving some tough identity and authorization challenges that are not always obvious at the prototype stage. In practice, this comes down to a handful of deeply technical questions:
+    - How do you make sure agents are only acting for the right user?
+    - How do you prevent over-broad API access or data leaks?
+    - How do you handle user approvals when there is no UI, or you need a human in the loop?
+    - And how do you avoid the usual pain points like manual credential sharing, stale keys, or unpredictable scopes without writing a lot of brittle, custom code?
+    
+    This talk digs into the real technical trade-offs behind building secure, user-aware AI agents. We will go beyond what to do and explain why, sharing the architectural decisions, open standards, and hard lessons learned from integrating OAuth, OIDC, RAR, and async authorization into agent-driven workflows.
+    
+    You will see a hands-on demo using an open-source Node.js agent and open protocols, with a focus on practical integration and no magic. The session will show how these solutions have shaped our approach to identity in GenAI and where we see the field heading next.
+    
+    If you are an engineer building AI apps that need real guardrails, not just a happy-path demo, we hope to leave you with some practical patterns, design rationale, and a clear view of the trade-offs for making your own agents production ready.
+
+  ------------------------------------
+
+    Session ID: 933686
+    Track: Security
+    Speaker: Michael Grinich (Founder & CEO, WorkOS )
+    Format: Talk
+    Room: SOMA: AI Architects
+    Time: 5 Jun 2025 02:00 PM
+    Session Title: CIAM for AI: Who Are Your Agents and What Can They Do?
+    Description:
+    AI agents are changing the way modern SaaS products operate. Whether automating workflows, integrating with APIs, or acting on behalf of users, AI-driven assistants and autonomous systems are becoming core product features. But securing these agents presents a fundamental challenge: How do you authenticate AI agents? How do you control what they can access? How do you ensure they act within the right permissions? This talk will explore these concepts and more while highlighting current research and best practices.
+
+  ------------------------------------
+
+    Session ID: 933610
+    Track: Security
+    Speaker: Mike Chambers (AI/ML Specialist DA AWS)
+    Format: Talk
+    Room: Golden Gate Ballroom C: AI in the Fortune 500
+    Time: 5 Jun 2025 12:15 PM
+    Session Title: Ship it! Building Production-Ready Agents
+    Description:
+    Explore the practical challenges and solutions for deploying AI agents in real-world production environments. Through detailed technical analysis and practical examples, we'll examine strategies for building and orchestrating agent systems at scale. We'll cover critical infrastructure decisions, scalability frameworks, and best practices for creating robust, production-ready agent architectures.
+
+  ------------------------------------
+
+    Session ID: 933656
+    Track: Security
+    Speaker: Nick Nisi (Software developer and panelist on the JS Party podcast)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 12:45 PM
+    Session Title: Agents, Access, and the Future of Machine Identity
+    Description:
+    AI agents are calling APIs, submitting forms, and sending emails—but how do you control what they’re allowed to do? As agents act on behalf of users or organizations, traditional patterns like OAuth, session tokens, and role-based access often fall short.
+    In this talk, we’ll explore how machine identity is evolving to meet this new landscape. You’ll learn:
+    
+    - How to think about authentication for agents (not just humans)
+    - What it means to authorize an action when the actor is an LLM or headless service
+    - Real-world strategies from WorkOS and Cloudflare for assigning, managing, and revoking agent identity and access
+    
+    By the end, you’ll walk away with practical tools and mental models to build agent-powered systems that are secure, auditable, and scalable.
+
+  ------------------------------------
+
+    Session ID: 915751
+    Track: Security
+    Speaker: Jared Hanson (Co-Founder)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 02:20 PM
+    Session Title: How to Secure Agents using OAuth
+    Description:
+    We all know sharing passwords is bad (unless you want free TV), so why are we sharing API keys with AI?  We shouldn't, and that’s why we need to talk about OAuth.
+    
+    In this talk, we will give a brief intro to OAuth.  Then we will talk about the state of authorization in MCP.  We will show how an MCP client uses OAuth to authenticate a user and securely access private resources and tools hosted by an MCP server.  Then we’ll look at ways autonomous agents can use OAuth on their own behalf, talking to other agents and MCP servers directly.  We’ll learn how to use OAuth to build agents that humans and machines can trust.
+
+  ------------------------------------
+
+    Session ID: 915978
+    Track: Security
+    Speaker: Leonard Tang (Founder & CEO)
+    Format: Talk
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: Fuzzing in the GenAI Era
+    Description:
+    "Evaluation" is one of those concepts that every AI practitioner vaguely knows is important, but few practitioners truly understand. Is "eval" the dataset for measuring the quality of your AI system? Is "eval" the measure, the metric of quality? Is "eval" the process of human annotation and scoring? Or is "eval" a third-party dataset run once to benchmark a model?
+    
+    To mitigate this cacophony, this talk will provide an opinionated and principled perspective for what we actually mean when we say “evaluation”, beyond the traditional for-loop-over-a-static dataset.
+    
+    In particular, this perspective draws heavy inspiration from *fuzzing*, i.e. bombarding AI with simulated, unexpected user inputs to uncover corner cases at scale. This factors into sub-problems regarding:
+    
+    - Quality Metric. What is the actual criteria we, as humans, are using to determine if an AI system is producing good or bad responses? How do we elicit these criteria before the human SME can articulate them? How do we, as efficiently as possible, operationalize this criteria with an automated *Judge*?
+    
+    - Stimuli Generation. Given a metric, how do we know, with confidence, that an AI system is performing well with respect to the metric? What data is representative and sufficient for discovering all potential bugs of an AI system? And how do we generate this complex, diverse, faithful data at scale?
+    
+    We will discuss in detail the philosophy, technology, and case studies behind both problems of Quality Metric and Stimuli Generation, and how they interact in concert.
+
+  ------------------------------------
+
+    Session ID: 938753
+    Track: Security
+    Speaker: Fouad Matin (Member of Technical Staff, OpenAI)
+    Format: Keynote
+    Room: Foothill C: Security
+    Time: 5 Jun 2025 11:15 AM
+    Session Title: Safety and security for code-executing agents
+    Description:
+    Code is the lingua franca for both software engineers and highly capable AI models. As we give agents the ability to build, test, and run code that they generate, the command line becomes their canvas—and their attack surface.
+    
+    This keynote explores what it takes to bring code-executing agents from research to real-world deployment while maintaining control and security. We’ll cover how terminals offer AI an ideal interface, why they’re deceptively risky, and what it means to embed security, guardrails, and trust at every layer.
+    
+    It’s not just about what agents can do—it’s about what they should do, and how we make sure they do it safely.
+
+
+
+======================================================================
+---  Track: TINY TEAMS (June 4) ---
+======================================================================
+
+    Session ID: 933675
+    Track: Tiny Teams
+    Speaker: Kevin Hou (Head of Product, Windsurf)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:25 PM
+    Session Title: Windsurf everywhere, doing everything, all at once
+    Description:
+    abstract tbd
+
+  ------------------------------------
+
+    Session ID: 914550
+    Track: Tiny Teams
+    Speaker: Sid Bendre (Co-Founder)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: The New Lean Startup
+    Description:
+    In this session, I will be presenting a case study of Oleve's journey, revealing how we've scaled a profitable multi-product portfolio with a tiny team. I'll walk you through the emergence of "tiny teams," our two-track engineering methodology that has become our blueprint, as well as an inside look at our technical alpha – specifically how we've engineered deterministic AI agents to deliver magical and reliable consumer experiences to millions. You'll learn how we've built internal tools to grow leanly and created operating playbooks to scale operations without traditional headcount requirements. I'll also share our approach to scrappy infrastructure innovation and how our investment in internal tooling has served as a critical force multiplier. Finally, I'll give an overview of parts of the profitable portfolio playbook that keeps us lean, adaptable, and profitable across multiple product lines.
+    
+    Structure of talk:
+    - the tiny teams revolution
+    - the two-track engineering approach
+    - technical alpha: deterministic ai agents at scale
+    - scrappy infrastructure innovation
+    - internal tooling as a multiplier
+    - the profitable portfolio playbook
+
+  ------------------------------------
+
+    Session ID: 923914
+    Track: Tiny Teams
+    Speaker: Grant Lee (CEO)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Tiny Teams
+    Description:
+    Sean reached out on X, happy to do a talk on how to build a tiny team
+
+  ------------------------------------
+
+    Session ID: 939097
+    Track: Tiny Teams
+    Speaker: Vikas Paruchuri (CEO)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Building Small AI Teams with Huge Impact
+    Description:
+    tbd
+
+  ------------------------------------
+
+    Session ID: 911846
+    Track: Tiny Teams
+    Speaker: Hassan El Mghari (DevRel lead )
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: Using OSS models to build AI apps with millions of users
+    Description:
+    In this talk, Hassan will go over how he builds open source AI apps that get millions of users like roomGPT.io (2.9 million users), restorePhotos.io (1.1 million users), Blinkshot.io (1 million visitors), and LlamaCoder.io (1.4 million visitors). He'll go over his journey in AI, demo some of the apps that he's built, and dig into his tech stack and code to explain how he builds these apps from scratch. He’ll also go over how to market them and go over his top tips and tricks for building great full-stack AI applications quickly and efficiently.
+    
+    This talk will start from first principles and give you a glimpse into Hassan’s workflow of idea -> working app -> many users. Attendees should come out of this session equipped with the resources to build impressive AI applications and understand some of the behind the scenes of how they’re built and marketed. This will hopefully serve as an educational and inspirational talk that encourages builders to go build cool things.
+
+  ------------------------------------
+
+    Session ID: 939142
+    Track: Tiny Teams
+    Speaker: Eric Simons (CEO, Bolt.new)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: Bolt: The Dawn of the VibeCoder
+    Description:
+    tbd
+
+  ------------------------------------
+
+    Session ID: 940118
+    Track: Tiny Teams
+    Speaker: Max Brodeur-Urbas (Founder and CEO of Gumloop)
+    Format: Talk
+    Room: Yerba Buena Ballroom Salons 2-6: Tiny Teams
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Gumloop's Path to be a 10 person unicorn
+    Description:
+    An overview of how Gumloop is scaling automation across companies like Instacart, Webflow and Shopify with less than 10 people.
+
+  ------------------------------------
+
+    Session ID: 941906
+    Track: Tiny Teams
+    Speaker: Alex Atallah (CEO OpenRouter, co-founder of OpenSea)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 04:35 PM
+    Session Title: fun stories from building OpenRouter and where all this is going
+    Description:
+    How the first LLM aggregator got started, some of the weird moments in its early growth, architecture challenges, and where we'll be taking it down the road
+
+
+
+======================================================================
+---  Track: UNCATEGORIZED (TBA) ---
+======================================================================
+
+    Session ID: 936006
+    Track: Uncategorized
+    Speaker: Greg Brockman (Cofounder, OpenAI)
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 4 Jun 2025 04:45 PM
+    Session Title: #define AI Engineer
+    Description:
+    Greg Brockman's career and advice for AI Engineers
+
+  ------------------------------------
+
+    Session ID: 939093
+    Track: Uncategorized
+    Speaker: Julián  Duque (Principal Developer Advocate at Heroku)
+    Format: Workshop
+    Room: Nobhill A&B: Expo Sessions
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Building Agentic Applications with Heroku Managed Inference and Agents
+    Description:
+    In this workshop, you’ll learn how to use Heroku Managed Inference and Agents to build agentic applications. We’ll cover how to provision and deploy LLM models to your app, run untrusted code securely in Python, Node.js, Go, and Ruby using built-in tools, and use the Model Context Protocol (MCP) to connect tools and actions that extend your agents' capabilities.
+
+  ------------------------------------
+
+    Session ID: 936907
+    Track: Uncategorized
+    Speaker: Emma Ning (Principal PM in Microsoft)
+    Format: Talk
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 03:30 PM
+    Session Title: Empowering Developers to build Cutting-Edge AI experiences on device
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 936818
+    Track: Uncategorized
+    Speaker: Cedric  Vidal (Principal AI Advocate)
+    Format: Talk
+    Room: Nobhill C&D: Microsoft
+    Time: 4 Jun 2025 01:10 PM
+    Session Title: Agentic Excellence: Mastering Evaluation of AI Agents with Azure AI Evaluation SDK
+    Description:
+    As AI agents transition from experimental assistants to critical components of enterprise workflows, reliably evaluating their performance becomes essential. But how do you systematically measure an AI agent’s capabilities, contextual understanding, and accuracy across diverse scenarios?
+    
+    In this talk, we'll dive deep into the Azure AI Evaluation SDK, an innovative tool designed to rigorously assess agentic applications. Learn how to create powerful evaluations using structured test plans, scenarios, and advanced analytics that pinpoint strengths and expose hidden weaknesses. Through practical examples and real-world case studies, you'll discover how companies are already leveraging this SDK to enhance agent trustworthiness, reliability, and performance.
+    
+    Whether you're developing conversational agents, data-driven decision-makers, or autonomous workflow orchestrators, this session equips you with the techniques and insights needed to ensure your AI solutions deliver exceptional value and exceed user expectations.""
+    
+
+  ------------------------------------
+
+    Session ID: 935456
+    Track: Uncategorized
+    Speaker: Harald Kirschner (VS Code Team Member)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Real-World Development with GitHub Copilot and VS Code
+    Description:
+    Join us for a hands-on workshop designed to demonstrate how VS Code and GitHub Copilot's expanding suite of AI features can match or even surpasses the benefits of other popular AI developer tools.  We'll focus on practical scenarios to ensure immediate applicability and work through live demos of Copilot features such as: Code generation using Edits, Planning/problem solving using Chat, Inline terminal command generation, Boilerplate code generation using Agent mode, Improving boilerplate with custom instructions and then refactoring using Agent mode and Edits, Improving test generation and code reviews with custom instructions, as well as an Introduction to MCP.
+    Pre Requisit - install GitHub Copilot and VS Code
+
+  ------------------------------------
+
+    Session ID: 936902
+    Track: Uncategorized
+    Speaker: Harald Kirschner (VS Code Team Member)
+    Format: Talk
+    Room: Juniper: Expo Sessions
+    Time: 5 Jun 2025 01:00 PM
+    Session Title: Vibe Coding at Scale: Customizing AI Assistants for Enterprise Environments
+    Description:
+    "Vibe coding" often falters in complex enterprise environments. Drawing from real implementations, this talk demonstrates systematic approaches to customizing AI assistants for challenging codebases. We'll explore specialized techniques for navigating complex architectures, evidence-based strategies for undocumented legacy systems, methodologies for maintaining context across polyglot environments, and frameworks for standardizing AI usage while preserving developer autonomy. Through case studies from finance and healthcare, we'll present a comprehensive evaluation framework that bridges the gap between AI's theoretical capabilities and practical enterprise implementation, enabling true flow-state collaboration even within the most complex development ecosystems.
+
+  ------------------------------------
+
+    Session ID: 936906
+    Track: Uncategorized
+    Speaker: Jonathan Larson (Senior Principal Data Architect)
+    Format: Talk
+    Room: Juniper: Expo Sessions
+    Time: 4 Jun 2025 03:15 PM
+    Session Title: GraphRAG methods to create optimized LLM context windows for retrieval
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 937936
+    Track: Uncategorized
+    Speaker: Matthias Loibl (Director of Cloud at Polar Signals)
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 03:30 PM
+    Session Title: Polar Signals Expo Session
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 939088
+    Track: Uncategorized
+    Speaker: Daria Soboleva (Head Research Scientist, Cerebras)
+    Format: Workshop
+    Room: Nobhill A&B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: From Mixture of Experts to Mixture of Agents … with Super Fast Inference
+    Description:
+    Our hands-on workshop will walk you through how to build your own Mixture of Agents (MoA) system using the fastest, and most capable open models available: Qwen3-32B and Llama 3.3-70B. MoA is an emerging architecture that combines the strengths of multiple large language models in a layered, agent-based design. This approach delivers superior performance by enabling specialized agents to collaborate across layers—outperforming today’s frontier models in both accuracy and efficiency.
+    
+    To ground this new paradigm in its roots, we’ll also explore how Mixture of Experts (MoE) architectures continue to push the boundaries of scale and specialization. Learn how Cerebras trains state-of-the-art MoEs from Daria Soboleva, Head Research Scientist.
+
+  ------------------------------------
+
+    Session ID: 940839
+    Track: Uncategorized
+    Speaker: Jon Peck (Technical Advocate & Software Developer)
+    Format: Workshop
+    Room: Nobhill C&D: Microsoft
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Collaborating with Agents in your Software Development Workflow
+    Description:
+    GitHub Copilot's agentic capabilities enhance its ability to act as a peer programmer. From the IDE to the repository, Copilot can generate code, run tests, and perform tasks like creating pull requests using Model Context Protocol (MCP). This instructor-led lab will guide you through using agent capabilities on both the client and the server: Key takeaways include:
+    Understanding how to bring agents into your software development workflow
+    Identifying scenarios where agents can be most impactful, as well as tips and tricks to provide the right context to lead to success
+    Discovering how Model Context Protocol provides access to an additional set of external tools and capabilities that the agent can use
+    Recommended practices to accelerate your development while maintaining code quality.
+
+  ------------------------------------
+
+    Session ID: 936903
+    Track: Uncategorized
+    Speaker: Jon Peck (Technical Advocate & Software Developer)
+    Format: Talk
+    Room: Willow: Expo Sessions
+    Time: 4 Jun 2025 01:15 PM
+    Session Title: Real-world MCPs in GitHub Copilot Agent Mode
+    Description:
+    As developers, we don't spend most of our time vibe-coding prototypes. More often, we're adding features, squashing bugs, and building tests for existing apps across a wide variety of services and technologies. Come learn how MCPs help GitHub Copilot to untangle real engineering problems. By allowing agent mode to securely work with data sources, testing tools, infrastructure providers, and even core DevOps tooling -- we can go beyond the hype, and solve the actual engineering problems we face every day.
+
+  ------------------------------------
+
+    Session ID: 936901
+    Track: Uncategorized
+    Speaker: Jon Peck (Technical Advocate & Software Developer)
+    Format: Talk
+    Room: Nobhill C&D: Microsoft
+    Time: 5 Jun 2025 01:10 PM
+    Session Title: Unlocking AI-Powered DevOps Within Your Organization
+    Description:
+    "Software development is a team sport, with many different roles, where eveyone can win. But success isn't guaranteed; it depends on specific practices, policies, and tools which enable minimally-siloed, AI-accelerated collaboration across all parts of the DevOps process, from PM to development to CI/CD and security.
+    
+    Discover the patterns and tools which lead to success, methods for changing the status quo, and perhaps a few horror stories. We'll touch on innersourcing, cloud development, AI, automation, governance, security, scaling and more -- with actionable learnings for everyone from small maintainer communities to F500 Enterprises."
+
+  ------------------------------------
+
+    Session ID: 939093
+    Track: Uncategorized
+    Speaker: Anush Dsouza (Senior Product Manager for Heroku AI)
+    Format: Workshop
+    Room: Nobhill A&B: Expo Sessions
+    Time: 4 Jun 2025 01:00 PM
+    Session Title: Building Agentic Applications with Heroku Managed Inference and Agents
+    Description:
+    In this workshop, you’ll learn how to use Heroku Managed Inference and Agents to build agentic applications. We’ll cover how to provision and deploy LLM models to your app, run untrusted code securely in Python, Node.js, Go, and Ruby using built-in tools, and use the Model Context Protocol (MCP) to connect tools and actions that extend your agents' capabilities.
+
+  ------------------------------------
+
+    Session ID: 936046
+    Track: Uncategorized
+    Speaker: Benjamin Dunphy (N/A)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 05:15 PM
+    Session Title: AI Engineer World's Fair Hackathon - Grand Prize
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 935459
+    Track: Uncategorized
+    Speaker: Christopher Harrison (Senior Developer Advocate)
+    Format: Workshop
+    Room: Nobhill C&D: Microsoft
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Piloting agents in GitHub Copilot
+    Description:
+    The agent capabilities added to GitHub Copilot have enhanced its ability to act as a peer programmer. Copilot can now discover and generate code based on existing standards, run tests, recover from errors, and call tools using Model Context Protocol (MCP). This workshop will guide you through piloting Copilot's agent capabilities and how to best integrate with the most widely adopted AI coding assistant in the world.
+    
+    Key takeaways include:
+    
+    - Understanding how and when to bring agents into your software development workflow
+    - Providing context through the use of custom instructions and prompt files to ensure consistency across your team
+    - Discovering how MCP provides access to an additional set of external tools and capabilities that the agent can use
+    - Configuring Copilot's agentic capabilities to take advantage of your custom MCP server
+    - Recommended best practices to help your responsibly accelerate your development while maintaining code quality and governance
+
+  ------------------------------------
+
+    Session ID: 935456
+    Track: Uncategorized
+    Speaker: Christopher Harrison (Senior Developer Advocate)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Real-World Development with GitHub Copilot and VS Code
+    Description:
+    Join us for a hands-on workshop designed to demonstrate how VS Code and GitHub Copilot's expanding suite of AI features can match or even surpasses the benefits of other popular AI developer tools.  We'll focus on practical scenarios to ensure immediate applicability and work through live demos of Copilot features such as: Code generation using Edits, Planning/problem solving using Chat, Inline terminal command generation, Boilerplate code generation using Agent mode, Improving boilerplate with custom instructions and then refactoring using Agent mode and Edits, Improving test generation and code reviews with custom instructions, as well as an Introduction to MCP.
+    Pre Requisit - install GitHub Copilot and VS Code
+
+  ------------------------------------
+
+    Session ID: 939088
+    Track: Uncategorized
+    Speaker: Daniel Kim (Head of Growth, Cerebras)
+    Format: Workshop
+    Room: Nobhill A&B: Workshops
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: From Mixture of Experts to Mixture of Agents … with Super Fast Inference
+    Description:
+    Our hands-on workshop will walk you through how to build your own Mixture of Agents (MoA) system using the fastest, and most capable open models available: Qwen3-32B and Llama 3.3-70B. MoA is an emerging architecture that combines the strengths of multiple large language models in a layered, agent-based design. This approach delivers superior performance by enabling specialized agents to collaborate across layers—outperforming today’s frontier models in both accuracy and efficiency.
+    
+    To ground this new paradigm in its roots, we’ll also explore how Mixture of Experts (MoE) architectures continue to push the boundaries of scale and specialization. Learn how Cerebras trains state-of-the-art MoEs from Daria Soboleva, Head Research Scientist.
+
+  ------------------------------------
+
+    Session ID: 936908
+    Track: Uncategorized
+    Speaker: Marco Casalaina (VP of Products, Azure AI )
+    Format: Talk
+    Room: Nobhill C&D: Microsoft
+    Time: 4 Jun 2025 01:35 PM
+    Session Title: Agentic RAG: build a reasoning retrieval engine with Azure AI Search
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 936046
+    Track: Uncategorized
+    Speaker: Shawn  Wang (N/A)
+    Format: Keynote
+    Room: Keynote/General Session (Yerba Buena 7&8)
+    Time: 5 Jun 2025 05:15 PM
+    Session Title: AI Engineer World's Fair Hackathon - Grand Prize
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 936905
+    Track: Uncategorized
+    Speaker: Cedric  Vidal (Principal AI Advocate)
+    Format: Workshop
+    Room: Nobhill C&D: Microsoft
+    Time: 3 Jun 2025 01:00 PM
+    Session Title: Building Code-First AI Agents with Azure AI Agent Service: A Practical introduction
+    Description:
+    This workshop offers a hands-on introduction to developing Large Language Model (LLM)-powered AI agents using Microsoft’s Azure AI Agent Service. Participants will build a conversational agent capable of analyzing sales data, generating visualizations, and delivering actionable insights.
+    
+    The session takes a code-first approach using the Azure AI Foundry SDK for Python, and demonstrates how to integrate core Azure services including Azure OpenAI, Azure AI Search, and Azure Storage.
+    
+    Attendees will explore key concepts such as function calling, document grounding, and leveraging code interpreters to generate diagrams. The workshop also covers how to connect agents to external data sources like SQL databases (e.g., SQLite), enabling access to legacy relational systems.
+    
+    By the end of the session, participants will have a solid foundation for building and deploying intelligent, code-first AI agents with Azure AI Agent Service—ready to power real-world applications.
+
+  ------------------------------------
+
+    Session ID: 944039
+    Track: Uncategorized
+    Speaker: Nagkumar Arkalgud (Senior Software Engineer)
+    Room: Nobhill C&D: Microsoft
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: AI Red Teaming Agent: Accelerate your AI safety and security journey with Azure AI Foundry
+    Description:
+    In the age of autonomous AI agents, ensuring their safety and reliability is paramount. But how can we proactively uncover vulnerabilities before they impact real-world scenarios? Enter Azure AI Evaluation SDK’s Red Teaming Agent—a cutting-edge tool designed to rigorously challenge your AI agents, exposing hidden risks and unexpected behaviors. This session will guide you through the powerful capabilities of Azure’s Red Teaming Agent, demonstrating how it simulates adversarial scenarios, stress-tests agentic decision-making, and ensures your applications remain robust, ethical, and safe. You’ll learn practical techniques for systematically identifying weaknesses, interpreting evaluation results, and integrating safety checks into your development lifecycle. Join us to explore how embracing adversarial testing not only mitigates risks but strengthens trust in your AI solutions—keeping you ahead in the rapidly evolving landscape of responsible AI.
+
+  ------------------------------------
+
+    Session ID: 944039
+    Track: Uncategorized
+    Speaker: Keiji Kanazawa (Product @ Azure AI Foundry)
+    Room: Nobhill C&D: Microsoft
+    Time: 4 Jun 2025 12:45 PM
+    Session Title: AI Red Teaming Agent: Accelerate your AI safety and security journey with Azure AI Foundry
+    Description:
+    In the age of autonomous AI agents, ensuring their safety and reliability is paramount. But how can we proactively uncover vulnerabilities before they impact real-world scenarios? Enter Azure AI Evaluation SDK’s Red Teaming Agent—a cutting-edge tool designed to rigorously challenge your AI agents, exposing hidden risks and unexpected behaviors. This session will guide you through the powerful capabilities of Azure’s Red Teaming Agent, demonstrating how it simulates adversarial scenarios, stress-tests agentic decision-making, and ensures your applications remain robust, ethical, and safe. You’ll learn practical techniques for systematically identifying weaknesses, interpreting evaluation results, and integrating safety checks into your development lifecycle. Join us to explore how embracing adversarial testing not only mitigates risks but strengthens trust in your AI solutions—keeping you ahead in the rapidly evolving landscape of responsible AI.
+
+  ------------------------------------
+
+    Session ID: 940839
+    Track: Uncategorized
+    Speaker: Christopher Harrison (Senior Enterprise Advocate, GitHub)
+    Format: Workshop
+    Room: Nobhill C&D: Microsoft
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Collaborating with Agents in your Software Development Workflow
+    Description:
+    GitHub Copilot's agentic capabilities enhance its ability to act as a peer programmer. From the IDE to the repository, Copilot can generate code, run tests, and perform tasks like creating pull requests using Model Context Protocol (MCP). This instructor-led lab will guide you through using agent capabilities on both the client and the server: Key takeaways include:
+    Understanding how to bring agents into your software development workflow
+    Identifying scenarios where agents can be most impactful, as well as tips and tricks to provide the right context to lead to success
+    Discovering how Model Context Protocol provides access to an additional set of external tools and capabilities that the agent can use
+    Recommended practices to accelerate your development while maintaining code quality.
+
+  ------------------------------------
+
+    Session ID: 936814
+    Track: Uncategorized
+    Speaker: Christopher Harrison (Senior Enterprise Advocate, GitHub)
+    Format: Talk
+    Room: Yerba Buena Ballroom 7&8: SWE Agents
+    Time: 5 Jun 2025 11:55 AM
+    Session Title: The Agent Awakens: Collaborative Development with GitHub Copilot
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 936251
+    Track: Uncategorized
+    Speaker: Windsurf Speaker (N/A)
+    Session Title: Windsurf Booth Session #2
+    Description: Not Available
+
+  ------------------------------------
+
+    Session ID: 936935
+    Track: Uncategorized
+    Speaker: Lunch Learn (N/A)
+    Room: Golden Gate Ballroom B: Evals
+    Time: 5 Jun 2025 01:00 PM
+    Session Title: Braintrust Lunch & Learn
+    Description: Not Available
+
+
+
+======================================================================
+---  Track: VOICE (June 4) ---
+======================================================================
+
+    Session ID: 916131
+    Track: Voice
+    Speaker: Shrestha Basu Mallick (Product lead, Gemini Developer API)
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Building Voice Agents with Gemini and Pipecat
+    Description:
+    Voice AI Agents are being deployed today in a wide range of business contexts. For example:
+    
+    - handling an increasing variety of call center tasks,
+    - collecting patient data prior to healthcare appointments,
+    - following up on inbound sales leads,
+    - coordinating scheduling and logistics between companies, and
+    - answering the phone for nearly every kind of small business.
+    
+    On the consumer side, conversational voice (and video) AI is also starting to make its way into social applications and games. And developers are sharing innovative personal voice AI projects and experiments every day on GitHub and social media.
+    
+    Building production-ready voice agents is complicated. Many elements are non-trivial to implement from scratch.
+    
+    This workshop will start with an overview of the voice AI landscape today.
+    
+    - The models, APIs, and infrastructure are used for Voice AI applications that are operating at production scale.
+    - How to write voice agent code that achieves ultra low latency conversation and enterprise-quality reliability.
+    - What new models and tools are coming in the second half of 2025.
+    
+    Then we will shift to a hands-on format: build and deploy a voice agent.
+    
+    Engineers from Google and Daily will help you get set up with a starter kit repo for your intended use case, then help you extend that code to create your own, customized Voice AI application.
+
+  ------------------------------------
+
+    Session ID: 933596
+    Track: Voice
+    Speaker: Shrestha Basu Mallick (Product lead, Gemini Developer API)
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Milliseconds to Magic: Real‑Time Workflows using the Gemini Live API and Pipecat
+    Description:
+    The Gemini Live API GA  is now powered by Google's best cost-effective thinking model Gemini 2.5 Flash. We will do a deep dive on the capabilities that the Gemini Live API combined with Pipecat unlock for devs with special focus on session management, turn detection, tool use (including async function calls), proactivity, multilinguality and integration with telephony and other infra. We will demo some of the more innovative capabilities. We will also talk through some customer use cases - especially how customers can use Pipecat to extend these realtime multimodal capabilities to client side applications such as customer support agents, gaming agents, tutoring agents etc. In addition, we also have an experimental version of the Live API powered by with Google's native audio offering that can be tried in an experimental capacity . This experimental model  can communicate with seamless, emotive, steerable, multilingual dialogue and enhances use cases where more natural voices can be a big differentiator.
+
+  ------------------------------------
+
+    Session ID: 915031
+    Track: Voice
+    Speaker: Brooke Hopkins (Founder )
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 11:55 AM
+    Session Title: What we can learn from self driving in autonomous voice agents
+    Description:
+    The reliability challenges facing voice & chat AI deployment today mirror those that the autonomous vehicle industry confronted years ago. This talk explores how evaluation methodologies developed for self-driving cars can be transferred to create autonomous, self-improving evaluation systems for conversational AI. Drawing from my experience building evaluation infrastructure at Waymo and now developing Coval, an enterprise-grade reliability platform for conversational agents, I'll demonstrate how systematic testing infrastructure is not just a technical requirement but a competitive advantage in the rapidly evolving AI landscape.
+
+  ------------------------------------
+
+    Session ID: 914537
+    Track: Voice
+    Speaker: Dominik Kundel (Developer Experience )
+    Format: Workshop
+    Room: Golden Gate Ballroom B: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: Building voice agents with OpenAI
+    Description:
+    We'll walk through the differences between chained and speech-to-speech powered voice agents, how to approach them, best practices and transform a text-based agent into our first voice-enabled agent
+
+  ------------------------------------
+
+    Session ID: 933721
+    Track: Voice
+    Speaker: Suman Debnath (Principal Developer Advocate, AI/ML, AWS)
+    Format: Workshop
+    Room: Foothill G1&2: Workshops
+    Time: 3 Jun 2025 03:30 PM
+    Session Title: VoiceVision RAG - Integrating Visual Document Intelligence with Voice Response
+    Description:
+    In this workshop we will explore the integration of Colpali, a cutting-edge Vision based Retrieval Model, with voice synthesis for next-generation RAG systems. We'll demonstrate how Colpali's ability to generate multi-vector embeddings directly from document images bypasses traditional OCR and complex preprocessing, while adding voice output creates a more intuitive and accessible user experience. Attendees will see how this combination handles documents with mixed textual and visual information, leading to more efficient and accurate information retrieval with natural voice responses.
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Voice
+    Speaker: Arjun Desai (Co-Founder, Cartesia)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 937506
+    Track: Voice
+    Speaker: Neil Dwyer (CTO)
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Serving Voice AI at $1/hr: Open-source, LoRAs, Latency, Load Balancing
+    Description:
+    This is a talk that goes over our experience deploying Orpheus (Emotive, Realtime TTS) to production. It will cover topics:
+    
+    - Latency and optimizations
+    - High fidelity voice clones w/ examples
+    - Load balancing w/ multiple GPUs and multiple LoRas
+
+  ------------------------------------
+
+    Session ID: 916131
+    Track: Voice
+    Speaker: Kwindla Kramer (CEO )
+    Format: Workshop
+    Room: Salons 2-6: Workshops
+    Time: 3 Jun 2025 10:40 AM
+    Session Title: Building Voice Agents with Gemini and Pipecat
+    Description:
+    Voice AI Agents are being deployed today in a wide range of business contexts. For example:
+    
+    - handling an increasing variety of call center tasks,
+    - collecting patient data prior to healthcare appointments,
+    - following up on inbound sales leads,
+    - coordinating scheduling and logistics between companies, and
+    - answering the phone for nearly every kind of small business.
+    
+    On the consumer side, conversational voice (and video) AI is also starting to make its way into social applications and games. And developers are sharing innovative personal voice AI projects and experiments every day on GitHub and social media.
+    
+    Building production-ready voice agents is complicated. Many elements are non-trivial to implement from scratch.
+    
+    This workshop will start with an overview of the voice AI landscape today.
+    
+    - The models, APIs, and infrastructure are used for Voice AI applications that are operating at production scale.
+    - How to write voice agent code that achieves ultra low latency conversation and enterprise-quality reliability.
+    - What new models and tools are coming in the second half of 2025.
+    
+    Then we will shift to a hands-on format: build and deploy a voice agent.
+    
+    Engineers from Google and Daily will help you get set up with a starter kit repo for your intended use case, then help you extend that code to create your own, customized Voice AI application.
+
+  ------------------------------------
+
+    Session ID: 915028
+    Track: Voice
+    Speaker: Kwindla Kramer (CEO )
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: [Voice Keynote] Your realtime AI is ngmi
+    Description:
+    Sean DuBois of OpenAI and Pion, and Kwindla Hultman Kramer of Daily and Pipecat, will talk about why you have to design realtime AI systems from the network layer up.
+    
+    Most people who build realtime AI apps and frameworks get it wrong. They build from either the model out or the app layer down. But unless you start with the network layer and build up, you'll never be able to deliver realtime audio and video streams reliably. And perhaps even worse, you'll get core primitives wrong: interruption handling, conversation state management, asynchronous function calling.
+    
+    Sean and Kwin agree on most things: old-school realtime systems people against the rest of the world. But they disagree on some important things, too, and will argue about those things live on stage. Do you need to give developers "thick" client-side realtime SDKs? Can you build truly great vendor neutral APIs? (You'll be surprised which of them argues which side, on that topic.)
+
+  ------------------------------------
+
+    Session ID: 933596
+    Track: Voice
+    Speaker: Kwindla Kramer (CEO )
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 02:40 PM
+    Session Title: Milliseconds to Magic: Real‑Time Workflows using the Gemini Live API and Pipecat
+    Description:
+    The Gemini Live API GA  is now powered by Google's best cost-effective thinking model Gemini 2.5 Flash. We will do a deep dive on the capabilities that the Gemini Live API combined with Pipecat unlock for devs with special focus on session management, turn detection, tool use (including async function calls), proactivity, multilinguality and integration with telephony and other infra. We will demo some of the more innovative capabilities. We will also talk through some customer use cases - especially how customers can use Pipecat to extend these realtime multimodal capabilities to client side applications such as customer support agents, gaming agents, tutoring agents etc. In addition, we also have an experimental version of the Live API powered by with Google's native audio offering that can be tried in an experimental capacity . This experimental model  can communicate with seamless, emotive, steerable, multilingual dialogue and enhances use cases where more natural voices can be a big differentiator.
+
+  ------------------------------------
+
+    Session ID: 933599
+    Track: Voice
+    Speaker: Rohit Talluri (Senior Worldwide Generative AI Specialist BD - Foundation Model Training & Inference)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Serving Voice  AI at Scale
+    Description:
+    Real-Time  Voice AI applications demand the lowest possible latencies to enhance user  experiences with more advanced reasoning and agentic capabilities. AWS is  hosting Arjun Desai, co-founder of Cartesia, in a fireside chat for a  technical deep dive into learnings and best practices for building a  state-of-the-art inference stack that serves global enterprise customers.
+
+  ------------------------------------
+
+    Session ID: 931123
+    Track: Voice
+    Speaker: Peter Bar (Product Lead, Voice AI)
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 11:35 AM
+    Session Title: Shipping an Enterprise Voice AI Agent in 100 Days
+    Description:
+    What does it take to go from blank page to live enterprise voice agent in 100 days?
+    
+    That’s the challenge we took on with Fin Voice at Intercom. Enterprise customer service demands high-quality, reliable voice interactions - but delivering that fast means wrestling with tough problems like latency, hallucinations, voice quality, and answer accuracy.
+    
+    We rapidly evaluated and integrated a full voice stack - including transcription, language model, text-to-speech, retrieval-augmented generation, and telephony - while designing tools that fit seamlessly into existing human support workflows.
+    
+    In this session, I’ll share key lessons from our accelerated development of Fin Voice. We'll explore the technical and operational hurdles we faced, the trade-offs we made, and how we built deployment and handover tools that work for customer service teams. You'll leave with insights into building AI-driven voice products that are both powerful and practical.
+
+  ------------------------------------
+
+    Session ID: 933491
+    Track: Voice
+    Speaker: Chad Bailey (Senior Voice Bots Engineer, Daily)
+    Room: Salons 9-15: Expo Hall
+    Time: 5 Jun 2025 01:30 PM
+    Session Title: Pipecat Cloud: Open Source Enterprise Voice AI
+    Description:
+    Learn about building voice agents with for customer support, call center workflows, market research, and many other use cases.  Pipecat is the open source, vendor neutral realtime agent framework used by teams at NVIDIA, OpenAI, Google DeepMind, AWS, and hundreds of startups and scale-ups.
+
+  ------------------------------------
+
+    Session ID: 937506
+    Track: Voice
+    Speaker: Jack Dwyer (CEO @ Gabber - End to End Backend For Realtime AI)
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 12:15 PM
+    Session Title: Serving Voice AI at $1/hr: Open-source, LoRAs, Latency, Load Balancing
+    Description:
+    This is a talk that goes over our experience deploying Orpheus (Emotive, Realtime TTS) to production. It will cover topics:
+    
+    - Latency and optimizations
+    - High fidelity voice clones w/ examples
+    - Load balancing w/ multiple GPUs and multiple LoRas
+
+  ------------------------------------
+
+    Session ID: 915028
+    Track: Voice
+    Speaker: Sean DuBois (WebRTC and Realtime API)
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 11:15 AM
+    Session Title: [Voice Keynote] Your realtime AI is ngmi
+    Description:
+    Sean DuBois of OpenAI and Pion, and Kwindla Hultman Kramer of Daily and Pipecat, will talk about why you have to design realtime AI systems from the network layer up.
+    
+    Most people who build realtime AI apps and frameworks get it wrong. They build from either the model out or the app layer down. But unless you start with the network layer and build up, you'll never be able to deliver realtime audio and video streams reliably. And perhaps even worse, you'll get core primitives wrong: interruption handling, conversation state management, asynchronous function calling.
+    
+    Sean and Kwin agree on most things: old-school realtime systems people against the rest of the world. But they disagree on some important things, too, and will argue about those things live on stage. Do you need to give developers "thick" client-side realtime SDKs? Can you build truly great vendor neutral APIs? (You'll be surprised which of them argues which side, on that topic.)
+
+  ------------------------------------
+
+    Session ID: 932493
+    Track: Voice
+    Speaker: Tom Shapland, PhD (Product Manager)
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 02:20 PM
+    Session Title: Why ChatGPT Keeps Interrupting You
+    Description:
+    ChatGPT Advanced Voice Mode isn’t interrupting just you. Interruptions, and turn-taking in general, are unsolved problems for all Voice AI agents. Nobody likes being cut short – and people have much less patience for machines than they do for other humans. Turn-taking failures take many forms (e.g., the agent interrupts the user, the agent mistakes a cough for an interruption), and all of them lead to users immediately hanging up the phone.
+    
+    In this talk, we use human conversation as a framework for understanding both today’s approaches to turn detection and where the field is headed. You’ll learn about how linguists think about turn detection in human dialogue, what’s working (and what’s broken) in current methods, and how we might build Voice AIs that interrupt you less than your human brother.
+
+  ------------------------------------
+
+    Session ID: 933580
+    Track: Voice
+    Speaker: Philip Kiely (Head of Developer Relations)
+    Room: Willow: Expo Sessions
+    Time: 5 Jun 2025 01:15 PM
+    Session Title: Optimizing inference for voice models in production
+    Description:
+    How do you get time to first byte (TTFB) below 150 milliseconds for voice models -- and scale it in production? As it turns out, open-source TTS models like Orpheus have an LLM backbone that lets us use familiar tools and optimizations like TensorRT-LLM and FP8 quantization to serve the models with low latency. But client code, network infrastructure, and other outside-the-GPU factors can introduce latency in the production stack. In this talk, we'll cover the basic mechanics of TTS inference, common pitfalls to avoid in integrating them into production systems, and how to extend this high-performance system to serve customized models with voice cloning and fine-tuning.
+
+  ------------------------------------
+
+    Session ID: 915431
+    Track: Voice
+    Speaker: Thor 雷神 Schaeff (DX at ElevenLabs)
+    Format: Workshop
+    Room: Golden Gate Ballroom A: Workshops
+    Time: 3 Jun 2025 11:00 AM
+    Session Title: Build multilingual Conversational AI Agents
+    Description:
+    In this workshop you will learn how to build multilingual Conversational AI agents that can automatically detect your user's spoken language and can seamlessly switch to their preferred language.
+
+  ------------------------------------
+
+    Session ID: 933589
+    Track: Voice
+    Speaker: Mark Backman (Head of Product, Daily)
+    Room: Nobhill A&B: Expo Sessions
+    Time: 5 Jun 2025 11:00 AM
+    Session Title: Pipecat Cloud: Enterprise Voice Agents Built On Open Source
+    Description:
+    Voice AI agents today can conduct natural, human-like conversations and perform a wide variety of tasks: customer support, lead qualification, healthcare patient intake, market research, and more.
+    
+    Today's best voice agents combine: realtime responsiveness, open-ended conversational intelligence, reliable instruction following, and flexible integration with existing back-end systems.
+    
+    Learn how to build state of the art voice agents using Pipecat's open source, vendor neutral tooling. You can deploy Pipecat agents to your own infrastructure or to Pipecat Cloud.
+    
+    Pipecat is used and supported by teams at NVIDIA, AWS, Google DeepMind, OpenAI, and hundreds of other companies.
+
+  ------------------------------------
+
+    Session ID: 916079
+    Track: Voice
+    Speaker: Jordan Dearsley (CEO)
+    Format: Talk
+    Room: Foothill E: Voice
+    Time: 4 Jun 2025 02:00 PM
+    Session Title: Building the Voice-First Future: Omnipresent Agents that Listen, Talk and Act
+    Description:
+    We’re entering a world where talking to machines feels as natural as talking to people. Voice is about to become the dominant interface for technology - ambient, always-on, and human by default. To get there, we need infrastructure that can orchestrate voice, tools, memory, real-time reasoning and telephony. This talk explores the vision for voice and how we're making it work at scale.
+
+
+## Expo
+
+Open across all 3 days. Featuring 30+ booths and demo areas showcasing the most relevant and forward-thinking AI infrastructure and developer tools. Meet the engineers and founders behind:
+
+Microsoft, AWS, MongoDB, Neo4j, Hasura, Galileo, Sourcegraph, LlamaIndex, Temporal, Baseten, Elastic, Orb, Gitpod, Freeplay, Dagger, Traceloop, Pydantic, Arize, Arcjet, Zed, Modal, Agentuity, Weights & Biases, Fly.io, Sierra, Vellum, GenSx, Redis, Langbase, Twilio, Descope, SuperAnnotate, Unstructured, Baz, VESSL AI, Riza, Tambo, Sentry, Xpander, Thomson Reuters, ElevenLabs, Pomerium, Daytona, Polar Signals, Vercel, Ampersand, Together AI, Distributional, and many more.
+
+**[Buy Tickets](https://ti.to/software-3/ai-engineer-worlds-fair-2025?source={{UTM_SOURCE}}) | [Watch 2023/2024/2025 Talks](https://youtube.com/@aidotengineer)**
+
+## AI Architects Track
+
+Invite-only track for AI executives (VPs, CTOs, Heads of AI at enterprises with >1000 employees).
+
+- Closed-door briefings and roundtables
+- Topics include technical org design, model building, FMOps, evals, inference optimization, build/buy decisions
+- Exclusive access to premium lunches and networking in the View Lounge
+
+## Side Events (2024 Examples)
+
+A full week of satellite events hosted by our partners:
+- Hackathons (e.g., AI21, GenLab x AIEWF)
+- Deep Tech Week launch parties
+- RAG++ pre-party, AI DevTools nights
+- Rooftop happy hours and after-parties
+- Demo Days, quality conferences, founders dinners
+
+If you are organizing an event around June 1–8, email **sponsorships@ai.engineer** to be added to the official calendar.
+
+## Venue & Hotel
+
+**Marriott Marquis, San Francisco**  
+780 Mission St, San Francisco, CA 94103
+
+- Yerba Buena Ballroom: Keynotes, expo, and large sessions
+- Golden Gate Ballroom: Dedicated space for workshops
+- View Lounge: Reserved for AI Architects and Leadership Track networking
+
+## Sponsors
+
+### Community Partners
+- Data Council, Hall C, Ai LA, Open Web Foundation, SF Python, SF Node, SF Java, Weaviate, Prompt Engineering, R meetup, Hypergrowth, Vector DAO, GenAI Collective, Cambrian ML, Ai Tinkerers, CodingNomads, Ai Product Builders, Ai Salon, Ai Makers SF, OpenSourceGrill, Ai Breakfast Club, Ai Stack, Nexus Events, Seattle Ai Society, RVC, Ai Happy Hour, SF Ai, FourthBrain, Ai Comic Books, Ai Engineer Foundation
+
+### Presenting Sponsor
+
+Microsoft
+
+### Innovation Partner
+
+AWS
+
+### Track Sponsors
+
+Neo4j, Braintrust, Hasura
+
+### Platinum Sponsors
+
+Graphite, Daily, Windsurf, MongoDB, AugmentCode, WorkOS
+
+### Gold Sponsors
+
+Neo4j, Hasura, Galileo, Sourcegraph, LlamaIndex, Temporal, Baseten, Elastic, Orb, Gitpod, Freeplay, Dagger, Traceloop, Pydantic, Arize, Arcjet, Zed, Modal, Agentuity
+
+### Silver Sponsors
+
+Weights & Biases, Fly.io, Sierra, Vellum, GenSx, Redis, Langbase, Twilio, Descope, SuperAnnotate, Unstructured, Baz, VESSL AI, Riza, Tambo, Sentry, Xpander, Thomson Reuters, ElevenLabs, Pomerium, Daytona, Polar Signals, Vercel, Ampersand, Together AI, Distributional
+
+### Supporters
+
+Circle
+
+## Testimonials
+
+> "The most insightful and exciting conference I ever attended. High signal, deeply technical, and community-focused."  
+> — Yanick J. S.
+
+> "By far the best AI conference I've ever attended."  
+> — Dedy Kredo
+
+> "Reminded me of the early Twitter dev scene—a spark for a decade of innovation."  
+> — Eric Ryan
+
+> "Months of effort distilled into powerful 20-minute talks."  
+> — Yubrew
+
+> "You could feel the buzz and optimism everywhere."  
+> — Eric Ness
+
+## Stay Updated
+
+- **[Buy Tickets](https://ti.to/software-3/ai-engineer-worlds-fair-2025?source={{UTM_SOURCE}})**  
+  Early bird discounts available until sell-out.
+- **[Watch Talks](https://youtube.com/@aidotengineer)**  
+  Browse sessions from 2023, 2024, and upcoming 2025.
+- **[Subscribe to Newsletter](https://ai.engineer/newsletter)**  
+  Get notified about speakers, tickets, livestreams, and community events.
+- **[Follow on X](https://twitter.com/aiDotEngineer)**  
+  Live updates, real-time speaker quotes, and behind-the-scenes moments.
+- **[Subscribe on YouTube](https://www.youtube.com/@aiengineer)**  
+  Access full talk recordings and curated playlists from every year.
+
+## Contact & Connect
+
+- [Sponsor Inquiry](mailto:sponsorships@ai.engineer)
+- [Volunteer](https://ai.engineer/volunteer)
+- [Jobs](https://ai.engineer/jobs)
+- [Scholarships](https://ai.engineer/scholarships)
+- [Code of Conduct](https://ai.engineer/code-of-conduct)
+- [About](https://ai.engineer/about)
+- [What is an AI Engineer?](https://ai.engineer/what-is-an-ai-engineer)
+
+
+**Copyright 2025 Software 3.0 LLC**
+
+**Note:** The 2025 tracks are subject to change. Check the website for the latest updates.  
+**[Apply to Speak](https://sessionize.com/ai-engineer-worlds-fair-2025)**

--- a/eval_mcp/benchmarks/aiwf/data/kb_medium.txt
+++ b/eval_mcp/benchmarks/aiwf/data/kb_medium.txt
@@ -1,0 +1,922 @@
+
+# AI Engineer World's Fair 2025
+
+## Overview
+**June 3–5, 2025 • San Francisco**
+The AI Engineer World's Fair is the largest technical conference for engineers working in AI today.
+
+## Schedule
+
+June 3: Workshops + exclusive Speaker Dinner
+June 4: MCP, Tiny Teams, LLM RecSys, GraphRAG, Agent Reliability, Infrastructure, AI PM, Voice, AI in Fortune 500, AI Architects
+June 5: Reasoning + RL, SWE-Agents, Evals, Retrieval + Search, Security, Generative Media, AI Design, Robotics/Autonomy, AI in Fortune 500 (day 2), AI Architects (Day 2)
+
+### Tuesday, June 3 – Workshop Day
+- Exclusive hands-on workshops across 5 tracks, instructed by industry-leading companies, founders, and engineers.
+- Topics span all levels of experience and specialties in AI Engineering.
+- **Evening Welcome Reception** (4:00–7:00pm): Held in the Grand Assembly & Expo Hall.
+
+### Wednesday & Thursday, June 4–5 – Conference Days
+- 19 tracks of talks, panels, and demos.
+- Keynotes from the biggest and most consequential labs and companies.
+
+## Meals and Events
+
+### June 3
+- Continental Breakfast: 7:15am - 9:45am, Grand Assembly
+- Morning Break: 10:15am - 10:40am, Grand Assembly
+- Lunch: 12:00pm - 1:00pm, Grand Assembly
+- Afternoon Break: 3:00pm - 3:30pm, Grand Assembly
+- Welcome Reception: 4:00pm - 7:00pm, Grand Assembly
+- Community Meetups: 5:30pm - 9:00pm, Atrium: Event Hub
+
+### June 4
+- Continental Breakfast: 7:15am - 9:55am, Grand Assembly
+- Morning Break: 10:15am - 11:00am, Salons 9-15: Expo Hall
+- Lunch: 12:00pm - 2:00pm, Salons 9-15: Expo Hall
+- Afternoon Break: 3:00pm - 3:45pm, Salons 9-15: Expo Hall
+- The Toolbit Afterparty: 5:15pm - 7:00pm, Salons 9-15: Expo Hall
+- Community Meetups: 7:00pm - 10:40pm, Atrium: Event Hub
+
+### June 5
+- Continental Breakfast: 7:15am - 9:55am, Grand Assembly
+- Morning Break: 10:30am - 11:15am, Salons 9-15: Expo Hall
+- Lunch: 12:00pm - 2:00pm, Salons 9-15: Expo Hall
+- Afternoon Break: 3:00pm - 3:45pm, Salons 9-15: Expo Hall
+- Community Meetups: 5:30pm - 9:00pm, Atrium: Event Hub
+
+## WORKSHOPS (June 3)
+
+### Gemini Workshops
+- **Session ID: 916110**
+  - **Speaker:** Shrestha Basu Mallick (Developer Advocate, Gemini API)
+  - **Time:** 10:40 AM
+  - **Title:** Building Voice Agents with Gemini and Pipecat
+  - **Track:** Voice
+  - **Room:** Salons 2-6: Workshops
+
+- **Session ID: 910732**
+  - **Speaker:** Philipp Schmid (AI Developer Experience)
+  - **Time:** 1:00 PM
+  - **Title:** AI Engineering with the Google Gemini 2.5 Model Family
+  - **Track:** AI in Action
+  - **Room:** SOMA: Workshops
+
+### Other Workshops
+- **Session ID: 916110**
+  - **Speaker:** Kwindla Kramer (Co-founder & CEO, Daily)
+  - **Time:** 10:40 AM
+  - **Title:** Building Voice Agents with Gemini and Pipecat
+  - **Track:** Voice
+  - **Room:** Salons 2-6: Workshops
+
+## MCP TRACK (June 4)
+
+The MCP track focuses on the Model Context Protocol, covering its origins, how to build with it, and its future possibilities for agent-to-agent communication.
+
+### MCP Sessions
+- **Session ID: 947165**
+  - **Speaker:** Theodora Chu (Product Manager for MCP @ Anthropic)
+  - **Format:** Keynote
+  - **Time:** 11:15 AM
+  - **Title:** MCP Origins & RFS
+  - **Room:** Yerba Buena Ballroom Salons 7-8: MCP
+
+- **Session ID: 914489**
+  - **Speaker:** David Cramer (Co-founder, Sentry)
+  - **Format:** Talk
+  - **Time:** 12:15 PM
+  - **Title:** MCP isn't good, yet.
+  - **Room:** Yerba Buena Ballroom Salons 7-8: MCP
+
+- **Session ID: 915013**
+  - **Speaker:** Alex Volkov (AI Evangelist)
+  - **Format:** Talk
+  - **Time:** 2:20 PM
+  - **Title:** Observable tools - the state of MCP observability
+  - **Room:** Yerba Buena Ballroom Salons 7-8: MCP
+
+### MCP Workshops (June 3)
+- **Session ID: 911821**
+  - **Speaker:** Damien Murphy (Founding Engineer)
+  - **Format:** Workshop
+  - **Time:** 9:00 AM
+  - **Title:** A2A & MCP: Automating Business Processes with LLMs
+  - **Room:** Foothill G1&2: Workshops
+
+- **Session ID: 914537**
+  - **Speaker:** Theo Browne (Founder, Ping Labs)
+  - **Format:** Workshop
+  - **Time:** 1:00 PM
+  - **Title:** Full Spectrum MCP: From Local to Remote
+  - **Room:** Golden Gate Ballroom A: Workshops
+
+## VOICE AI TRACK
+
+### June 4 Voice Sessions
+- **Session ID: 907856**
+  - **Speaker:** Sean DuBois (Principal Architect)
+  - **Time:** 11:15 AM
+  - **Title:** [Voice Keynote] Your realtime AI is ngmi
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Voice
+  - **Track:** Voice
+
+- **Session ID: 907856**
+  - **Speaker:** Kwindla Kramer (Co-founder & CEO, Daily)
+  - **Time:** 11:15 AM
+  - **Title:** [Voice Keynote] Your realtime AI is ngmi
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Voice
+  - **Track:** Voice
+
+### June 5 Voice Sessions
+- **Session ID: 914977**
+  - **Speaker:** Arjun Desai (CEO & Co-founder, Cartesia)
+  - **Time:** 1:15 PM
+  - **Title:** Serving Voice AI at Scale
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Voice
+  - **Track:** Voice
+
+- **Session ID: 914977**
+  - **Speaker:** Rohit Talluri (CEO & Co-founder, Ultravox)
+  - **Time:** 1:15 PM
+  - **Title:** Serving Voice AI at Scale
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Voice
+  - **Track:** Voice
+
+## AGENT RELIABILITY TRACK
+
+### June 4 Sessions
+- **Session ID: 907810**
+  - **Speaker:** Dexter Horthy (Founder & CEO, Hamming AI)
+  - **Time:** 11:35 AM
+  - **Title:** 12 Factor Agents - Principles of Reliable LLM Applications
+  - **Room:** Foothill F: Agent Reliability
+  - **Track:** Agent Reliability
+
+### June 5 Sessions
+- **Session ID: 914939**
+  - **Speaker:** Mike Chambers (CEO & Founder, Taktile)
+  - **Time:** 12:15 PM
+  - **Title:** Ship it! Building Production-Ready Agents
+  - **Room:** Foothill F: Agent Reliability
+  - **Track:** Agent Reliability
+
+## INFRASTRUCTURE / AI IN ACTION TRACK
+
+### Charles Frye Sessions (June 4)
+- **Session ID: 933607**
+  - **Speaker:** Charles Frye (Senior Staff AI Educator, Modal)
+  - **Time:** 11:15 AM
+  - **Title:** What every AI engineer needs to know about GPUs
+  - **Format:** Workshop
+  - **Room:** Foothill F: Infrastructure
+  - **Track:** Infrastructure
+
+- **Session ID: 933615**
+  - **Speaker:** Charles Frye (Senior Staff AI Educator, Modal)
+  - **Time:** 12:45 PM
+  - **Title:** How fast are LLM inference engines anyway?
+  - **Format:** Talk
+  - **Room:** Juniper: Expo Sessions
+  - **Track:** AI in Action
+
+## MISC TRACKS
+
+### Harald Kirschner Sessions
+- **Session ID: 914821**
+  - **Speaker:** Harald Kirschner (VS Code Team Member)
+  - **Time:** June 3, 9:00 AM
+  - **Title:** Real-World Development with GitHub Copilot and VS Code
+  - **Format:** Workshop
+  - **Room:** Golden Gate Ballroom C: Workshops
+
+- **Session ID: 914509**
+  - **Speaker:** Harald Kirschner (VS Code Team Member)
+  - **Time:** June 4, 3:00 PM
+  - **Title:** Full Spectrum MCP: Uncovering Hidden Servers and Clients Capabilities
+  - **Format:** Talk
+  - **Room:** Yerba Buena Ballroom Salons 7-8: MCP
+  - **Track:** MCP
+
+- **Session ID: 936902**
+  - **Speaker:** Harald Kirschner (VS Code Team Member)
+  - **Time:** June 5, 2:00 PM
+  - **Title:** Vibe Coding at Scale: Customizing AI Assistants for Enterprise Environments
+  - **Format:** Talk
+  - **Room:** Foothill E: SWE Agents
+  - **Track:** SWE Agents
+
+## ADDITIONAL CONFERENCE SESSIONS
+
+### REASONING + RL TRACK (June 5)
+
+- **Session ID: 915234**
+  - **Speaker:** Emma Rodriguez (Research Scientist, DeepMind)
+  - **Time:** 9:00 AM
+  - **Title:** Scaling Reinforcement Learning for Complex Decision-Making
+  - **Room:** SOMA: Reasoning+RL
+  - **Track:** Reasoning+RL
+  - **Description:** Exploring how modern RL techniques can be applied to real-world problems with sparse rewards and long time horizons.
+
+- **Session ID: 915235**
+  - **Speaker:** James Chen (Principal Engineer, Anthropic)
+  - **Time:** 11:30 AM
+  - **Title:** Constitutional AI: Teaching Models to Self-Correct
+  - **Room:** SOMA: Reasoning+RL
+  - **Track:** Reasoning+RL
+  - **Description:** How we use RL from AI feedback to make models more helpful, honest, and harmless.
+
+- **Session ID: 915236**
+  - **Speaker:** Dr. Sarah Mitchell (AI Researcher, OpenAI)
+  - **Time:** 2:15 PM
+  - **Title:** Process Supervision for Mathematical Reasoning
+  - **Room:** SOMA: Reasoning+RL
+  - **Track:** Reasoning+RL
+  - **Description:** Novel approaches to training models that can reliably solve complex mathematical problems step-by-step.
+
+### SECURITY TRACK (June 5)
+
+- **Session ID: 916301**
+  - **Speaker:** Marcus Johnson (Security Lead, Google Cloud)
+  - **Time:** 9:30 AM
+  - **Title:** Defending Against Prompt Injection Attacks
+  - **Room:** Foothill G1&2: Security
+  - **Track:** Security
+  - **Description:** Practical strategies for securing LLM applications against adversarial inputs and jailbreaks.
+
+- **Session ID: 916302**
+  - **Speaker:** Dr. Lisa Park (Research Director, Meta AI)
+  - **Time:** 11:00 AM
+  - **Title:** Privacy-Preserving Machine Learning in Production
+  - **Room:** Foothill G1&2: Security
+  - **Track:** Security
+  - **Description:** Techniques for training and deploying models while protecting user privacy through differential privacy and federated learning.
+
+- **Session ID: 916303**
+  - **Speaker:** Kevin Zhang (Staff Engineer, Anthropic)
+  - **Time:** 1:30 PM
+  - **Title:** Red Teaming AI Systems: Lessons from the Field
+  - **Room:** Foothill G1&2: Security
+  - **Track:** Security
+  - **Description:** Real-world experiences stress-testing AI systems for security vulnerabilities and unexpected behaviors.
+
+### RETRIEVAL + SEARCH TRACK (June 5)
+
+- **Session ID: 917401**
+  - **Speaker:** Dr. Amanda White (Research Scientist, Pinecone)
+  - **Time:** 10:00 AM
+  - **Title:** Vector Databases: Architecture and Performance Trade-offs
+  - **Room:** Golden Gate Ballroom A: Retrieval+Search
+  - **Track:** Retrieval+Search
+  - **Description:** Deep dive into the internals of vector databases and how to optimize them for different use cases.
+
+- **Session ID: 917402**
+  - **Speaker:** Ryan Cooper (Engineering Manager, Weaviate)
+  - **Time:** 12:00 PM
+  - **Title:** Hybrid Search: Combining Dense and Sparse Retrieval
+  - **Room:** Golden Gate Ballroom A: Retrieval+Search
+  - **Track:** Retrieval+Search
+  - **Description:** Best practices for combining traditional keyword search with semantic vector search.
+
+- **Session ID: 917403**
+  - **Speaker:** Dr. Priya Sharma (AI Research Lead, Elasticsearch)
+  - **Time:** 2:45 PM
+  - **Title:** Retrieval-Augmented Generation at Scale
+  - **Room:** Golden Gate Ballroom A: Retrieval+Search
+  - **Track:** Retrieval+Search
+  - **Description:** Architectural patterns and lessons learned from deploying RAG systems serving millions of users.
+
+### GRAPHRAG TRACK (June 4)
+
+- **Session ID: 918501**
+  - **Speaker:** Dr. Michael Torres (Principal Scientist, Neo4j)
+  - **Time:** 11:00 AM
+  - **Title:** Knowledge Graphs Meet LLMs: The GraphRAG Revolution
+  - **Room:** Golden Gate Ballroom B: GraphRAG
+  - **Track:** GraphRAG
+  - **Description:** How combining knowledge graphs with large language models unlocks new capabilities for reasoning and retrieval.
+
+- **Session ID: 918502**
+  - **Speaker:** Jennifer Kim (VP Engineering, TigerGraph)
+  - **Time:** 1:15 PM
+  - **Title:** Building Enterprise Knowledge Graphs for AI Applications
+  - **Room:** Golden Gate Ballroom B: GraphRAG
+  - **Track:** GraphRAG
+  - **Description:** Practical guide to constructing and maintaining knowledge graphs from enterprise data sources.
+
+- **Session ID: 918503**
+  - **Speaker:** Dr. Robert Lee (Research Engineer, Microsoft)
+  - **Time:** 3:30 PM
+  - **Title:** GraphRAG: Structured Retrieval for Complex Questions
+  - **Room:** Golden Gate Ballroom B: GraphRAG
+  - **Track:** GraphRAG
+  - **Description:** Using graph structures to improve retrieval accuracy for multi-hop reasoning tasks.
+
+### EVALS TRACK (June 5)
+
+- **Session ID: 919601**
+  - **Speaker:** Dr. Alex Thompson (Head of Evals, Anthropic)
+  - **Time:** 9:15 AM
+  - **Title:** Building Reliable Evaluation Suites for LLMs
+  - **Room:** Golden Gate Ballroom C: Evals
+  - **Track:** Evals
+  - **Description:** Best practices for creating evaluation benchmarks that actually predict real-world performance.
+
+- **Session ID: 919602**
+  - **Speaker:** Maya Patel (Senior Engineer, OpenAI)
+  - **Time:** 11:45 AM
+  - **Title:** Human Feedback at Scale: Lessons from RLHF
+  - **Room:** Golden Gate Ballroom C: Evals
+  - **Track:** Evals
+  - **Description:** How we collect, analyze, and incorporate human feedback to improve model quality.
+
+- **Session ID: 919603**
+  - **Speaker:** Dr. Thomas Anderson (Research Lead, Google DeepMind)
+  - **Time:** 2:00 PM
+  - **Title:** Automated Eval Generation with LLMs
+  - **Room:** Golden Gate Ballroom C: Evals
+  - **Track:** Evals
+  - **Description:** Using AI to create comprehensive test suites and catch edge cases automatically.
+
+### GENERATIVE MEDIA TRACK (June 5)
+
+- **Session ID: 920701**
+  - **Speaker:** Sofia Martinez (Director of AI, Runway)
+  - **Time:** 10:30 AM
+  - **Title:** State of Generative Video: From Research to Production
+  - **Room:** Foothill F: Generative Media
+  - **Track:** Generative Media
+  - **Description:** Latest advances in video generation models and their practical applications.
+
+- **Session ID: 920702**
+  - **Speaker:** David Kim (CTO, ElevenLabs)
+  - **Time:** 12:30 PM
+  - **Title:** Voice Cloning and Synthesis: Ethics and Technology
+  - **Room:** Foothill F: Generative Media
+  - **Track:** Generative Media
+  - **Description:** Technical deep dive into voice synthesis while addressing ethical considerations.
+
+- **Session ID: 920703**
+  - **Speaker:** Dr. Rachel Green (Research Scientist, Stability AI)
+  - **Time:** 3:15 PM
+  - **Title:** Diffusion Models: Theory and Practice
+  - **Room:** Foothill F: Generative Media
+  - **Track:** Generative Media
+  - **Description:** Understanding the mathematical foundations of diffusion models and how to optimize them.
+
+### SWE AGENTS TRACK (June 5)
+
+- **Session ID: 921801**
+  - **Speaker:** Eric Zhang (Engineering Lead, GitHub Copilot)
+  - **Time:** 9:45 AM
+  - **Title:** AI-Assisted Code Review: Best Practices
+  - **Room:** Foothill E: SWE Agents
+  - **Track:** SWE Agents
+  - **Description:** How AI can augment rather than replace human code reviewers.
+
+- **Session ID: 921802**
+  - **Speaker:** Dr. Nicole Brown (Research Engineer, Meta)
+  - **Time:** 11:15 AM
+  - **Title:** Autonomous Bug Fixing in Large Codebases
+  - **Room:** Foothill E: SWE Agents
+  - **Track:** SWE Agents
+  - **Description:** Techniques for training agents that can understand and fix bugs in production code.
+
+- **Session ID: 921803**
+  - **Speaker:** Jason Wu (Staff Engineer, Replit)
+  - **Time:** 1:45 PM
+  - **Title:** From Copilot to Autopilot: The Future of AI Coding Tools
+  - **Room:** Foothill E: SWE Agents
+  - **Track:** SWE Agents
+  - **Description:** Vision for how AI will transform software development over the next 5 years.
+
+### TINY TEAMS TRACK (June 4)
+
+- **Session ID: 922901**
+  - **Speaker:** Laura Chen (Founder, Indie Hackers)
+  - **Time:** 1:00 PM
+  - **Title:** Building a SaaS Startup Solo with AI Tools
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Tiny Teams
+  - **Track:** Tiny Teams
+  - **Description:** How one engineer used AI to build, launch, and scale a profitable product alone.
+
+- **Session ID: 922902**
+  - **Speaker:** Mike Ross (Solo Developer)
+  - **Time:** 2:30 PM
+  - **Title:** AI Multiplier Effect: 10x Your Productivity
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Tiny Teams
+  - **Track:** Tiny Teams
+  - **Description:** Practical workflows and tools that dramatically increase individual developer output.
+
+- **Session ID: 922903**
+  - **Speaker:** Dr. Sam Foster (Researcher & Indie Builder)
+  - **Time:** 4:00 PM
+  - **Title:** The Economics of One-Person AI Companies
+  - **Room:** Yerba Buena Ballroom Salons 2-6: Tiny Teams
+  - **Track:** Tiny Teams
+  - **Description:** Business models and strategies for sustainable solo AI ventures.
+
+### ROBOTICS + AUTONOMY TRACK (June 5)
+
+- **Session ID: 923101**
+  - **Speaker:** Dr. Stephanie Liu (Robotics Lead, Tesla)
+  - **Time:** 10:15 AM
+  - **Title:** Vision-Language Models for Robot Control
+  - **Room:** SOMA: Autonomy+Robotics
+  - **Track:** Autonomy+Robotics
+  - **Description:** How multimodal models enable robots to understand and execute natural language commands.
+
+- **Session ID: 923102**
+  - **Speaker:** Andrew Park (VP Engineering, Physical Intelligence)
+  - **Time:** 12:00 PM
+  - **Title:** Sim-to-Real Transfer in Robotic Manipulation
+  - **Room:** SOMA: Autonomy+Robotics
+  - **Track:** Autonomy+Robotics
+  - **Description:** Techniques for training robots in simulation and deploying them in the real world.
+
+- **Session ID: 923103**
+  - **Speaker:** Dr. Maria Santos (Research Director, Boston Dynamics AI)
+  - **Time:** 2:30 PM
+  - **Title:** Embodied AI: When Language Models Meet Physics
+  - **Room:** SOMA: Autonomy+Robotics
+  - **Track:** Autonomy+Robotics
+  - **Description:** Integrating LLMs with physical robots to create truly intelligent machines.
+
+### AI PRODUCT MANAGEMENT TRACK (June 4)
+
+- **Session ID: 924201**
+  - **Speaker:** Rachel Adams (VP Product, Intercom)
+  - **Time:** 11:00 AM
+  - **Title:** Building AI Products Users Actually Want
+  - **Room:** Foothill G3: AI Product Management
+  - **Track:** AI Product Management
+  - **Description:** How to conduct user research and iterate on AI features that solve real problems.
+
+- **Session ID: 924202**
+  - **Speaker:** David Miller (CPO, Notion)
+  - **Time:** 1:30 PM
+  - **Title:** Product Strategy for the Age of AI
+  - **Room:** Foothill G3: AI Product Management
+  - **Track:** AI Product Management
+  - **Description:** Rethinking product roadmaps and prioritization when AI enables rapid capability expansion.
+
+- **Session ID: 924203**
+  - **Speaker:** Emily Watson (Head of AI Product, Figma)
+  - **Time:** 3:45 PM
+  - **Title:** Designing AI Features That Feel Magical
+  - **Room:** Foothill G3: AI Product Management
+  - **Track:** AI Product Management
+  - **Description:** UX principles for making AI interactions delightful rather than frustrating.
+
+### LLM RecSys TRACK (June 4)
+
+- **Session ID: 925301**
+  - **Speaker:** Dr. Alex Kumar (ML Lead, Netflix)
+  - **Time:** 10:30 AM
+  - **Title:** LLMs for Next-Generation Recommendation Systems
+  - **Room:** Foothill G4: LLM RecSys
+  - **Track:** LLM RecSys
+  - **Description:** How language models are transforming personalization and content discovery.
+
+- **Session ID: 925302**
+  - **Speaker:** Jennifer Wong (Research Scientist, Spotify)
+  - **Time:** 12:15 PM
+  - **Title:** Multi-Modal Recommendations with Vision-Language Models
+  - **Room:** Foothill G4: LLM RecSys
+  - **Track:** LLM RecSys
+  - **Description:** Combining text, audio, and visual signals for better recommendations.
+
+- **Session ID: 925303**
+  - **Speaker:** Michael Chen (Engineering Manager, Pinterest)
+  - **Time:** 2:45 PM
+  - **Title:** Real-Time Personalization at Scale
+  - **Room:** Foothill G4: LLM RecSys
+  - **Track:** LLM RecSys
+  - **Description:** Infrastructure patterns for serving personalized LLM responses to millions of users.
+
+### AI IN FORTUNE 500 TRACK (June 4-5)
+
+#### Day 1: June 4
+
+- **Session ID: 926401**
+  - **Speaker:** Dr. Susan Taylor (Chief AI Officer, JPMorgan Chase)
+  - **Time:** 11:15 AM
+  - **Title:** Deploying AI in Highly Regulated Industries
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** Navigating compliance, risk management, and governance when building AI systems in finance.
+
+- **Session ID: 926402**
+  - **Speaker:** Robert Johnson (VP Engineering, Walmart)
+  - **Time:** 1:45 PM
+  - **Title:** AI-Powered Supply Chain Optimization
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** Real-world case studies of using AI to improve logistics and inventory management.
+
+- **Session ID: 926403**
+  - **Speaker:** Dr. Patricia Garcia (Head of AI Research, Pfizer)
+  - **Time:** 3:30 PM
+  - **Title:** Accelerating Drug Discovery with Foundation Models
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** How pharmaceutical companies are leveraging AI to speed up R&D.
+
+#### Day 2: June 5
+
+- **Session ID: 926404**
+  - **Speaker:** James Anderson (CTO, Ford Motor Company)
+  - **Time:** 10:45 AM
+  - **Title:** AI in Automotive: From Design to Autonomous Driving
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** End-to-end AI integration across the automotive value chain.
+
+- **Session ID: 926405**
+  - **Speaker:** Dr. Maria Rodriguez (VP Data Science, Target)
+  - **Time:** 1:15 PM
+  - **Title:** Retail AI: Personalization at Physical Scale
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** Bridging online and offline experiences with AI.
+
+- **Session ID: 926406**
+  - **Speaker:** Kevin O'Brien (Chief Innovation Officer, General Electric)
+  - **Time:** 3:00 PM
+  - **Title:** Industrial AI: Predictive Maintenance and Beyond
+  - **Room:** Golden Gate Ballroom C: AI in the Fortune 500
+  - **Track:** AI in Fortune 500
+  - **Description:** Applying AI to heavy industry and manufacturing.
+
+### DESIGN ENGINEERING TRACK (June 5)
+
+- **Session ID: 927501**
+  - **Speaker:** Sarah Kim (Design Lead, Linear)
+  - **Time:** 9:30 AM
+  - **Title:** Designing for AI-First Products
+  - **Room:** Foothill G5: Design Engineering
+  - **Track:** Design Engineering
+  - **Description:** New paradigms in UI/UX when AI is core to the product experience.
+
+- **Session ID: 927502**
+  - **Speaker:** Jordan Lee (Principal Designer, Vercel)
+  - **Time:** 11:45 AM
+  - **Title:** The Future of Design Tools: AI as Collaborator
+  - **Room:** Foothill G5: Design Engineering
+  - **Track:** Design Engineering
+  - **Description:** How AI is changing the designer's workflow and toolset.
+
+- **Session ID: 927503**
+  - **Speaker:** Dr. Nina Patel (Research Lead, Adobe)
+  - **Time:** 2:15 PM
+  - **Title:** Generative Design: When AI Becomes the Designer
+  - **Room:** Foothill G5: Design Engineering
+  - **Track:** Design Engineering
+  - **Description:** Exploring the boundaries between human creativity and AI generation.
+
+### ADDITIONAL WORKSHOPS (June 3)
+
+- **Session ID: 928601**
+  - **Speaker:** Dr. Robert Chen (Staff Engineer, Databricks)
+  - **Time:** 9:00 AM
+  - **Title:** Building Production RAG Systems with Vector Databases
+  - **Room:** Foothill G6: Workshops
+  - **Track:** Infrastructure
+  - **Description:** Hands-on workshop covering the full stack of RAG implementation.
+
+- **Session ID: 928602**
+  - **Speaker:** Lisa Martinez (Engineering Lead, Hugging Face)
+  - **Time:** 10:40 AM
+  - **Title:** Fine-Tuning Open Source LLMs for Specialized Tasks
+  - **Room:** Foothill G7: Workshops
+  - **Track:** AI in Action
+  - **Description:** Practical guide to customizing models for your specific use case.
+
+- **Session ID: 928603**
+  - **Speaker:** Daniel Park (Founder, LangChain)
+  - **Time:** 1:00 PM
+  - **Title:** Building Complex AI Workflows with LangChain
+  - **Room:** Foothill G8: Workshops
+  - **Track:** Agent Reliability
+  - **Description:** Advanced patterns for orchestrating multi-step AI processes.
+
+- **Session ID: 928604**
+  - **Speaker:** Dr. Amanda Foster (Research Scientist, Cohere)
+  - **Time:** 3:30 PM
+  - **Title:** Prompt Engineering Masterclass
+  - **Room:** Foothill G9: Workshops
+  - **Track:** Evals
+  - **Description:** Deep dive into techniques for getting the best results from LLMs.
+
+### INFRASTRUCTURE TRACK (June 4)
+
+- **Session ID: 929701**
+  - **Speaker:** Dr. Thomas Liu (VP Infrastructure, Anthropic)
+  - **Time:** 12:00 PM
+  - **Title:** Scaling LLM Inference to Millions of Users
+  - **Room:** Foothill F: Infrastructure
+  - **Track:** Infrastructure
+  - **Description:** Architecture patterns and lessons from running Claude in production.
+
+- **Session ID: 929702**
+  - **Speaker:** Sarah Johnson (Staff Engineer, Databricks)
+  - **Time:** 2:15 PM
+  - **Title:** Cost Optimization for LLM Workloads
+  - **Room:** Foothill F: Infrastructure
+  - **Track:** Infrastructure
+  - **Description:** Techniques for reducing inference costs while maintaining performance.
+
+- **Session ID: 929703**
+  - **Speaker:** Kevin Zhang (Principal Engineer, Together AI)
+  - **Time:** 4:00 PM
+  - **Title:** Open Source LLM Serving: A Deep Dive
+  - **Room:** Foothill F: Infrastructure
+  - **Track:** Infrastructure
+  - **Description:** Comparing vLLM, TGI, and other serving frameworks.
+
+### EXPO HALL SESSIONS (June 4-5)
+
+- **Session ID: 930801**
+  - **Speaker:** Multiple Vendors
+  - **Time:** All Day June 4
+  - **Title:** Expo Hall Demos and Networking
+  - **Room:** Salons 9-15: Expo Hall
+  - **Description:** Meet with leading AI infrastructure providers, dev tools, and startups.
+
+- **Session ID: 930802**
+  - **Speaker:** Various Startups
+  - **Time:** All Day June 5
+  - **Title:** Startup Showcase
+  - **Room:** Salons 9-15: Expo Hall
+  - **Description:** Discover the next generation of AI companies and products.
+
+### KEYNOTES AND SPECIAL SESSIONS
+
+- **Session ID: 931901**
+  - **Speaker:** Sam Altman (CEO, OpenAI)
+  - **Time:** June 4, 9:00 AM
+  - **Title:** Opening Keynote: The State of AI
+  - **Room:** Keynote/General Session (Yerba Buena 7&8)
+  - **Track:** Keynote
+  - **Description:** Vision for the future of AI from one of the industry's leading voices.
+
+- **Session ID: 931902**
+  - **Speaker:** Dario Amodei (CEO, Anthropic)
+  - **Time:** June 4, 10:00 AM
+  - **Title:** Building Safe and Beneficial AI Systems
+  - **Room:** Keynote/General Session (Yerba Buena 7&8)
+  - **Track:** Keynote
+  - **Description:** Anthropic's approach to AI safety and alignment.
+
+- **Session ID: 931903**
+  - **Speaker:** Demis Hassabis (CEO, Google DeepMind)
+  - **Time:** June 5, 9:00 AM
+  - **Title:** From AlphaGo to Gemini: The Journey of AI Research
+  - **Room:** Keynote/General Session (Yerba Buena 7&8)
+  - **Track:** Keynote
+  - **Description:** Reflections on a decade of breakthrough AI research.
+
+- **Session ID: 931904**
+  - **Speaker:** Satya Nadella (CEO, Microsoft)
+  - **Time:** June 5, 10:00 AM
+  - **Title:** AI for Everyone: Democratizing Intelligence
+  - **Room:** Keynote/General Session (Yerba Buena 7&8)
+  - **Track:** Keynote
+  - **Description:** Microsoft's vision for making AI accessible to all developers.
+
+### PANEL DISCUSSIONS
+
+- **Session ID: 932001**
+  - **Speakers:** Multiple Industry Leaders
+  - **Time:** June 4, 4:45 PM
+  - **Title:** The Future of Work in the Age of AI
+  - **Room:** Keynote/General Session (Yerba Buena 7&8)
+  - **Track:** Panel
+  - **Description:** How AI will transform jobs, education, and the economy.
+
+- **Session ID: 932002**
+  - **Speakers:** Ethics Researchers and Practitioners
+  - **Time:** June 5, 11:30 AM
+  - **Title:** AI Ethics: From Principles to Practice
+  - **Room:** Golden Gate Ballroom A
+  - **Track:** Panel
+  - **Description:** Turning ethical guidelines into concrete engineering practices.
+
+- **Session ID: 932003**
+  - **Speakers:** Founders and VCs
+  - **Time:** June 5, 4:15 PM
+  - **Title:** Investing in AI: What VCs Look For
+  - **Room:** Yerba Buena Ballroom Salons 2-6
+  - **Track:** Panel
+  - **Description:** Insights from investors funding the next wave of AI companies.
+
+### COMMUNITY MEETUPS
+
+Throughout the conference, there are community-organized meetups where attendees with shared interests can connect. These informal gatherings are a great way to meet fellow engineers, share experiences, and learn from each other.
+
+#### June 3 Community Meetups (5:30 PM - 9:00 PM, Atrium: Event Hub)
+- AI Safety & Alignment Community
+- Open Source LLM Developers
+- AI in Healthcare Practitioners
+- EdTech AI Builders
+- AI for Climate Tech
+- LangChain Community Meetup
+- Women in AI Engineering
+- AI Ethics Discussion Group
+
+#### June 4 Community Meetups (7:00 PM - 10:40 PM, Atrium: Event Hub)
+- Voice AI Developers Circle
+- RAG Systems Best Practices
+- MLOps & Infrastructure
+- AI Agent Builders
+- Computer Vision Engineers
+- AI for Creative Applications
+- Startup Founders in AI
+- AI Research to Production
+
+#### June 5 Community Meetups (5:30 PM - 9:00 PM, Atrium: Event Hub)
+- LLM Fine-Tuning Practitioners
+- Prompt Engineering Best Practices
+- AI in Finance & Trading
+- Indie Hackers Building with AI
+- Reinforcement Learning Community
+- AI for Social Good
+- Enterprise AI Leaders
+- Academic AI Researchers
+
+### EXPO HALL SPONSORS AND EXHIBITORS
+
+Visit the Expo Hall (Salons 9-15) on June 4-5 to connect with leading companies shaping the AI landscape:
+
+#### Infrastructure & Platforms
+- Modal - Serverless infrastructure for AI/ML
+- Together AI - Fast, scalable LLM inference
+- Replicate - Run models in the cloud with one line of code
+- Baseten - Deploy ML models in production
+- Anyscale - Ray-based ML platform
+- Databricks - Unified analytics and AI platform
+
+#### Vector Databases & Search
+- Pinecone - Vector database for AI applications
+- Weaviate - Open source vector search engine
+- Qdrant - High-performance vector similarity search
+- Chroma - AI-native open-source embedding database
+- Milvus - Cloud-native vector database
+
+#### LLM Development Tools
+- LangChain - Framework for LLM applications
+- LlamaIndex - Data framework for LLM apps
+- Weights & Biases - ML experiment tracking
+- Humanloop - LLM evaluation and optimization
+- Braintrust - AI product evaluation platform
+
+#### Model Providers
+- OpenAI - GPT-4 and beyond
+- Anthropic - Claude AI assistant
+- Google DeepMind - Gemini models
+- Cohere - Enterprise language models
+- Mistral AI - Open and commercial LLMs
+- Hugging Face - Open source model hub
+
+#### Observability & Monitoring
+- LangSmith - LLM application observability
+- Arize AI - ML observability platform
+- WhyLabs - AI monitoring and observability
+- Helicone - LLM monitoring and analytics
+
+#### Security & Compliance
+- Robust Intelligence - AI security platform
+- HiddenLayer - ML security solutions
+- Protect AI - MLSecOps platform
+- Credo AI - AI governance and risk management
+
+### SPEAKER BIOS (SELECTED)
+
+**Sean DuBois** - Principal Architect at Dolby and WebRTC pioneer. Sean has contributed to real-time communication protocols and infrastructure for over a decade, working on projects that handle millions of concurrent connections.
+
+**Kwindla Kramer** - Co-founder & CEO of Daily, a leading video and audio platform. Kwindla has been building internet infrastructure for 25 years and is passionate about making real-time AI accessible to developers.
+
+**Dexter Horthy** - Founder & CEO of Hamming AI. Former ML engineer at Scale AI and Affirm. Dexter focuses on making AI systems reliable and production-ready.
+
+**Mike Chambers** - CEO & Founder of Taktile. Previously led engineering teams at McKinsey and BCG. Expert in deploying ML models in regulated industries.
+
+**Charles Frye** - Senior Staff AI Educator at Modal. PhD dropout from UC Berkeley. Makes AI infrastructure accessible through teaching and writing.
+
+**Theodora Chu** - Product Manager for MCP at Anthropic. Leads the development of the Model Context Protocol standard. Previously worked on developer tools at GitHub.
+
+**David Cramer** - Co-founder of Sentry, the application monitoring platform. Known for pragmatic takes on developer tools and infrastructure.
+
+**Harald Kirschner** - VS Code Team Member at Microsoft. Works on GitHub Copilot integration and AI-assisted development tools.
+
+**Philipp Schmid** - AI Developer Experience at Hugging Face. Focuses on making state-of-the-art models accessible to developers through great APIs and documentation.
+
+### CONFERENCE LOGISTICS
+
+**Venue:** San Francisco Marriott Marquis, 780 Mission St, San Francisco, CA 94103
+
+**WiFi:** Network Name: AIEngineer2025 | Password: (provided on-site)
+
+**Badge Pickup:** Badges can be picked up at Registration (Atrium: Event Hub) starting at 8:00 AM on June 3rd.
+
+**Mobile App:** Download the AI Engineer World's Fair app (iOS/Android) for schedule updates, navigation, and networking features.
+
+**Accessibility:** The venue is fully wheelchair accessible. For specific accommodation requests, contact accessibility@ai.engineer.
+
+**Parking:** Valet parking available at the venue. Public parking at 5th & Mission Garage.
+
+**Public Transit:** BART/MUNI Powell St. Station (2 blocks), Multiple bus lines nearby.
+
+**Code of Conduct:** All attendees must adhere to our Code of Conduct ensuring a welcoming, inclusive environment for everyone.
+
+### FREQUENTLY ASKED QUESTIONS
+
+**Q: What's the difference between the Conference Pass and Conference + Workshop Pass?**
+A: The Conference Pass gives you access to all talks, keynotes, panels, and expo sessions on June 4-5. The Conference + Workshop Pass also includes access to the exclusive hands-on workshops on June 3, plus the evening Welcome Reception.
+
+**Q: Will sessions be recorded?**
+A: Yes! All keynotes and main track talks will be recorded and made available to ticket holders after the conference. Workshops are not recorded to maintain an intimate learning environment.
+
+**Q: What should I bring?**
+A: Bring your laptop for workshops, business cards for networking, comfortable shoes (lots of walking!), and a reusable water bottle. Don't forget your ticket confirmation email for badge pickup.
+
+**Q: Is there a dress code?**
+A: The conference is business casual. Most attendees wear jeans and a t-shirt or button-down. The important thing is to be comfortable!
+
+**Q: Can I bring a guest who isn't registered?**
+A: Sorry, all attendees must be registered. Badges are checked at session entrances. However, the Expo Hall has limited guest access on a space-available basis.
+
+**Q: Will there be swag?**
+A: Yes! All attendees receive a conference bag with sponsor goodies. Visit sponsor booths in the Expo Hall for more swag, demos, and giveaways.
+
+**Q: How do I get the most out of the conference?**
+A: Come with questions you want answered, attend sessions outside your comfort zone, talk to people in line, visit the Expo Hall, join community meetups, and don't be afraid to ask speakers questions!
+
+**Q: Are meals included with my ticket?**
+A: Continental breakfast and lunch are provided all three days for all ticket types. There are also morning and afternoon breaks with refreshments.
+
+**Q: Can I switch between tracks during the day?**
+A: Absolutely! Most sessions are 20-30 minutes, making it easy to sample different tracks. Check the schedule for session times and plan your route through the venue.
+
+**Q: Is there childcare available?**
+A: While we don't provide on-site childcare, we can recommend local services. Contact hello@ai.engineer for recommendations.
+
+**Q: What if I can't attend in person?**
+A: We offer a limited number of virtual passes that include access to livestreamed keynotes and all recorded sessions. However, the in-person experience, networking, and hands-on workshops are highly recommended.
+
+### TICKET INFORMATION
+
+**Early Bird Pricing (Ended March 1):**
+- Conference Pass: $599
+- Conference + Workshop Pass: $899
+
+**Regular Pricing (March 2 - May 15):**
+- Conference Pass: $799
+- Conference + Workshop Pass: $1,199
+
+**Late Registration (After May 15):**
+- Conference Pass: $999
+- Conference + Workshop Pass: $1,499
+
+**Student Discount:** 50% off with valid .edu email (limited availability)
+
+**Group Discounts:** Contact sales@ai.engineer for groups of 5 or more
+
+**Diversity Scholarships:** Apply by April 15 for need-based scholarships covering full conference admission
+
+### HOTEL AND TRAVEL
+
+**Conference Hotel:** San Francisco Marriott Marquis - Book using code AIENG25 for discounted rate ($299/night, limited availability)
+
+**Nearby Hotels:**
+- Hotel Zephyr ($350/night, 0.3 miles)
+- The Mosser ($200/night, 0.2 miles)
+- Hyatt Regency San Francisco ($400/night, 0.4 miles)
+
+**Airport:** San Francisco International Airport (SFO) - 14 miles from venue
+- BART public transit: ~30 minutes, $10
+- Rideshare/Taxi: ~25 minutes, $40-60
+- Shuttle service: Available through select hotels
+
+**Getting Around SF:**
+- BART/Muni: Extensive public transit system
+- Rideshare: Uber, Lyft readily available
+- Bike Share: Bay Wheels stations throughout the city
+- Walking: Downtown area is very walkable
+
+### CONTACT INFORMATION
+
+**General Questions:** hello@ai.engineer
+**Sponsorship Inquiries:** sponsors@ai.engineer
+**Speaker Questions:** speakers@ai.engineer
+**Technical Support:** support@ai.engineer
+**Media/Press:** press@ai.engineer
+
+**Social Media:**
+- Twitter/X: @aiDotEngineer
+- LinkedIn: AI Engineer Community
+- Discord: discord.gg/aiengineer
+- Newsletter: ai.engineer/newsletter
+
+**Website:** https://ai.engineer
+**Schedule:** https://ai.engineer/schedule
+**Tickets:** https://ti.to/software-3/ai-engineer-worlds-fair-2025

--- a/eval_mcp/benchmarks/aiwf/data/system_preamble.txt
+++ b/eval_mcp/benchmarks/aiwf/data/system_preamble.txt
@@ -1,0 +1,39 @@
+
+Today is June 2, 2025.
+
+You are a helpful, friendly, and enthusiastic voice assistant for the AI Engineer World's Fair 2025.
+
+Your **only** purpose is to answer questions and perform tasks related to the AI Engineer World's Fair 2025. You can answer questions about:
+  - The AI Engineer World's Fair 2025 event schedule, including sessions, speakers, and topics.
+  - The conversation you've had with the user so far.
+  - What you are able to do.
+
+You must be polite but firm in deflecting any questions that are not about the event, the conversation, or your capabilities. Do not try to answer questions about locations, directions, or the event venue in general. Do not try to answer questions about general interest topics unrelated to the event. For such questions, respond with a clear and friendly statement like, "I'm the voice assistant for the AI Engineer World's Fair 2025, and I can only answer questions about the event. How can I help you with the fair today?"
+
+You must act as a voice assistant, meaning your responses should be conversational, concise, and easy to understand when spoken.
+
+**Primary Instructions:**
+
+1.  **Be Factual:** Base all your answers strictly on the information provided in the "KNOWLEDGE BASE" section below. Do not invent or infer information. If the information is not in the text, state that you do not have that information.
+2. **When asked for information about talks, workshops, or sessions, look up the information in the "KNOWLEDGE BASE" section below. Do not invent or infer information. If the information is not in the text, state that you do not have that information.
+3. **When using the KNOWLEDGE BASE:** Include information about all relevant sessions, speakers, and topics if you are asked to list sessions, speakers, or topics. Make sure to consider all entries in the KNOWLEDGE BASE.
+3. **When using the KNOWLEDGE BASE:** If you are looking up information about talks by a speaker, include all sessions by that speaker. Make sure to consider all entries in the KNOWLEDGE BASE.
+4. **When using the KNOWLEDGE BASE:** If you are asked a general question about a topic or track, give a concise overview answer, *not* a list.
+5. **When using the KNOWLEDGE BASE:** Do not attempt to calculate or infer total numbers of sessions, speakers, or topics. For example, if asked how many sessions there are for a specific track, respond with the kinds of sessions there are for that track and on which days.
+6.  **Use Your Tools:** You have access to a specific set of tools (functions) listed under the "AVAILABLE TOOLS" section. You must use these tools when a user's request matches a tool's description.
+7.  **Gather Information for Tools:** Before calling a function, you **must** collect all the `required` parameters from the user. Engage in a natural conversation to get this information. For example, if a user wants to submit a dietary request, you must ask for their name and preference before calling the `submit_dietary_request` function.
+8. **When using Tools, use information that has been provided previously:** Whenever you use tools, you **should** use information you already know to help you complete the task. For example, if you are asked to submit a dietary request, you should use the information you already know about the user to help you complete the task.
+9.  **Confirm Actions:** After calling a function, confirm to the user that the action has been taken. For example, "Thank you, [Name]. I've submitted your request for [preference] meals."
+10.  **End the Conversation:** When the user indicates the conversation is over (e.g., "goodbye," "that's all," "thank you"), use the `end_session` function.
+
+**Recommendation Instructions:**
+
+If you are asked to suggest or recommend sessions:
+1. Start by asking about the user's interests,
+2. Then ask about whether the user will be at the conference a specific day, and if so all day or only in the morning or afternoon.
+3.  Finally, provide 2 suggestions, listing the title, speaker, date, and time for the sessions you recommend.
+
+
+---
+### **KNOWLEDGE BASE**
+

--- a/eval_mcp/benchmarks/aiwf/data/system_tools_section.txt
+++ b/eval_mcp/benchmarks/aiwf/data/system_tools_section.txt
@@ -1,0 +1,101 @@
+---
+### **AVAILABLE TOOLS**
+
+You have access to the following functions. You must call them when a user's request matches the description. Do not call a function until all required parameters are collected.
+
+
+# 1. End Session
+end_session_function = FunctionSchema(
+    name="end_session", description="End the current session.", properties={}, required=None
+)
+
+# 2. Submit Dietary Request
+submit_dietary_request_function = FunctionSchema(
+    name="submit_dietary_request",
+    description="Submit a dietary request for event meals.",
+    properties={
+        "name": {
+            "type": "string",
+            "description": "The name of the person making the request.",
+        },
+        "dietary_preference": {
+            "type": "string",
+            "description": "The dietary preference (e.g., vegetarian, gluten-free, vegan).",
+        },
+    },
+    required=["name", "dietary_preference"],
+)
+
+# 3. Submit Session Suggestion
+submit_session_suggestion_function = FunctionSchema(
+    name="submit_session_suggestion",
+    description="Submit a suggestion for a new session or talk at the event.",
+    properties={
+        "name": {
+            "type": "string",
+            "description": "The name of the person making the suggestion.",
+        },
+        "suggestion_text": {
+            "type": "string",
+            "description": "The text of the session suggestion.",
+        },
+    },
+    required=["name", "suggestion_text"],
+)
+
+# 4. Vote for a Session
+vote_for_session_function = FunctionSchema(
+    name="vote_for_session",
+    description="Vote for an existing session to show your interest.",
+    properties={
+        "name": {
+            "type": "string",
+            "description": "The name of the person voting.",
+        },
+        "session_id": {
+            "type": "string",
+            "description": "The Session ID of the session being voted for. The Session ID is a number.",
+        },
+    },
+    required=["name", "session_id"],
+)
+
+# 5. Request for Tech Support
+request_tech_support_function = FunctionSchema(
+    name="request_tech_support",
+    description="Request technical support for an issue at the event (e.g., WiFi problems, app issues).",
+    properties={
+        "name": {
+            "type": "string",
+            "description": "The name of the person requesting support.",
+        },
+        "issue_description": {
+            "type": "string",
+            "description": "A description of the technical issue.",
+        },
+    },
+    required=["name", "issue_description"],
+)
+```
+
+**Example Interactions:**
+
+*   **User:** "Where can I get breakfast on June 4th?"
+*   **You:** "On June 4th, a continental breakfast is available from 7:15 AM to 9:55 AM in the Grand Assembly."
+
+*   **User:** "I have a food allergy."
+*   **You:** "I can submit a dietary request for you. What is your name and what is your dietary preference or allergy?"
+
+*   **User:** "My name is Jane Doe, and I need gluten-free options."
+*   **You (Action):** Call `submit_dietary_request(name="Jane Doe", dietary_preference="gluten-free")`.
+*   **You (Response):** "Thank you, Jane. I've submitted your request for gluten-free options."
+
+*   **User:** "I want to vote for the session on the Rise of the AI Architect as the best session I saw at the World's Fair."
+*   **You:** "That sounds like a great session! I can help you vote for it to show your interest. What is your name?"
+
+*   **User:** "My name is Sam. The session ID is 941249."
+*   **You (Action):** Call `vote_for_session(name="Sam", session_id="941249")`.
+*   **You (Response):** "Got it, Sam! Your vote for session 941249, 'Rise of the AI Architect', has been recorded. Thanks!"
+
+*   **User:** "What's the capital of California?"
+*   **You:** "I'm the voice assistant for the AI Engineer World's Fair 2025, so I can only answer questions about the event. Is there anything I can help you with for the fair?"

--- a/eval_mcp/benchmarks/aiwf/data/turns.json
+++ b/eval_mcp/benchmarks/aiwf/data/turns.json
@@ -1,0 +1,215 @@
+[
+  {
+    "index": 0,
+    "input": "I'm trying to decide whether to come for workshop day. When are the workshops?",
+    "golden_text": "Workshop day is on Tuesday, June 3rd. There will be exclusive, hands-on workshops across five different tracks, with topics for all experience levels.",
+    "required_function_call": null
+  },
+  {
+    "index": 1,
+    "input": "Are there any workshops about Gemini?",
+    "golden_text": "Yes, there are two workshops on that day that feature Gemini!\n\nFirst, at 10:40 AM, there's **\"Building Voice Agents with Gemini and Pipecat,\"** where you can build and deploy your own voice agent.\n\nLater, at 1:00 PM, you can attend **\"AI Engineering with the Google Gemini 2.5 Model Family,\"** which is a hands-on workshop where you'll learn to use Gemini 2.5 Pro with agentic tooling.",
+    "required_function_call": null
+  },
+  {
+    "index": 2,
+    "input": "How many conference tracks are there?",
+    "golden_text": "There will be 19 tracks of talks, panels, and demos during the main conference days on June 4th and 5th.",
+    "required_function_call": null
+  },
+  {
+    "index": 3,
+    "input": "Is there a track about MCP?",
+    "golden_text": "Yes, there is an MCP track on June 4th. It focuses on the Model Context Protocol and covers its origins, how to build with it, and its future possibilities for agent-to-agent communication.",
+    "required_function_call": null
+  },
+  {
+    "index": 4,
+    "input": "How many sessions are in that track?",
+    "golden_text": "The MCP track on June 4th features a variety of sessions, including keynotes and talks. There are also several workshops on June 3rd that are focused on building with MCP. The sessions cover topics like the origins of MCP, its practical implementation, and its role in the future of AI agents.",
+    "required_function_call": null
+  },
+  {
+    "index": 5,
+    "input": "It seems like there are so many great sessions. Can you suggest some sessions for me?",
+    "golden_text": "I agree, there are a lot of exciting sessions! To give you the best recommendations, could you tell me what topics you're most interested in? For example, are you into building agents, infrastructure, voice technology, or something else?",
+    "required_function_call": null
+  },
+  {
+    "index": 6,
+    "input": "I'm particularly interested in Voice AI and in techniques for building reliable agents.",
+    "golden_text": "Those are fantastic topics! To help me narrow down the best sessions for you, could you let me know which day or days you'll be at the conference? And will you be there all day, or just for the morning or afternoon?",
+    "required_function_call": null
+  },
+  {
+    "index": 7,
+    "input": "I'll be at the conference on June 4th all day.",
+    "golden_text": "Excellent! Based on your interests in Voice AI and building reliable agents, I have two great suggestions for you for June 4th.\n\nFirst, I'd recommend the session **\"[Voice Keynote] Your realtime AI is ngmi\"** by Sean DuBois and Kwindla Kramer. It's on June 4th at 11:15 AM. They'll be discussing why you need to design real-time AI systems from the network layer up to be successful.\n\nSecond, you might like **\"12 Factor Agents - Principles of Reliable LLM Applications\"** by Dexter Horthy. That's on June 4th at 11:35 AM. He'll be sharing principles for building LLM-powered software that is reliable enough for production customers.\n\nI hope these suggestions are helpful for planning your day! Let me know if you need anything else.",
+    "required_function_call": null
+  },
+  {
+    "index": 8,
+    "input": "Actually, I made a mistake. I will only be at the conference on June 5th.",
+    "golden_text": "No problem at all! Let's find you some great sessions for June 5th. Based on your interest in Voice AI and building reliable agents, here are two recommendations for that day:\n\nFirst, for your interest in Voice AI, I suggest **\"Serving Voice AI at Scale,\"** which is a fireside chat with Arjun Desai and Rohit Talluri. It's happening on June 5th at 1:15 PM. They'll be doing a technical deep dive into the best practices for building a state-of-the-art inference stack for voice AI.\n\nSecond, to learn more about reliable agents, I'd recommend **\"Ship it! Building Production-Ready Agents\"** by Mike Chambers. This talk is on June 5th at 12:15 PM and will cover the practical challenges and solutions for deploying AI agents in real-world production environments.\n\nI hope these updated suggestions are helpful for planning your day on June 5th! Let me know if you need anything else",
+    "required_function_call": null
+  },
+  {
+    "index": 9,
+    "input": "I heard there will be community organized hallway track sessions. Can I make a suggestion for a hallway track session?",
+    "golden_text": "Yes, I can help with that! I can submit a suggestion for a hallway track session for you. What is your name and what is your suggestion?",
+    "required_function_call": null
+  },
+  {
+    "index": 10,
+    "input": "My name is Jennifer Smith.",
+    "golden_text": "Thanks, Jennifer! And what's your suggestion for the hallway track session?",
+    "required_function_call": null
+  },
+  {
+    "index": 11,
+    "input": "My suggestion is for a session about open telemetry tracing.",
+    "golden_text": "Thank you, Jennifer! I've submitted your suggestion for a session on open telemetry tracing. Is there anything else I can help you with today?",
+    "required_function_call": {
+      "name": "submit_session_suggestion",
+      "args": {
+        "name": "Jennifer Smith",
+        "suggestion_text": "A session about open telemetry tracing."
+      }
+    }
+  },
+  {
+    "index": 12,
+    "input": "Oh, one more suggestion. How about a session on state machine abstractions for complex workflows?.",
+    "golden_text": "Thank you, Jennifer! I've submitted your suggestion for a session on state machine abstractions for complex workflows. Is there anything else I can help you with today?",
+    "required_function_call": {
+      "name": "submit_session_suggestion",
+      "args": {
+        "suggestion_text": "A session on state machine abstractions for complex workflows.",
+        "name": "Jennifer Smith"
+      }
+    }
+  },
+  {
+    "index": 13,
+    "input": "Thanks for submitting both session suggestions. Is there food at the conference?",
+    "golden_text": "Yes, meals are provided throughout the conference. Continental breakfast and lunch are available on all three days, June 3rd through the 5th. There are also morning and afternoon breaks with refreshments, a Welcome Reception on the evening of the 3rd, and an afterparty on the evening of the 4th.",
+    "required_function_call": null
+  },
+  {
+    "index": 14,
+    "input": "Will there be vegan options?",
+    "golden_text": "Of course! I can submit a dietary request for you. Would you like me to do that?",
+    "required_function_call": null
+  },
+  {
+    "index": 15,
+    "input": "Yes.",
+    "golden_text": "Thank you, Jennifer. I've submitted your request for vegan meals. Is there anything else I can help you with today?",
+    "required_function_call": {
+      "name": "submit_dietary_request",
+      "args": {
+        "name": "Jennifer Smith",
+        "dietary_preference": "vegan"
+      }
+    }
+  },
+  {
+    "index": 16,
+    "input": "Yes. I'm having trouble with the mobile app.",
+    "golden_text": "I'm sorry to hear you're having trouble. I can create a tech support ticket for you. What seems to be the problem with the mobile app?",
+    "required_function_call": null
+  },
+  {
+    "index": 17,
+    "input": "I can't access the location maps.",
+    "golden_text": "Thank you, Jennifer. I've created a tech support ticket for you regarding the issue with accessing location maps on the mobile app. Someone from our tech team will look into it. Is there anything else I can help you with?",
+    "required_function_call": {
+      "name": "request_tech_support",
+      "args": {
+        "issue_description": "Cannot access location maps on the mobile app.",
+        "name": "Jennifer Smith"
+      }
+    }
+  },
+  {
+    "index": 18,
+    "input": "What's the weather supposed to be like in San Francisco tomorrow?",
+    "golden_text": "I'm sorry, I don't have weather information. I'm the voice assistant for the AI Engineer World's Fair 2025 and can only help with questions about the event. Is there anything about the conference I can help you with?",
+    "required_function_call": null
+  },
+  {
+    "index": 19,
+    "input": "Well, since I can't access the mobile maps, can you tell me how to get to Salon 2?",
+    "golden_text": "I understand you're looking for Salon 2 since the maps in the app aren't working for you. Unfortunately, I don't have the ability to provide directions or information about specific locations within the venue. The tech support team has been notified about the app issue. Can I help you with any information about the sessions or speakers instead?",
+    "required_function_call": null
+  },
+  {
+    "index": 20,
+    "input": "Is there a talk by Charles Frye?",
+    "golden_text": "Yes, Charles Frye is speaking at the conference. He has two sessions on June 4th.\n\nFirst, at 11:15 AM, he's giving a workshop called **\"What every AI engineer needs to know about GPUs.\"**\n\nThen, at 12:45 PM, he's giving a talk titled **\"How fast are LLM inference engines anyway?\"**\n\nThe workshop is part of the Infrastructure track, and the talk is part of the AI in Action track.",
+    "required_function_call": null
+  },
+  {
+    "index": 21,
+    "input": "Where is the second one?",
+    "golden_text": "That talk, \"How fast are LLM inference engines anyway?\", will be in the Juniper: Expo Sessions room.",
+    "required_function_call": null
+  },
+  {
+    "index": 22,
+    "input": "I heard that there's some way to vote for our favorite talk of the conference. Is that true?",
+    "golden_text": "Yes, that's correct! You can vote for your favorite sessions. I can help you with that. I'll just need the Session ID for the talk you'd like to vote for. I already have your name as Jennifer Smith.",
+    "required_function_call": null
+  },
+  {
+    "index": 23,
+    "input": "I don't know the session ID, but the talk was by Harald Kirschner.",
+    "golden_text": "Of course. Harald Kirschner is involved in three sessions. Could you please tell me which one you'd like to vote for?\n\n*   First, there's the workshop on June 3rd titled: **\"Real-World Development with GitHub Copilot and VS Code.\"**\n*   Second, is the talk on June 4th titled: **\"Full Spectrum MCP: Uncovering Hidden Servers and Clients Capabilities.\"**\n*   And third, the talk on June 5th is titled: **\"Vibe Coding at Scale: Customizing AI Assistants for Enterprise Environments.\"**",
+    "required_function_call": null
+  },
+  {
+    "index": 24,
+    "input": "I'd like to vote for the one about vibe coding.",
+    "golden_text": "Thank you, Jennifer! I've submitted your vote for the session on Vibe Coding at Scale: Customizing AI Assistants for Enterprise Environments. Is there anything else I can help you with today?",
+    "required_function_call": {
+      "name": "vote_for_session",
+      "args": {
+        "session_id": "936902",
+        "name": "Jennifer Smith"
+      }
+    }
+  },
+  {
+    "index": 25,
+    "input": "Yes — what time is lunch on June 5th?",
+    "golden_text": "Lunch on June 5th is from 12:00 PM to 2:00 PM in Salons 9–15: Expo Hall.",
+    "required_function_call": null
+  },
+  {
+    "index": 26,
+    "input": "Could you also confirm if there's an afterparty on June 4th?",
+    "golden_text": "Yes. The Toolbit Afterparty is on June 4th from 5:15 PM to 7:00 PM in Salons 9–15: Expo Hall.",
+    "required_function_call": null
+  },
+  {
+    "index": 27,
+    "input": "Are there community meetups on the evening of June 5th?",
+    "golden_text": "Yes. Community Meetups take place on June 5th from 5:30 PM to 9:00 PM in the Atrium: Event Hub.",
+    "required_function_call": null
+  },
+  {
+    "index": 28,
+    "input": "One last detail: when is continental breakfast on June 4th?",
+    "golden_text": "On June 4th, continental breakfast is available from 7:15 AM to 9:55 AM in the Grand Assembly.",
+    "required_function_call": null
+  },
+  {
+    "index": 29,
+    "input": "I just wanted to say the conference was great. I don't have anything else.",
+    "golden_text": "Thank you for your feedback, Jennifer! I'm so glad you enjoyed the conference. Have a great day",
+    "required_function_call": {
+      "name": "end_session",
+      "args": {}
+    }
+  }
+]

--- a/eval_mcp/benchmarks/aiwf/data/upstream_judge_system_prompt.txt
+++ b/eval_mcp/benchmarks/aiwf/data/upstream_judge_system_prompt.txt
@@ -1,0 +1,111 @@
+# Role
+You are an expert evaluator for conversational AI systems. You will judge a multi-turn conversation between a user and an AI assistant for the AI Engineer World's Fair 2025.
+
+# CRITICAL: Evaluate ALL Turns
+
+**You MUST output a judgment for EVERY turn provided in the input.** Do not stop early or skip turns. Even if the conversation seems to have gone off-track, continue evaluating all remaining turns. The final_judgments array must contain exactly one entry for each turn in the input.
+
+# Two-Phase Evaluation Process
+
+You will evaluate in TWO phases:
+
+## PHASE 1: Initial Turn-by-Turn Analysis
+For each turn, evaluate against the golden expectation and note any discrepancies.
+
+## PHASE 2: Realignment Analysis
+After the initial pass, look for "turn misalignment" patterns:
+- **Early function calls**: A function was called earlier than expected (e.g., at turn N instead of N+1)
+- **Late function calls**: A function was called later than expected (e.g., at turn N+1 instead of N)
+- **Cascading effects**: If a function was called early, subsequent turns expecting that call should NOT be penalized
+- **Semantic equivalence**: Even if timing differs, did the conversation accomplish the same goals?
+
+# Evaluation Dimensions
+
+For each turn, evaluate FOUR dimensions:
+
+1. **turn_taking** (bool):
+   - This dimension is PRE-COMPUTED based on audio timing analysis
+   - If marked as a turn-taking failure in the input, set to FALSE
+   - If not marked, set to TRUE
+   - Turn-taking failures indicate audio timing issues (interruptions, overlaps, missing audio)
+
+2. **tool_use_correct** (bool):
+   - TRUE if the assistant correctly called the expected function with semantically equivalent arguments
+   - TRUE if no function call was expected and none was made
+   - TRUE if a function call was expected but was already made in an earlier turn (realignment case)
+   - TRUE if a late function call is made at this turn (the call eventually happened, credit this turn)
+   - FALSE if a function call was expected, not made, and NOT already made earlier
+   - FALSE if the assistant's words imply waiting for confirmation but it acts without waiting
+   - FALSE if the assistant asks for unnecessary confirmation instead of making the expected function call
+   - For argument matching, use semantic equivalence (not verbatim)
+   - Session IDs must match exactly
+
+3. **instruction_following** (bool):
+   - TRUE if assistant directly answers the question OR advances the task
+   - TRUE if assistant properly deflects out-of-scope questions
+   - TRUE if the turn is part of a realigned workflow that still accomplishes the goal
+   - FALSE if assistant's words contradict its actions (says "Does that work?" but doesn't wait)
+   - FALSE if assistant neither answers nor advances the workflow
+   - FALSE if the assistant asks for unnecessary confirmation when it already has all needed information
+   - **IMPORTANT**: If a turn has turn_taking=FALSE, be lenient on instruction_following since garbled audio may cause transcription issues
+
+4. **kb_grounding** (bool):
+   - TRUE unless assistant states an explicit factual error
+   - TRUE if assistant provides additional correct information
+   - FALSE only for clear factual contradictions (wrong dates, times, locations, speakers)
+
+# Critical: Detecting Words-Actions Mismatch
+
+A turn should FAIL instruction_following if the assistant's text implies one behavior but its actions show another:
+- Says "I'll wait for confirmation" but calls the function immediately
+- Says "Could you confirm?" but doesn't actually wait for the response
+- Says "Does that work?" in the same turn where it confirms completion
+
+# Critical: Handling Early Function Calls
+
+When you detect an early function call:
+1. Note which function was called and at which turn
+2. In subsequent turns, if that same function was "expected", mark tool_use_correct as TRUE (already satisfied)
+3. Add a note in reasoning explaining the realignment
+
+# Critical: Handling Late Function Calls
+
+When you detect a late function call (assistant asked for unnecessary confirmation instead of acting):
+1. Penalize the turn where the function SHOULD have been called (tool_use_correct=FALSE, instruction_following=FALSE)
+2. Credit the turn where the function was ACTUALLY called (tool_use_correct=TRUE)
+3. Continue evaluating ALL subsequent turns normally
+4. Add a note in function_call_tracking with status "late"
+
+Example: If vote_for_session was expected at turn 24 but called at turn 25:
+- Turn 24: tool_use_correct=FALSE (didn't call when it should have), instruction_following=FALSE (asked unnecessary confirmation)
+- Turn 25: tool_use_correct=TRUE (function was called correctly)
+- Turns 26-29: Evaluate normally, do NOT skip these turns
+
+# Critical: Empty Assistant Text with Tool Calls
+
+A turn with empty assistant_text but a valid tool call is still a valid turn. The assistant may have called the function without generating speech. Evaluate the tool call normally.
+
+# Output Format
+
+Output a JSON object with this structure:
+```json
+{
+  "phase1_analysis": [
+    {"turn": 0, "initial_tool_use": true, "initial_instruction": true, "initial_kb": true, "notes": "..."},
+    ...
+  ],
+  "realignment_notes": "Description of any detected misalignments and how they were resolved",
+  "function_call_tracking": {
+    "submit_dietary_request": {"expected_turn": 15, "actual_turn": 14, "status": "early"},
+    ...
+  },
+  "final_judgments": [
+    {"turn": 0, "reasoning": "...", "turn_taking": true, "tool_use_correct": true, "instruction_following": true, "kb_grounding": true},
+    ...
+  ]
+}
+```
+
+Note: The `turn_taking` field should match what was provided in the input (pre-computed from audio timing analysis).
+
+Output ONLY this JSON object, no markdown code blocks, no explanations outside the JSON.

--- a/eval_mcp/benchmarks/aiwf/data_loader.py
+++ b/eval_mcp/benchmarks/aiwf/data_loader.py
@@ -1,0 +1,182 @@
+"""Vendored aiewf data + the five conference tools, as Inspect primitives.
+
+Everything here is data loading and schema translation — no model calls. The
+JSON/txt files under ``data/`` are upstream's, converted once at vendor time:
+
+- ``turns.json`` — upstream's ``benchmarks/_shared/turns.py`` list, with the
+  ``audio_file`` key dropped (speech-only) and an explicit ``index`` added.
+- ``kb_medium.txt`` / ``kb_long.txt`` — the two knowledge bases verbatim.
+- ``system_preamble.txt`` / ``system_tools_section.txt`` — the two literal
+  blocks upstream concatenates around the knowledge base, verbatim. Kept as
+  separate files because the prompt is ``preamble + kb + tools_section`` and
+  only the middle differs between the two variants.
+"""
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from inspect_ai.tool import Tool, ToolDef
+
+_DATA = Path(__file__).parent / "data"
+
+# Variant name → knowledge-base file. Upstream's two benchmarks differ ONLY in
+# this file; turns, tools and prompt scaffolding are shared.
+AIWF_TASKS: Dict[str, str] = {
+    "aiwf_medium_context": "kb_medium.txt",
+    "aiwf_long_context": "kb_long.txt",
+}
+
+
+@dataclass(frozen=True)
+class Turn:
+    """One scripted user utterance and what a correct response looks like.
+
+    ``required_function_call`` is upstream's golden tool call: ``{"name": ...,
+    "args": {...}}`` on the 6 turns that expect one, ``None`` on the other 24
+    (where calling anything is itself a failure).
+    """
+
+    index: int
+    input: str
+    golden_text: str
+    required_function_call: Optional[Dict[str, Any]]
+
+    @property
+    def expected_tool(self) -> Optional[str]:
+        return (self.required_function_call or {}).get("name")
+
+    @property
+    def expected_args(self) -> Dict[str, Any]:
+        return (self.required_function_call or {}).get("args") or {}
+
+
+@lru_cache(maxsize=1)
+def turns() -> List[Turn]:
+    """The 30 conversation turns, in order."""
+    raw = json.loads((_DATA / "turns.json").read_text(encoding="utf-8"))
+    return [Turn(**t) for t in raw]
+
+
+@lru_cache(maxsize=None)
+def knowledge_base(variant: str) -> str:
+    """The knowledge base for one variant (~12K tokens medium, ~40K long)."""
+    try:
+        filename = AIWF_TASKS[variant]
+    except KeyError:
+        raise ValueError(
+            f"Unknown aiwf variant {variant!r}. Expected one of: "
+            f"{sorted(AIWF_TASKS)}"
+        ) from None
+    return (_DATA / filename).read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=None)
+def system_prompt(variant: str) -> str:
+    """Upstream's system instruction: preamble + knowledge base + tool docs.
+
+    Reproduces ``system_instruction = _PREAMBLE + _load_knowledge_base() +
+    _TOOLS_SECTION`` from upstream's ``prompts/system.py``. The tools section
+    is prose *about* the tools (kept because the benchmark's instruction-
+    following criteria reference it); the actual callable schemas come from
+    ``tool_defs()`` and are passed to the model as real tools.
+    """
+    preamble = (_DATA / "system_preamble.txt").read_text(encoding="utf-8")
+    tools_section = (_DATA / "system_tools_section.txt").read_text(encoding="utf-8")
+    return preamble + knowledge_base(variant) + tools_section
+
+
+# ---------------------------------------------------------------------------
+# The five conference tools.
+#
+# Upstream registers a single catch-all handler that returns {"status":
+# "success"} for every call and treats ``end_session`` specially. We do the
+# same: nothing is actually submitted anywhere, and what's being measured is
+# whether the model calls the right function with the right arguments — the
+# result only has to be plausible enough for the conversation to continue.
+#
+# Built via ToolDef rather than @tool so the JSON schema stays a faithful
+# transcription of upstream's FunctionSchema definitions (names, descriptions
+# and required-ness all affect whether a model calls them correctly, so they're
+# part of the benchmark, not an implementation detail).
+# ---------------------------------------------------------------------------
+
+_SUCCESS = {"status": "success"}
+
+
+async def _end_session() -> Dict[str, str]:
+    return _SUCCESS
+
+
+async def _submit_dietary_request(name: str, dietary_preference: str) -> Dict[str, str]:
+    return _SUCCESS
+
+
+async def _submit_session_suggestion(name: str, suggestion_text: str) -> Dict[str, str]:
+    return _SUCCESS
+
+
+async def _vote_for_session(name: str, session_id: str) -> Dict[str, str]:
+    return _SUCCESS
+
+
+async def _request_tech_support(name: str, issue_description: str) -> Dict[str, str]:
+    return _SUCCESS
+
+
+def tool_defs() -> List[Tool]:
+    """The five tools, in upstream's declaration order."""
+    return [
+        ToolDef(
+            _end_session,
+            name="end_session",
+            description="End the current session.",
+            parameters={},
+        ).as_tool(),
+        ToolDef(
+            _submit_dietary_request,
+            name="submit_dietary_request",
+            description="Submit a dietary request for event meals.",
+            parameters={
+                "name": "The name of the person making the request.",
+                "dietary_preference": (
+                    "The dietary preference (e.g., vegetarian, gluten-free, vegan)."
+                ),
+            },
+        ).as_tool(),
+        ToolDef(
+            _submit_session_suggestion,
+            name="submit_session_suggestion",
+            description="Submit a suggestion for a new session or talk at the event.",
+            parameters={
+                "name": "The name of the person making the suggestion.",
+                "suggestion_text": "The text of the session suggestion.",
+            },
+        ).as_tool(),
+        ToolDef(
+            _vote_for_session,
+            name="vote_for_session",
+            description="Vote for an existing session to show your interest.",
+            parameters={
+                "name": "The name of the person voting.",
+                "session_id": (
+                    "The Session ID of the session being voted for. "
+                    "The Session ID is a number."
+                ),
+            },
+        ).as_tool(),
+        ToolDef(
+            _request_tech_support,
+            name="request_tech_support",
+            description=(
+                "Request technical support for an issue at the event "
+                "(e.g., WiFi problems, app issues)."
+            ),
+            parameters={
+                "name": "The name of the person requesting support.",
+                "issue_description": "A description of the technical issue.",
+            },
+        ).as_tool(),
+    ]

--- a/eval_mcp/benchmarks/aiwf/eval.yaml
+++ b/eval_mcp/benchmarks/aiwf/eval.yaml
@@ -1,0 +1,61 @@
+# Metadata for the bundled aiwf benchmark. Schema mirrors inspect_evals'
+# eval.yaml (see its src/inspect_evals/*/eval.yaml) so this stays familiar and
+# could be submitted to their register later with little change.
+#
+# Discovered automatically by eval_mcp/benchmarks/registry.py — adding a
+# benchmark means dropping a directory with one of these in it, NOT editing any
+# Python.
+title: "AI Engineer World's Fair multi-turn conversation"
+description: |
+  A 30-turn scripted conversation with a conference assistant, measuring whether
+  a model holds up as context accumulates: calling the right tool at the right
+  moment, following its system prompt, and staying factually grounded in a
+  knowledge base. Text mode only.
+group: Multi-turn
+version: "1"
+
+# Every task exposed by task.py, and what running one costs.
+tasks:
+  - name: aiwf_medium_context
+    description: "~12K-token knowledge base"
+    turns: 30
+    approx_input_tokens_per_model: 500000
+  - name: aiwf_long_context
+    description: "~40K-token knowledge base"
+    turns: 30
+    approx_input_tokens_per_model: 3000000
+
+# What the scorer reports. First entry is the headline.
+metrics:
+  - name: pass_rate
+    description: "Turns where all 3 judged dimensions pass (upstream's headline)"
+  - name: tool_use_rate
+    description: "Turns where the expected tool call was made, or correctly absent"
+  - name: instruction_rate
+    description: "Turns where the assistant answered or advanced the task"
+  - name: kb_grounding_rate
+    description: "Turns free of explicit factual contradictions"
+  - name: truncated_turns
+    description: "Turns cut off at the token ceiling; non-zero means scores are a floor"
+
+# Judge-scored, so the judge is part of the measuring instrument.
+judge:
+  default: bedrock/us.anthropic.claude-opus-5
+  overridable: true
+
+source:
+  repository_url: https://github.com/kwindla/aiewf-eval
+  repository_commit: d0dabb6c473d8e8d5a84a5504af3f68ec50e9e70
+  license: MIT
+  notice: NOTICE.md
+
+# Anything about this port a caller should know before comparing numbers.
+caveats:
+  - "Text mode only — upstream's speech-to-speech pipelines are not ported."
+  - >-
+    Judge differs from upstream's (claude-opus-4-5 via the Claude Agent SDK),
+    so absolute scores are not directly comparable to their published table.
+  - >-
+    max_turns caps the conversation for a cheap smoke run; those scores are NOT
+    comparable to a full run, since the tool-call turns cluster late (11, 12,
+    15, 17, 24, 29).

--- a/eval_mcp/benchmarks/aiwf/task.py
+++ b/eval_mcp/benchmarks/aiwf/task.py
@@ -23,6 +23,8 @@ all three hold on that same turn.
 
 import json
 import os
+import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 # Omit max_tokens so Bedrock applies each model's own default rather than
@@ -130,6 +132,7 @@ def aiwf_conversation(variant: str):
                 state.messages.extend(result.messages)
 
             texts = [output.completion or ""]
+            recovery_calls: List[Any] = []
             recovered = False
             if turn.expected_tool and not any(
                 c.function == turn.expected_tool for c in calls
@@ -139,23 +142,46 @@ def aiwf_conversation(variant: str):
                 state.messages.append(ChatMessageUser(content=_RECOVERY_UTTERANCE))
                 retry = await model.generate(state.messages, tools=state.tools)
                 state.messages.append(retry.message)
-                retry_calls = list(retry.message.tool_calls or [])
-                if retry_calls:
+                recovery_calls = list(retry.message.tool_calls or [])
+                if recovery_calls:
                     retry_result = await execute_tools([retry.message], state.tools)
                     state.messages.extend(retry_result.messages)
-                calls.extend(retry_calls)
                 texts.append(retry.completion or "")
+                # NOTE: recovery_calls are deliberately NOT merged into `calls`.
+                # Upstream records the nudge attempt as a separate transcript
+                # entry (recovery_turn=True) whose tool calls sit on that entry —
+                # start_turn() resets the recorder's turn_calls first — and its
+                # judge skips those entries. So a call that only happened after
+                # the nudge is not credited to the scripted turn. The nudge's
+                # real effect is on the CONVERSATION: it unblocks the workflow so
+                # later turns aren't derailed by the missing call.
                 output = retry
 
             records.append(
                 {
                     "turn": turn.index,
                     "user_text": turn.input,
-                    # Both attempts' text, so the judge sees what the model
-                    # actually said across the turn.
-                    "assistant_text": "\n".join(t for t in texts if t),
+                    # Upstream writes the recovery attempt as a SEPARATE
+                    # transcript record flagged recovery_turn=True, and its judge
+                    # skips those records entirely
+                    # (``if rec.get("recovery_turn"): continue``) — only the
+                    # scripted turn is scored. So the judge sees the FIRST
+                    # attempt's text, not the nudge reply. We match that: the
+                    # recovery attempt's text is kept in
+                    # ``recovery_assistant_text`` for debugging but is not shown
+                    # to the judge. Concatenating both (an earlier version of
+                    # this file) let a model that only complied after the nudge
+                    # look like it complied immediately.
+                    "assistant_text": texts[0],
+                    "recovery_assistant_text": texts[1] if len(texts) > 1 else None,
                     "tool_calls": [
                         {"name": c.function, "args": c.arguments} for c in calls
+                    ],
+                    # Recorded for debugging + the recoveries_used metric, and
+                    # deliberately not shown to the judge (see above).
+                    "recovery_tool_calls": [
+                        {"name": c.function, "args": c.arguments}
+                        for c in recovery_calls
                     ],
                     "expected_function": turn.required_function_call,
                     "golden_text": turn.golden_text,
@@ -172,7 +198,7 @@ def aiwf_conversation(variant: str):
             state.output = output
 
             if turn.expected_tool == "end_session" and any(
-                c.function == "end_session" for c in calls
+                c.function == "end_session" for c in (calls + recovery_calls)
             ):
                 # Upstream terminates the run here. It's the last turn anyway;
                 # break rather than relying on that.
@@ -197,113 +223,114 @@ def aiwf_conversation(variant: str):
 # time couldn't know a function was already called two turns earlier. We keep
 # that, so we keep its consequence — the per-turn judgments are not
 # independent.
-_JUDGE_SYSTEM_PROMPT = """You are an expert evaluator for conversational AI \
-systems. You will judge a multi-turn conversation between a user and an AI \
-assistant for the AI Engineer World's Fair 2025.
+#
+# The prompt is upstream's, VERBATIM, loaded from the vendored copy of its
+# JUDGE_SYSTEM_PROMPT. Do not paraphrase it: the wording is the measuring
+# instrument, and an earlier version of this file rewrote it "more cleanly",
+# which silently changed what the benchmark measures. The only edit is the
+# mechanical removal of the audio-only `turn_taking` dimension, done by
+# transforming upstream's text at load time (rather than hand-editing a copy)
+# so the excision stays auditable and can't drift — see _strip_audio_dimension
+# and the tests that pin it.
 
-# CRITICAL: Evaluate ALL turns
 
-You MUST output a judgment for EVERY turn provided in the input. Do not stop \
-early or skip turns. Even if the conversation went off-track, continue \
-evaluating all remaining turns.
+def _strip_audio_dimension(prompt: str) -> str:
+    """Remove upstream's audio-only ``turn_taking`` dimension from its prompt.
 
-# Evaluation dimensions
+    We have no audio, so that dimension is undefined. Everything else — the
+    two-phase structure, every scoring rule, the worked examples, the output
+    schema — is left exactly as upstream wrote it.
 
-For each turn, evaluate THREE dimensions:
+    Four mechanical edits:
+      1. drop the ``1. **turn_taking**`` block
+      2. renumber the remaining dimensions 1..3 and say THREE, not FOUR
+      3. drop the "be lenient if turn_taking=FALSE" sub-rule
+      4. drop ``turn_taking`` from the output example + its trailing note
+    """
+    lines = prompt.splitlines()
+    out: List[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
 
-1. **tool_use_correct** (bool):
-   - TRUE if the assistant called the expected function with semantically \
-equivalent arguments
-   - TRUE if no function call was expected and none was made
-   - TRUE if a function call was expected but was already made in an earlier \
-turn (realignment case)
-   - TRUE if a late function call is made at this turn (the call eventually \
-happened, credit this turn)
-   - FALSE if a function call was expected, not made, and NOT already made \
-earlier
-   - FALSE if the assistant's words imply waiting for confirmation but it acts \
-without waiting
-   - FALSE if the assistant asks for unnecessary confirmation instead of \
-making the expected function call
-   - For argument matching, use semantic equivalence (not verbatim). Session \
-IDs must match exactly.
+        # 1. the whole "1. **turn_taking** (bool):" block, up to the next
+        #    numbered dimension.
+        if line.strip().startswith("1. **turn_taking**"):
+            i += 1
+            while i < len(lines) and not re.match(r"^\d+\. \*\*", lines[i].strip()):
+                i += 1
+            continue
 
-2. **instruction_following** (bool):
-   - TRUE if the assistant directly answers the question OR advances the task
-   - TRUE if the assistant properly deflects out-of-scope questions
-   - TRUE if the turn is part of a realigned workflow that still accomplishes \
-the goal
-   - FALSE if the assistant's words contradict its actions (says "Does that \
-work?" but doesn't wait)
-   - FALSE if the assistant neither answers nor advances the workflow
-   - FALSE if the assistant asks for unnecessary confirmation when it already \
-has all needed information
+        # 3. the audio-conditional leniency sub-rule.
+        if "If a turn has turn_taking=FALSE" in line:
+            i += 1
+            continue
 
-3. **kb_grounding** (bool):
-   - TRUE unless the assistant states an explicit factual error
-   - TRUE if the assistant provides additional correct information
-   - FALSE only for clear factual contradictions (wrong dates, times, \
-locations, speakers)
-   - Judge against the Golden Response shown for each turn. You do NOT have \
-the knowledge base; do not penalise detail you cannot verify.
+        # 4. the trailing note about the turn_taking field.
+        if line.startswith("Note: The `turn_taking` field"):
+            i += 1
+            # also swallow the blank line that followed it
+            if i < len(lines) and not lines[i].strip():
+                i += 1
+            continue
 
-# Handling early function calls
+        # 2. dimension count + renumbering (2,3,4 -> 1,2,3).
+        if line == "For each turn, evaluate FOUR dimensions:":
+            line = "For each turn, evaluate THREE dimensions:"
+        else:
+            m = re.match(r"^([234])\. \*\*(\w+)\*\* \(bool\):$", line.strip())
+            if m:
+                line = f"{int(m.group(1)) - 1}. **{m.group(2)}** (bool):"
 
-When you detect an early function call: note which function and at which turn. \
-In subsequent turns, if that same function was "expected", mark \
-tool_use_correct TRUE (already satisfied) and explain the realignment.
+        # 4. turn_taking key inside the JSON output example.
+        if '"turn_taking": true,' in line:
+            line = line.replace('"turn_taking": true, ', "")
 
-# Handling late function calls
+        out.append(line)
+        i += 1
+    return "\n".join(out)
 
-When the assistant asked for unnecessary confirmation instead of acting: \
-penalise the turn where the function SHOULD have been called \
-(tool_use_correct=FALSE, instruction_following=FALSE), credit the turn where \
-it WAS called (tool_use_correct=TRUE), and keep evaluating all later turns.
 
-# Empty assistant text with a tool call
+_UPSTREAM_JUDGE_PROMPT = (
+    Path(__file__).parent / "data" / "upstream_judge_system_prompt.txt"
+).read_text(encoding="utf-8")
 
-A turn with empty assistant text but a valid tool call is still valid. The \
-assistant may have called the function without speaking. Evaluate the tool \
-call normally.
-
-# Truncated turns
-
-A turn marked TRUNCATED hit the model's token ceiling before finishing. Judge \
-what is present; do not treat the truncation itself as a factual error.
-
-Submit your judgments with the submit_judgments tool. Provide exactly one \
-entry per turn, in order."""
+_JUDGE_SYSTEM_PROMPT = _strip_audio_dimension(_UPSTREAM_JUDGE_PROMPT)
 
 
 def _render_transcript(records: List[Dict[str, Any]]) -> str:
-    """Format the conversation for the judge.
+    """Format the conversation for the judge, following upstream exactly.
 
-    Mirrors upstream's ``build_judge_prompt``: user text, assistant text,
-    golden response, expected function, actual functions. The knowledge base is
-    deliberately NOT included — upstream's judge doesn't get it either, and
-    including it would change what kb_grounding measures (and add ~92K tokens
-    per judge call on the long variant).
+    Ports ``format_turns_for_claude``: an "Expected Function Calls Summary"
+    header listing every golden call up front, then per-turn User / Assistant /
+    Golden Response / Expected Function / Actual Functions. The knowledge base
+    is NOT included — upstream's judge doesn't get it either.
+
+    Upstream also emits ``**Turn-Taking**: OK (no audio analysis)`` per turn
+    even in text mode. That line is dropped here rather than hard-coded, since
+    the dimension it feeds doesn't exist for us.
     """
-    lines: List[str] = []
+    lines: List[str] = ["# Expected Function Calls Summary", ""]
+    for r in records:
+        fc = r.get("expected_function")
+        if fc:
+            lines.append(f"- Turn {r['turn']}: {fc['name']}({json.dumps(fc['args'])})")
+    lines += ["", "---", "", "# Conversation Turns", ""]
+
     for r in records:
         lines.append(f"## Turn {r['turn']}")
         lines.append(f"**User**: {r['user_text']}")
-        assistant = r["assistant_text"] or "(no text)"
+        assistant = r["assistant_text"] or ""
         if r.get("stop_reason") == "max_tokens":
-            assistant += "  [TRUNCATED: hit token ceiling]"
+            # Not upstream's — our runs can hit a token ceiling that its
+            # pipeline never surfaced. Marked so the judge doesn't read a
+            # severed answer as a factual error.
+            assistant += "  [TRUNCATED: hit the model's token ceiling]"
         lines.append(f"**Assistant**: {assistant}")
-        if r.get("recovery_used"):
-            # Upstream merges the nudge attempt into the same turn, so the judge
-            # must know both replies belong to one turn — otherwise it reads the
-            # concatenation as the assistant rambling or repeating itself.
-            lines.append(
-                "**Note**: the assistant did not act on the first attempt, so a "
-                'synthetic "Please go ahead." nudge was sent; the text above '
-                "combines both replies of this one turn."
-            )
         lines.append("")
-        if r.get("golden_text"):
-            lines.append(f"**Golden Response**: {r['golden_text']}")
+        golden = r.get("golden_text") or ""
+        if golden:
+            lines.append(f"**Golden Response**: {golden}")
             lines.append("")
         expected = r.get("expected_function")
         lines.append(
@@ -313,10 +340,36 @@ def _render_transcript(records: List[Dict[str, Any]]) -> str:
         lines.append(
             f"**Actual Functions**: {json.dumps(actual) if actual else 'none'}"
         )
-        lines.append("")
-        lines.append("---")
-        lines.append("")
+        lines += ["", "---", ""]
     return "\n".join(lines)
+
+
+def _render_user_prompt(records: List[Dict[str, Any]]) -> str:
+    """Upstream's user-turn prompt: formatted turns + its closing instructions.
+
+    The numbered two-phase instructions and the "Remember:" recap are quoted
+    verbatim from upstream's ``judge_with_claude``. An earlier version of this
+    port omitted them; they are part of the rubric, not decoration.
+    """
+    n = len(records)
+    return f"""{_render_transcript(records)}
+
+Please perform your two-phase evaluation:
+1. First, analyze each turn against its golden expectation
+2. Then, identify any turn misalignments (early/late function calls)
+3. Apply realignment adjustments to avoid double-penalizing
+4. Output the final judgments for ALL {n} turns
+
+CRITICAL: Your judgments array MUST contain exactly {n} entries.
+
+Remember:
+- If a function is called early (before expected turn), subsequent turns should not be penalized for the "missing" call
+- If a function is called late (after expected turn), penalize the turn that should have called it, credit the turn that did call it, then continue evaluating all remaining turns
+- If the assistant says "Does that work?" but doesn't wait for confirmation, that's an instruction_following failure
+- If the assistant asks for unnecessary confirmation when it has all needed info, that's a tool_use_correct AND instruction_following failure
+- Be generous with kb_grounding unless there's a clear factual error
+- Empty assistant_text with a valid tool call is still a valid turn - evaluate the tool call
+"""
 
 
 def _build_judgment_tool(n_turns: int) -> ToolInfo:
@@ -505,7 +558,7 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
             output = await judge.generate(
                 [
                     ChatMessageSystem(content=_JUDGE_SYSTEM_PROMPT),
-                    ChatMessageUser(content=_render_transcript(records)),
+                    ChatMessageUser(content=_render_user_prompt(records)),
                 ],
                 tools=[_build_judgment_tool(len(records))],
                 tool_choice="any",

--- a/eval_mcp/benchmarks/aiwf/task.py
+++ b/eval_mcp/benchmarks/aiwf/task.py
@@ -1,0 +1,680 @@
+"""AI Engineer World's Fair multi-turn benchmark — Inspect task (text mode).
+
+Two tasks, differing only in knowledge-base size:
+
+    aiwf_medium_context   ~12K-token KB
+    aiwf_long_context     ~40K-token KB
+
+Run via ``run_multiturn_benchmark``, or directly:
+
+    inspect eval eval_mcp/benchmarks/aiwf/task.py@aiwf_medium_context \\
+        --model bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
+
+Shape: ONE sample per model = the whole 30-turn conversation. Turns are scripted
+(the user side is fixed, so every model faces an identical conversation), and the
+model's replies accumulate into the context — which is the point of the
+benchmark: performance under a growing multi-turn context, not single-shot Q&A.
+
+Scoring reproduces upstream's three judged dimensions per turn —
+``tool_use_correct``, ``instruction_following``, ``kb_grounding`` — and its
+headline ``pass_rate = turn_pass / total_turns``, where a turn passes only if
+all three hold on that same turn.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+# Omit max_tokens so Bedrock applies each model's own default rather than
+# Inspect's constant 2048. Essential here: a 30-turn conversation with a 40K
+# knowledge base is exactly where a reasoning model burns its whole visible
+# budget on the reasoning channel and returns empty. See CLAUDE.md
+# ("Don't pass max_tokens to evals").
+import eval_mcp.inspect_patches  # noqa: F401
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.model import (
+    ChatMessageSystem,
+    ChatMessageUser,
+    execute_tools,
+    get_model,
+)
+from inspect_ai.scorer import Metric, SampleScore, Score, Target, metric, scorer
+from inspect_ai.solver import Generate, TaskState, solver
+from inspect_ai.tool import ToolInfo, ToolParams
+
+from eval_mcp.benchmarks.aiwf.data_loader import (
+    AIWF_TASKS,
+    system_prompt,
+    tool_defs,
+    turns,
+)
+from eval_mcp.core.judge_config import JUDGE_MODELS
+
+# Bump when a change could move scores (upstream's convention, see
+# inspect_evals TASK_VERSIONING.md). 1 = initial port of aiewf-eval @ 2c9ae4e.
+TASK_VERSION = 1
+
+DIMENSIONS = ("tool_use_correct", "instruction_following", "kb_grounding")
+
+
+def _max_turns() -> Optional[int]:
+    """Turn cap for smoke runs (``EVAL_MCP_AIWF_MAX_TURNS``), else all 30.
+
+    Read from the environment rather than a task parameter so it stays out of
+    the benchmark's public signature — a truncated run is a debugging aid, not
+    a variant of the benchmark, and its scores are NOT comparable to a full run
+    (the tool-call turns cluster in the second half: 11, 12, 15, 17, 24, 29).
+    """
+    raw = os.environ.get("EVAL_MCP_AIWF_MAX_TURNS")
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+# ---------------------------------------------------------------------------
+# Solver: replay the scripted conversation
+# ---------------------------------------------------------------------------
+
+
+# Upstream's synthetic recovery utterance (``MTE_ENABLE_RECOVERY``, default on).
+_RECOVERY_UTTERANCE = "Please go ahead."
+
+
+@solver
+def aiwf_conversation(variant: str):
+    """Replay all 30 turns against one model, recording per-turn behaviour.
+
+    Two upstream behaviours this reproduces, both of which materially move
+    scores — verified against a real run before porting:
+
+    **Turn boundary.** Upstream's text pipeline sets
+    ``default_tool_result_run_llm = False``, so a turn ENDS at the tool call.
+    The tool result goes into the context for the next turn, but we do not
+    generate again within the same turn. Generating twice would hand the model
+    a free second attempt and inflate scores.
+
+    **Recovery nudge.** When a turn expected a tool call and the model didn't
+    make one, upstream injects ONE synthetic ``"Please go ahead."`` turn and
+    merges that attempt into the same scripted turn. This is what lets a model
+    that narrates ("Let me submit that for you") before acting still pass. Both
+    attempts' tool calls are recorded against the turn, matching upstream's
+    ``_has_required_call`` check, which ignores which attempt produced the call.
+    Without this the same model scores ~15 points lower than upstream reports.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        model = get_model()
+        state.tools = list(tool_defs())
+        state.messages = [ChatMessageSystem(content=system_prompt(variant))]
+
+        cap = _max_turns()
+        script = turns()[:cap] if cap else turns()
+
+        records: List[Dict[str, Any]] = []
+        recoveries = 0
+        for turn in script:
+            state.messages.append(ChatMessageUser(content=turn.input))
+            output = await model.generate(state.messages, tools=state.tools)
+            state.messages.append(output.message)
+
+            calls = list(output.message.tool_calls or [])
+            if calls:
+                # Tool results must land in context, or the next turn starts
+                # from a dangling tool_use block, which Bedrock rejects.
+                result = await execute_tools([output.message], state.tools)
+                state.messages.extend(result.messages)
+
+            texts = [output.completion or ""]
+            recovered = False
+            if turn.expected_tool and not any(
+                c.function == turn.expected_tool for c in calls
+            ):
+                recovered = True
+                recoveries += 1
+                state.messages.append(ChatMessageUser(content=_RECOVERY_UTTERANCE))
+                retry = await model.generate(state.messages, tools=state.tools)
+                state.messages.append(retry.message)
+                retry_calls = list(retry.message.tool_calls or [])
+                if retry_calls:
+                    retry_result = await execute_tools([retry.message], state.tools)
+                    state.messages.extend(retry_result.messages)
+                calls.extend(retry_calls)
+                texts.append(retry.completion or "")
+                output = retry
+
+            records.append(
+                {
+                    "turn": turn.index,
+                    "user_text": turn.input,
+                    # Both attempts' text, so the judge sees what the model
+                    # actually said across the turn.
+                    "assistant_text": "\n".join(t for t in texts if t),
+                    "tool_calls": [
+                        {"name": c.function, "args": c.arguments} for c in calls
+                    ],
+                    "expected_function": turn.required_function_call,
+                    "golden_text": turn.golden_text,
+                    "recovery_used": recovered,
+                    # Upstream's TTFT column. Inspect reports total generate
+                    # time, not true time-to-first-token (it doesn't stream),
+                    # so this is an upper bound — named accordingly.
+                    "response_seconds": round(output.time, 3) if output.time else None,
+                    "stop_reason": output.stop_reason,
+                }
+            )
+            # Keep the last output as state.output so a truncated final turn is
+            # still visible to anything inspecting the sample.
+            state.output = output
+
+            if turn.expected_tool == "end_session" and any(
+                c.function == "end_session" for c in calls
+            ):
+                # Upstream terminates the run here. It's the last turn anyway;
+                # break rather than relying on that.
+                break
+
+        state.metadata["transcript"] = records
+        state.metadata["turns_run"] = len(records)
+        state.metadata["recoveries_used"] = recoveries
+        if cap:
+            state.metadata["turn_cap"] = cap
+        return state
+
+    return solve
+
+
+# ---------------------------------------------------------------------------
+# Scorer: one judge call over the whole conversation
+# ---------------------------------------------------------------------------
+
+# Upstream judges all 30 turns in a SINGLE call, which is what makes its
+# early/late tool-call realignment possible: a judge that saw one turn at a
+# time couldn't know a function was already called two turns earlier. We keep
+# that, so we keep its consequence — the per-turn judgments are not
+# independent.
+_JUDGE_SYSTEM_PROMPT = """You are an expert evaluator for conversational AI \
+systems. You will judge a multi-turn conversation between a user and an AI \
+assistant for the AI Engineer World's Fair 2025.
+
+# CRITICAL: Evaluate ALL turns
+
+You MUST output a judgment for EVERY turn provided in the input. Do not stop \
+early or skip turns. Even if the conversation went off-track, continue \
+evaluating all remaining turns.
+
+# Evaluation dimensions
+
+For each turn, evaluate THREE dimensions:
+
+1. **tool_use_correct** (bool):
+   - TRUE if the assistant called the expected function with semantically \
+equivalent arguments
+   - TRUE if no function call was expected and none was made
+   - TRUE if a function call was expected but was already made in an earlier \
+turn (realignment case)
+   - TRUE if a late function call is made at this turn (the call eventually \
+happened, credit this turn)
+   - FALSE if a function call was expected, not made, and NOT already made \
+earlier
+   - FALSE if the assistant's words imply waiting for confirmation but it acts \
+without waiting
+   - FALSE if the assistant asks for unnecessary confirmation instead of \
+making the expected function call
+   - For argument matching, use semantic equivalence (not verbatim). Session \
+IDs must match exactly.
+
+2. **instruction_following** (bool):
+   - TRUE if the assistant directly answers the question OR advances the task
+   - TRUE if the assistant properly deflects out-of-scope questions
+   - TRUE if the turn is part of a realigned workflow that still accomplishes \
+the goal
+   - FALSE if the assistant's words contradict its actions (says "Does that \
+work?" but doesn't wait)
+   - FALSE if the assistant neither answers nor advances the workflow
+   - FALSE if the assistant asks for unnecessary confirmation when it already \
+has all needed information
+
+3. **kb_grounding** (bool):
+   - TRUE unless the assistant states an explicit factual error
+   - TRUE if the assistant provides additional correct information
+   - FALSE only for clear factual contradictions (wrong dates, times, \
+locations, speakers)
+   - Judge against the Golden Response shown for each turn. You do NOT have \
+the knowledge base; do not penalise detail you cannot verify.
+
+# Handling early function calls
+
+When you detect an early function call: note which function and at which turn. \
+In subsequent turns, if that same function was "expected", mark \
+tool_use_correct TRUE (already satisfied) and explain the realignment.
+
+# Handling late function calls
+
+When the assistant asked for unnecessary confirmation instead of acting: \
+penalise the turn where the function SHOULD have been called \
+(tool_use_correct=FALSE, instruction_following=FALSE), credit the turn where \
+it WAS called (tool_use_correct=TRUE), and keep evaluating all later turns.
+
+# Empty assistant text with a tool call
+
+A turn with empty assistant text but a valid tool call is still valid. The \
+assistant may have called the function without speaking. Evaluate the tool \
+call normally.
+
+# Truncated turns
+
+A turn marked TRUNCATED hit the model's token ceiling before finishing. Judge \
+what is present; do not treat the truncation itself as a factual error.
+
+Submit your judgments with the submit_judgments tool. Provide exactly one \
+entry per turn, in order."""
+
+
+def _render_transcript(records: List[Dict[str, Any]]) -> str:
+    """Format the conversation for the judge.
+
+    Mirrors upstream's ``build_judge_prompt``: user text, assistant text,
+    golden response, expected function, actual functions. The knowledge base is
+    deliberately NOT included — upstream's judge doesn't get it either, and
+    including it would change what kb_grounding measures (and add ~92K tokens
+    per judge call on the long variant).
+    """
+    lines: List[str] = []
+    for r in records:
+        lines.append(f"## Turn {r['turn']}")
+        lines.append(f"**User**: {r['user_text']}")
+        assistant = r["assistant_text"] or "(no text)"
+        if r.get("stop_reason") == "max_tokens":
+            assistant += "  [TRUNCATED: hit token ceiling]"
+        lines.append(f"**Assistant**: {assistant}")
+        if r.get("recovery_used"):
+            # Upstream merges the nudge attempt into the same turn, so the judge
+            # must know both replies belong to one turn — otherwise it reads the
+            # concatenation as the assistant rambling or repeating itself.
+            lines.append(
+                "**Note**: the assistant did not act on the first attempt, so a "
+                'synthetic "Please go ahead." nudge was sent; the text above '
+                "combines both replies of this one turn."
+            )
+        lines.append("")
+        if r.get("golden_text"):
+            lines.append(f"**Golden Response**: {r['golden_text']}")
+            lines.append("")
+        expected = r.get("expected_function")
+        lines.append(
+            f"**Expected Function**: {json.dumps(expected) if expected else 'none'}"
+        )
+        actual = r.get("tool_calls") or []
+        lines.append(
+            f"**Actual Functions**: {json.dumps(actual) if actual else 'none'}"
+        )
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_judgment_tool(n_turns: int) -> ToolInfo:
+    """Forced-output schema: one judgment object per turn.
+
+    Nested arrays-of-objects are riskier than the flat schema the jury scorer
+    uses, but per-turn judgments genuinely are structured — and unlike the
+    jury, this call has to return 30 of them at once.
+    """
+    return ToolInfo(
+        name="submit_judgments",
+        description="Submit one judgment per conversation turn.",
+        parameters=ToolParams(
+            type="object",
+            properties={
+                "judgments": {
+                    "type": "array",
+                    "description": (
+                        f"Exactly {n_turns} entries, one per turn, in turn order."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "turn": {
+                                "type": "integer",
+                                "description": "0-based turn index.",
+                            },
+                            "tool_use_correct": {"type": "boolean"},
+                            "instruction_following": {"type": "boolean"},
+                            "kb_grounding": {"type": "boolean"},
+                            "reasoning": {
+                                "type": "string",
+                                "description": "One short sentence. Note any realignment.",
+                            },
+                        },
+                        "required": [
+                            "turn",
+                            "tool_use_correct",
+                            "instruction_following",
+                            "kb_grounding",
+                        ],
+                    },
+                }
+            },
+            required=["judgments"],
+        ),
+    )
+
+
+def _extract_judgments(
+    output: Any, n_turns: int
+) -> tuple[Optional[Dict[int, Dict[str, Any]]], Optional[str]]:
+    """Pull the judgments array out of the forced tool call."""
+    if not output or not output.message or not output.message.tool_calls:
+        text = output.completion[:200] if output and output.completion else "(empty)"
+        return None, f"No tool call. Response: {text}"
+
+    raw: List[Any] = []
+    for tc in output.message.tool_calls:
+        if tc.function == "submit_judgments":
+            raw.extend(tc.arguments.get("judgments") or [])
+    if not raw:
+        return None, "No submit_judgments tool call found"
+
+    by_turn: Dict[int, Dict[str, Any]] = {}
+    for j in raw:
+        if not isinstance(j, dict) or "turn" not in j:
+            continue
+        try:
+            idx = int(j["turn"])
+        except (TypeError, ValueError):
+            continue
+        by_turn[idx] = {
+            **{d: bool(j.get(d, False)) for d in DIMENSIONS},
+            "reasoning": str(j.get("reasoning", "") or ""),
+        }
+    if not by_turn:
+        return None, f"No parseable judgments in {len(raw)} entries"
+    return by_turn, None
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def _turn_rate(scores: List[SampleScore], key: str) -> float:
+    """Aggregate one per-turn counter across samples as a rate over turns.
+
+    Turn-level rather than sample-level: the unit the benchmark reports is the
+    turn, while a sample is a whole conversation. Counters are read off score
+    metadata so all four rates come from the one judge call.
+    """
+    num = sum(int(s.score.metadata.get(key, 0) or 0) for s in scores)
+    den = sum(int(s.score.metadata.get("turns_judged", 0) or 0) for s in scores)
+    return _rate(num, den)
+
+
+# Each rate needs its own decorated function: @metric fixes the display name at
+# decoration time, so a single parameterised factory would report four metrics
+# all called "turn_metric" (Inspect disambiguates them as turn_metric2/3/4,
+# which is unreadable in the viewer).
+@metric("pass_rate")
+def pass_rate() -> Metric:
+    """Upstream's headline: turns where all 3 dimensions pass, over all turns."""
+
+    def compute(scores: List[SampleScore]) -> float:
+        return _turn_rate(scores, "turn_pass")
+
+    return compute
+
+
+@metric("tool_use_rate")
+def tool_use_rate() -> Metric:
+    """Turns where the expected tool call was made (or correctly absent)."""
+
+    def compute(scores: List[SampleScore]) -> float:
+        return _turn_rate(scores, "tool_use_correct")
+
+    return compute
+
+
+@metric("instruction_rate")
+def instruction_rate() -> Metric:
+    """Turns where the assistant answered or advanced the task."""
+
+    def compute(scores: List[SampleScore]) -> float:
+        return _turn_rate(scores, "instruction_following")
+
+    return compute
+
+
+@metric("kb_grounding_rate")
+def kb_grounding_rate() -> Metric:
+    """Turns free of explicit factual contradictions."""
+
+    def compute(scores: List[SampleScore]) -> float:
+        return _turn_rate(scores, "kb_grounding")
+
+    return compute
+
+
+@metric("truncated_turns")
+def truncated_turns() -> Metric:
+    """Turns that hit the token ceiling. Non-zero means scores are a floor."""
+
+    def compute(scores: List[SampleScore]) -> float:
+        return float(
+            sum(int(s.score.metadata.get("truncated_turns", 0) or 0) for s in scores)
+        )
+
+    return compute
+
+
+@scorer(
+    metrics=[
+        pass_rate(),
+        tool_use_rate(),
+        instruction_rate(),
+        kb_grounding_rate(),
+        truncated_turns(),
+    ]
+)
+def aiwf_turn_judge(judge_model: Optional[str] = None):
+    """Judge the whole conversation in one call, score per turn.
+
+    Single judge, not our usual jury: upstream uses one strong judge over the
+    full conversation, and the realignment logic depends on seeing every turn
+    together. Three jurors would each need the whole 30-turn transcript, and
+    majority-voting per turn would still not make the turns independent.
+    """
+
+    async def score(state: TaskState, target: Target) -> Score:
+        records: List[Dict[str, Any]] = state.metadata.get("transcript") or []
+        if not records:
+            return Score(
+                value=0.0,
+                explanation="No conversation was recorded — the solver produced nothing.",
+                metadata={"turns_judged": 0, "error": "empty_transcript"},
+            )
+
+        truncated = sum(1 for r in records if r.get("stop_reason") == "max_tokens")
+        model_id = judge_model or JUDGE_MODELS["claude"]
+
+        try:
+            judge = get_model(model_id)
+            output = await judge.generate(
+                [
+                    ChatMessageSystem(content=_JUDGE_SYSTEM_PROMPT),
+                    ChatMessageUser(content=_render_transcript(records)),
+                ],
+                tools=[_build_judgment_tool(len(records))],
+                tool_choice="any",
+            )
+        except Exception as e:  # judge failure is a measurement failure
+            return Score(
+                value=0.0,
+                explanation=f"Judge call failed: {e}",
+                metadata={
+                    "turns_judged": 0,
+                    "truncated_turns": truncated,
+                    "error": f"judge_failed: {e}",
+                },
+            )
+
+        judgments, err = _extract_judgments(output, len(records))
+        if judgments is None:
+            return Score(
+                value=0.0,
+                explanation=f"Could not parse judge output: {err}",
+                metadata={
+                    "turns_judged": 0,
+                    "truncated_turns": truncated,
+                    "error": f"unparseable_judge_output: {err}",
+                },
+            )
+
+        # Only turns the judge actually returned count toward the denominator.
+        # Silently scoring a skipped turn 0 would blame the model for the
+        # judge's omission; unjudged_turns surfaces it instead.
+        per_turn: List[Dict[str, Any]] = []
+        counters = {d: 0 for d in DIMENSIONS}
+        turn_pass = 0
+        for r in records:
+            j = judgments.get(r["turn"])
+            if j is None:
+                continue
+            passed = all(j[d] for d in DIMENSIONS)
+            turn_pass += int(passed)
+            for d in DIMENSIONS:
+                counters[d] += int(j[d])
+            per_turn.append(
+                {
+                    "turn": r["turn"],
+                    **{d: j[d] for d in DIMENSIONS},
+                    "turn_pass": passed,
+                    "reasoning": j["reasoning"],
+                    "recovery_used": bool(r.get("recovery_used")),
+                    "tools_called": [c["name"] for c in (r.get("tool_calls") or [])],
+                    "expected_tool": (r.get("expected_function") or {}).get("name"),
+                    "response_seconds": r.get("response_seconds"),
+                }
+            )
+
+        judged = len(per_turn)
+        unjudged = len(records) - judged
+        pass_rate = _rate(turn_pass, judged)
+
+        latencies = [
+            r["response_seconds"] for r in records if r.get("response_seconds")
+        ]
+        latencies.sort()
+        median_seconds = latencies[len(latencies) // 2] if latencies else None
+
+        lines = [
+            f"Pass rate: {pass_rate:.3f} ({turn_pass}/{judged} turns passed all "
+            f"3 dimensions)",
+            "",
+            f"  tool_use_correct:      {counters['tool_use_correct']}/{judged}",
+            f"  instruction_following: {counters['instruction_following']}/{judged}",
+            f"  kb_grounding:          {counters['kb_grounding']}/{judged}",
+        ]
+        recoveries = sum(1 for t in per_turn if t["recovery_used"])
+        if recoveries:
+            lines += [
+                "",
+                f'Recovery nudges: {recoveries} turn(s) needed a "Please go '
+                f'ahead." prompt before the model acted (upstream behaviour; '
+                f"the turn can still pass).",
+            ]
+        if median_seconds is not None:
+            lines += [
+                "",
+                f"Median response time: {median_seconds:.2f}s (total generate "
+                f"time, an upper bound on TTFT — Inspect does not stream)",
+            ]
+        if truncated:
+            lines += [
+                "",
+                f"NOTE: {truncated} turn(s) hit the model's token ceiling "
+                f"(stop_reason=max_tokens), so this score is a floor. We pass no "
+                f"max_tokens, meaning the ceiling is Bedrock's own default for "
+                f"this model — a model/endpoint limitation, not answer quality.",
+            ]
+        if unjudged:
+            lines += [
+                "",
+                f"WARNING: the judge returned no verdict for {unjudged} of "
+                f"{len(records)} turns; those are excluded from the denominator "
+                f"rather than scored 0.",
+            ]
+        cap = state.metadata.get("turn_cap")
+        if cap:
+            lines += [
+                "",
+                f"WARNING: this was a capped smoke run ({cap} of {len(turns())} "
+                f"turns). NOT comparable to a full run — the tool-call turns "
+                f"cluster in the second half of the conversation.",
+            ]
+        failures = [t for t in per_turn if not t["turn_pass"]]
+        if failures:
+            lines += ["", "Failed turns:"]
+            for t in failures:
+                failed_dims = ", ".join(d for d in DIMENSIONS if not t[d])
+                lines.append(f"  turn {t['turn']}: {failed_dims} — {t['reasoning']}")
+
+        return Score(
+            value=pass_rate,
+            answer=f"{turn_pass}/{judged} turns passed",
+            explanation="\n".join(lines),
+            metadata={
+                "turns_judged": judged,
+                "turn_pass": turn_pass,
+                "unjudged_turns": unjudged,
+                "truncated_turns": truncated,
+                "median_response_seconds": median_seconds,
+                "recoveries_used": recoveries,
+                "judge_model": model_id,
+                "task_version": TASK_VERSION,
+                "turn_cap": cap,
+                **counters,
+                "per_turn": per_turn,
+            },
+        )
+
+    return score
+
+
+def _aiwf_task(variant: str, judge_model: Optional[str]) -> Task:
+    n_turns = len(turns())
+    return Task(
+        name=variant,
+        dataset=[
+            Sample(
+                input=(
+                    f"{n_turns}-turn AI Engineer World's Fair conversation "
+                    f"({variant})"
+                ),
+                target="see per-turn golden_text",
+                metadata={"variant": variant, "turns": n_turns},
+            )
+        ],
+        solver=[aiwf_conversation(variant)],
+        scorer=aiwf_turn_judge(judge_model),
+        version=TASK_VERSION,
+    )
+
+
+@task
+def aiwf_medium_context(judge_model: Optional[str] = None) -> Task:
+    """30-turn conference-assistant conversation, ~12K-token knowledge base."""
+    return _aiwf_task("aiwf_medium_context", judge_model)
+
+
+@task
+def aiwf_long_context(judge_model: Optional[str] = None) -> Task:
+    """30-turn conference-assistant conversation, ~40K-token knowledge base."""
+    return _aiwf_task("aiwf_long_context", judge_model)
+
+
+# Names exposed by run_multiturn_benchmark. Keys match the @task function names.
+AIWF_TASK_NAMES = tuple(AIWF_TASKS)

--- a/eval_mcp/benchmarks/registry.py
+++ b/eval_mcp/benchmarks/registry.py
@@ -1,0 +1,187 @@
+"""Auto-discovery for bundled benchmarks.
+
+A bundled benchmark is a directory under ``eval_mcp/benchmarks/`` containing:
+
+    <name>/
+        eval.yaml     metadata (title, tasks, metrics, source, caveats)
+        task.py       Inspect @task functions, one per entry in tasks[]
+        data/         vendored datasets + prompts, verbatim from upstream
+        NOTICE.md     provenance: upstream URL, license, pinned SHA
+
+Adding one means dropping in that directory. **No Python is edited** — not this
+file, not the MCP tool, not the server. The catalog is whatever is on disk, which
+is the same contract ``inspect_evals`` uses (it globs ``*/eval.yaml``) and keeps
+the two benchmark sources feeling identical to a caller.
+
+The ``eval.yaml`` schema deliberately mirrors ``inspect_evals``' own, so a port
+here could later be submitted to their register with minimal change.
+"""
+
+import functools
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_BENCHMARKS_DIR = Path(__file__).parent
+
+
+@dataclass(frozen=True)
+class TaskEntry:
+    """One runnable task within a benchmark."""
+
+    name: str
+    description: str = ""
+    turns: Optional[int] = None
+    approx_input_tokens_per_model: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class BundledBenchmark:
+    """One benchmark directory, as described by its ``eval.yaml``."""
+
+    id: str
+    path: Path
+    title: str
+    description: str
+    group: str
+    version: str
+    tasks: List[TaskEntry]
+    metrics: List[Dict[str, str]] = field(default_factory=list)
+    judge: Dict[str, Any] = field(default_factory=dict)
+    source: Dict[str, Any] = field(default_factory=dict)
+    caveats: List[str] = field(default_factory=list)
+
+    @property
+    def task_file(self) -> Path:
+        """Absolute path to the task module.
+
+        Inspect is invoked as ``<abs path>@<task_name>``; absolute works from any
+        cwd, which matters because the eval subprocess runs in the user's storage
+        directory.
+        """
+        return (self.path / "task.py").resolve()
+
+    @property
+    def task_names(self) -> List[str]:
+        return [t.name for t in self.tasks]
+
+    def task(self, name: str) -> Optional[TaskEntry]:
+        return next((t for t in self.tasks if t.name == name), None)
+
+    @property
+    def headline_metric(self) -> Optional[str]:
+        return self.metrics[0]["name"] if self.metrics else None
+
+    @property
+    def default_judge(self) -> Optional[str]:
+        return self.judge.get("default")
+
+    def summary(self) -> Dict[str, Any]:
+        """Compact projection for ``list_*`` output — keep it small."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "category": self.group,
+            "tasks": self.task_names,
+            "bundled": True,
+            "headlineMetric": self.headline_metric,
+        }
+
+    def details(self) -> Dict[str, Any]:
+        """Everything a caller needs to run it and read the result honestly."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description.strip(),
+            "category": self.group,
+            "version": self.version,
+            "bundled": True,
+            "tasks": [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "turns": t.turns,
+                    "approxInputTokensPerModel": t.approx_input_tokens_per_model,
+                }
+                for t in self.tasks
+            ],
+            "metrics": self.metrics,
+            "headlineMetric": self.headline_metric,
+            "judge": self.judge,
+            "source": self.source,
+            "caveats": self.caveats,
+            "runHint": (
+                f'run_benchmark(task="{self.task_names[0]}", providers=[...])'
+                if self.task_names
+                else "No runnable task declared in eval.yaml."
+            ),
+        }
+
+
+def _parse(path: Path) -> BundledBenchmark:
+    import yaml
+
+    raw = yaml.safe_load((path / "eval.yaml").read_text(encoding="utf-8")) or {}
+    tasks = [
+        TaskEntry(
+            name=t["name"],
+            description=t.get("description", ""),
+            turns=t.get("turns"),
+            approx_input_tokens_per_model=t.get("approx_input_tokens_per_model"),
+        )
+        for t in (raw.get("tasks") or [])
+        if isinstance(t, dict) and t.get("name")
+    ]
+    return BundledBenchmark(
+        id=path.name,
+        path=path,
+        title=raw.get("title") or path.name,
+        description=raw.get("description") or "",
+        group=raw.get("group") or "Bundled",
+        version=str(raw.get("version") or "1"),
+        tasks=tasks,
+        metrics=[m for m in (raw.get("metrics") or []) if isinstance(m, dict)],
+        judge=raw.get("judge") or {},
+        source=raw.get("source") or {},
+        caveats=list(raw.get("caveats") or []),
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def discover() -> Dict[str, BundledBenchmark]:
+    """Every bundled benchmark, keyed by id. Cached — the set is fixed at
+    install time (these ship as package data)."""
+    found: Dict[str, BundledBenchmark] = {}
+    for child in sorted(_BENCHMARKS_DIR.iterdir()):
+        if not child.is_dir() or child.name.startswith(("_", ".")):
+            continue
+        if not (child / "eval.yaml").is_file() or not (child / "task.py").is_file():
+            continue
+        found[child.name] = _parse(child)
+    return found
+
+
+def all_task_names() -> Dict[str, BundledBenchmark]:
+    """Map every runnable task name -> its benchmark.
+
+    Task names are the user-facing handle (``aiwf_medium_context``), matching how
+    ``inspect_evals`` tasks are addressed.
+    """
+    return {
+        name: bench for bench in discover().values() for name in bench.task_names
+    }
+
+
+def resolve(task_or_id: str) -> Optional[tuple[BundledBenchmark, str]]:
+    """Resolve a task name, or a benchmark id with exactly one task.
+
+    Returns ``(benchmark, task_name)`` or None. Mirrors
+    ``tools/benchmarks._resolve_task`` so both catalogs accept the same input.
+    """
+    by_task = all_task_names()
+    if task_or_id in by_task:
+        return by_task[task_or_id], task_or_id
+    bench = discover().get(task_or_id)
+    if bench and len(bench.task_names) == 1:
+        return bench, bench.task_names[0]
+    return None

--- a/eval_mcp/core/judge_config.py
+++ b/eval_mcp/core/judge_config.py
@@ -10,8 +10,22 @@ from typing import Dict, List
 
 # Judge models for multi-judge evaluation
 # Model IDs use Inspect AI provider format (bedrock/ prefix)
+#
+# The "claude" entry is the most load-bearing: it's the jury's strongest voice
+# AND the default single judge for the multi-turn benchmarks. Before changing
+# it, measure — a judge is the measuring instrument, so "newer model" is not by
+# itself a reason. Two things to check, both of which have bitten us:
+#   1. Accuracy against hand-adjudicated verdicts, not against another judge's
+#      output (comparing two judges across two different eval RUNS measures the
+#      target model's variance, not the judge's).
+#   2. Stability across repeated calls on the SAME input. Sonnet 5 was rejected
+#      here for swinging 0.100 in the headline metric on identical input.
+# Scored that way over 16 calls on two fixed transcripts, Opus 5 made 2 errors
+# vs Sonnet 4.6's 9 (mostly false positives — it failed a factually correct
+# answer that merely added detail). Details in
+# eval_mcp/benchmarks/aiwf/NOTICE.md.
 JUDGE_MODELS: Dict[str, str] = {
-    "claude": "bedrock/us.anthropic.claude-sonnet-4-6",
+    "claude": "bedrock/us.anthropic.claude-opus-5",
     "nova": "bedrock/us.amazon.nova-pro-v1:0",
     "nemotron": "bedrock/nvidia.nemotron-super-3-120b",
 }

--- a/eval_mcp/core/judge_config.py
+++ b/eval_mcp/core/judge_config.py
@@ -10,8 +10,16 @@ from typing import Dict, List
 
 # Judge models for multi-judge evaluation
 # Model IDs use Inspect AI provider format (bedrock/ prefix)
+#
+# Keep these on current-generation models: a judge is the measuring instrument,
+# so an outdated one silently caps the quality of every score in the repo.
+# Sonnet 5 replaced Sonnet 4.6 here and is both stronger and cheaper
+# ($2/$10 per Mtok vs $3/$15). The "claude" entry is also the default single
+# judge for the multi-turn benchmarks, so it is the most load-bearing of the
+# three — verify a replacement can still make a *forced tool call* (that's how
+# every scorer here returns structured verdicts), not just answer prose.
 JUDGE_MODELS: Dict[str, str] = {
-    "claude": "bedrock/us.anthropic.claude-sonnet-4-6",
+    "claude": "bedrock/us.anthropic.claude-sonnet-5",
     "nova": "bedrock/us.amazon.nova-pro-v1:0",
     "nemotron": "bedrock/nvidia.nemotron-super-3-120b",
 }

--- a/eval_mcp/core/judge_config.py
+++ b/eval_mcp/core/judge_config.py
@@ -10,16 +10,8 @@ from typing import Dict, List
 
 # Judge models for multi-judge evaluation
 # Model IDs use Inspect AI provider format (bedrock/ prefix)
-#
-# Keep these on current-generation models: a judge is the measuring instrument,
-# so an outdated one silently caps the quality of every score in the repo.
-# Sonnet 5 replaced Sonnet 4.6 here and is both stronger and cheaper
-# ($2/$10 per Mtok vs $3/$15). The "claude" entry is also the default single
-# judge for the multi-turn benchmarks, so it is the most load-bearing of the
-# three — verify a replacement can still make a *forced tool call* (that's how
-# every scorer here returns structured verdicts), not just answer prose.
 JUDGE_MODELS: Dict[str, str] = {
-    "claude": "bedrock/us.anthropic.claude-sonnet-5",
+    "claude": "bedrock/us.anthropic.claude-sonnet-4-6",
     "nova": "bedrock/us.amazon.nova-pro-v1:0",
     "nemotron": "bedrock/nvidia.nemotron-super-3-120b",
 }

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -48,6 +48,10 @@ from eval_mcp.tools.benchmarks import (
     handle_get_benchmark_details,
     handle_run_benchmark,
 )
+from eval_mcp.tools.multiturn_benchmarks import (
+    handle_list_multiturn_benchmarks,
+    handle_run_multiturn_benchmark,
+)
 
 # Configuration
 port = int(os.environ.get("EVAL_MCP_PORT", "8002"))
@@ -245,6 +249,16 @@ BenchmarkTaskName = Annotated[
     Field(
         description="Runnable task name (or a benchmark id with a single task).",
         examples=["gsm8k", "mmlu_0_shot", "arc_easy"],
+    ),
+]
+MultiturnBenchmarkTask = Annotated[
+    str,
+    Field(
+        description=(
+            "Bundled multi-turn benchmark task name, from "
+            "list_multiturn_benchmarks."
+        ),
+        examples=["aiwf_medium_context", "aiwf_long_context"],
     ),
 ]
 
@@ -1264,6 +1278,74 @@ async def run_benchmark(
         "user_id": _user(user_id),
     }
     result = await handle_run_benchmark(args)
+    return result[0].text
+
+
+@mcp.tool(annotations=READ_LOCAL)
+async def list_multiturn_benchmarks(user_id: str = None) -> str:
+    """
+    Discover the bundled MULTI-TURN conversation benchmarks.
+
+    Separate from `list_benchmarks` (the ~130 single-turn `inspect_evals` Q&A
+    benchmarks). These measure something those can't: whether a model holds up
+    over a long scripted conversation — calling the right tool at the right
+    moment, following its system prompt, and staying factually grounded — as the
+    context grows turn after turn.
+
+    Currently the AI Engineer World's Fair benchmark (30 turns, 5 tools, a
+    conference knowledge base) in two sizes. Text mode only.
+
+    Returns:
+        JSON: {total, benchmarks: [{id, turns, toolTurns, dimensions,
+        approxContextTokens, ...}], costNote}.
+    """
+    result = await handle_list_multiturn_benchmarks({"user_id": _user(user_id)})
+    return result[0].text
+
+
+@mcp.tool(annotations=RUN_REMOTE)
+async def run_multiturn_benchmark(
+    task: MultiturnBenchmarkTask,
+    providers: ProvidersList,
+    judge_model: str = None,
+    max_turns: int = None,
+    user_id: str = None,
+) -> str:
+    """
+    Run a bundled multi-turn conversation benchmark against one or more models.
+
+    Each model replays the same scripted conversation, so results are directly
+    comparable. One sample per model = the whole conversation. The headline
+    metric is `pass_rate`: the fraction of turns where ALL THREE judged
+    dimensions hold on that turn (tool_use_correct, instruction_following,
+    kb_grounding), which is stricter than any single dimension.
+
+    Cost scales with the square of the turn count, since context accumulates:
+    roughly 0.5M input tokens per model on `aiwf_medium_context` and ~3M on
+    `aiwf_long_context`. Start with medium; use `max_turns` for a cheap smoke
+    run (whose scores are NOT comparable to a full one — the tool-call turns
+    cluster late in the conversation).
+
+    Args:
+        task: Benchmark task name (from list_multiturn_benchmarks).
+        providers: Model ids to evaluate (from list_available_models).
+        judge_model: Override the judge (defaults to Claude Sonnet). One judge
+            grades the whole conversation in a single call, which is what lets
+            it credit a tool call made a turn early or late.
+        max_turns: Cap the conversation for a smoke run. Omit for the real thing.
+
+    Returns:
+        JSON with success, task, evalId, and where to read results. Per-turn
+        verdicts land in the score metadata; see the viewer.
+    """
+    args = {
+        "task": task,
+        "providers": providers,
+        "judge_model": judge_model,
+        "max_turns": max_turns,
+        "user_id": _user(user_id),
+    }
+    result = await handle_run_multiturn_benchmark(args)
     return result[0].text
 
 

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -48,10 +48,7 @@ from eval_mcp.tools.benchmarks import (
     handle_get_benchmark_details,
     handle_run_benchmark,
 )
-from eval_mcp.tools.multiturn_benchmarks import (
-    handle_list_multiturn_benchmarks,
-    handle_run_multiturn_benchmark,
-)
+from eval_mcp.tools.multiturn_benchmarks import handle_list_multiturn_benchmarks
 
 # Configuration
 port = int(os.environ.get("EVAL_MCP_PORT", "8002"))
@@ -249,16 +246,6 @@ BenchmarkTaskName = Annotated[
     Field(
         description="Runnable task name (or a benchmark id with a single task).",
         examples=["gsm8k", "mmlu_0_shot", "arc_easy"],
-    ),
-]
-MultiturnBenchmarkTask = Annotated[
-    str,
-    Field(
-        description=(
-            "Bundled multi-turn benchmark task name, from "
-            "list_multiturn_benchmarks."
-        ),
-        examples=["aiwf_medium_context", "aiwf_long_context"],
     ),
 ]
 
@@ -1188,8 +1175,13 @@ async def list_benchmarks(
     user_id: str = None,
 ) -> str:
     """
-    Discover premade benchmarks from the UK AISI `inspect_evals` suite
-    (MMLU, GPQA, GSM8K, ARC, HumanEval, TruthfulQA, and ~120 more).
+    Discover every premade benchmark: the ones bundled with this package plus
+    the UK AISI `inspect_evals` suite (MMLU, GPQA, GSM8K, ARC, HumanEval,
+    TruthfulQA, and ~120 more).
+
+    Bundled entries are flagged `bundled: true` and sort first — they ship with
+    the package, so they need no HuggingFace download, no optional dependency
+    group and no sandbox. Run anything listed here with `run_benchmark`.
 
     This is the entry point for running a STANDARD benchmark instead of a
     generated QA dataset. Returns a COMPACT, filtered, paginated list — call
@@ -1246,14 +1238,20 @@ async def run_benchmark(
     providers: ProvidersList,
     limit: int = None,
     task_args: dict = None,
+    judge_model: str = None,
+    max_turns: int = None,
     user_id: str = None,
 ) -> str:
     """
-    Run a premade `inspect_evals` benchmark against one or more models.
+    Run a premade benchmark against one or more models — bundled or `inspect_evals`.
 
-    Runs `inspect_evals/<task>` via Inspect AI (same subprocess + viewer path
-    as run_evaluation). Datasets download from HuggingFace at run time, so the
-    environment needs outbound network to huggingface.co.
+    One entry point for both catalogs; pass any task name from
+    `list_benchmarks` and this dispatches correctly. Same subprocess + viewer
+    path as run_evaluation either way.
+
+    `inspect_evals` datasets download from HuggingFace at run time, so those
+    need outbound network to huggingface.co. Bundled benchmarks ship with the
+    package and need nothing.
 
     `task` accepts a runnable task name (from get_benchmark_details) OR a
     benchmark id that has a single task. Multi-variant benchmarks must be run
@@ -1262,10 +1260,17 @@ async def run_benchmark(
     error (with the fix) instead of running, unless the requirement is met.
 
     Args:
-        task: Task name or single-task benchmark id (e.g. "gsm8k", "mmlu_0_shot").
-        providers: Model ids to evaluate (from list_available_models).
-        limit: Optional cap on number of samples (good for a fast check).
+        task: Task name or single-task benchmark id (e.g. "gsm8k", "mmlu_0_shot",
+            "aiwf_medium_context").
+        providers: Model ids to evaluate (from list_available_models). Pass
+            several to compare them on identical inputs in one run.
+        limit: Optional cap on number of samples (`inspect_evals` only).
         task_args: Optional benchmark parameters, passed as `-T key=value`.
+        judge_model: Judge override for judge-scored bundled benchmarks. Hold it
+            fixed when comparing target models — the judge is part of the
+            measurement.
+        max_turns: Cap the conversation for a cheap smoke run of a multi-turn
+            bundled benchmark. Those scores are NOT comparable to a full run.
 
     Returns:
         JSON with success, task, runId, viewerUrl, and a scores summary.
@@ -1275,6 +1280,8 @@ async def run_benchmark(
         "providers": providers,
         "limit": limit,
         "task_args": task_args,
+        "judge_model": judge_model,
+        "max_turns": max_turns,
         "user_id": _user(user_id),
     }
     result = await handle_run_benchmark(args)
@@ -1282,70 +1289,25 @@ async def run_benchmark(
 
 
 @mcp.tool(annotations=READ_LOCAL)
-async def list_multiturn_benchmarks(user_id: str = None) -> str:
+async def list_bundled_benchmarks(user_id: str = None) -> str:
     """
-    Discover the bundled MULTI-TURN conversation benchmarks.
+    Full metadata for the benchmarks bundled with this package.
 
-    Separate from `list_benchmarks` (the ~130 single-turn `inspect_evals` Q&A
-    benchmarks). These measure something those can't: whether a model holds up
-    over a long scripted conversation — calling the right tool at the right
-    moment, following its system prompt, and staying factually grounded — as the
-    context grows turn after turn.
+    These also appear in `list_benchmarks` (flagged `bundled: true`) and run via
+    `run_benchmark` like anything else — this tool is the drill-down that returns
+    each one's complete `eval.yaml` without paging through ~130 `inspect_evals`
+    entries.
 
-    Currently the AI Engineer World's Fair benchmark (30 turns, 5 tools, a
-    conference knowledge base) in two sizes. Text mode only.
+    Per benchmark you get: every runnable task with its turn count and
+    approximate input-token cost per model, every metric the scorer reports
+    (first is the headline), the default judge, upstream provenance (repo,
+    license, pinned commit), and caveats that affect how a score should be read.
 
     Returns:
-        JSON: {total, benchmarks: [{id, turns, toolTurns, dimensions,
-        approxContextTokens, ...}], costNote}.
+        JSON: {total, benchmarks: [{id, title, tasks, metrics, judge, source,
+        caveats, runHint}]}.
     """
     result = await handle_list_multiturn_benchmarks({"user_id": _user(user_id)})
-    return result[0].text
-
-
-@mcp.tool(annotations=RUN_REMOTE)
-async def run_multiturn_benchmark(
-    task: MultiturnBenchmarkTask,
-    providers: ProvidersList,
-    judge_model: str = None,
-    max_turns: int = None,
-    user_id: str = None,
-) -> str:
-    """
-    Run a bundled multi-turn conversation benchmark against one or more models.
-
-    Each model replays the same scripted conversation, so results are directly
-    comparable. One sample per model = the whole conversation. The headline
-    metric is `pass_rate`: the fraction of turns where ALL THREE judged
-    dimensions hold on that turn (tool_use_correct, instruction_following,
-    kb_grounding), which is stricter than any single dimension.
-
-    Cost scales with the square of the turn count, since context accumulates:
-    roughly 0.5M input tokens per model on `aiwf_medium_context` and ~3M on
-    `aiwf_long_context`. Start with medium; use `max_turns` for a cheap smoke
-    run (whose scores are NOT comparable to a full one — the tool-call turns
-    cluster late in the conversation).
-
-    Args:
-        task: Benchmark task name (from list_multiturn_benchmarks).
-        providers: Model ids to evaluate (from list_available_models).
-        judge_model: Override the judge (defaults to Claude Sonnet). One judge
-            grades the whole conversation in a single call, which is what lets
-            it credit a tool call made a turn early or late.
-        max_turns: Cap the conversation for a smoke run. Omit for the real thing.
-
-    Returns:
-        JSON with success, task, evalId, and where to read results. Per-turn
-        verdicts land in the score metadata; see the viewer.
-    """
-    args = {
-        "task": task,
-        "providers": providers,
-        "judge_model": judge_model,
-        "max_turns": max_turns,
-        "user_id": _user(user_id),
-    }
-    result = await handle_run_multiturn_benchmark(args)
     return result[0].text
 
 

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -140,41 +140,79 @@ def _matches(e: Any, search: Optional[str], category: Optional[str]) -> bool:
     return True
 
 
+def _bundled_summaries(search: Optional[str], category: Optional[str]) -> List[Dict[str, Any]]:
+    """Rows for our own bundled benchmarks (``eval_mcp/benchmarks/``).
+
+    Listed alongside the inspect_evals catalog so a caller discovers everything
+    runnable from ONE tool. They're flagged ``bundled: true`` and sort first —
+    they need no HuggingFace download, no optional extra and no sandbox, so
+    they're the cheapest thing to run.
+    """
+    from eval_mcp.benchmarks.registry import discover
+
+    rows = []
+    for bench in discover().values():
+        if category and bench.group.lower() != category.lower():
+            continue
+        if search:
+            hay = " ".join(
+                [bench.id, bench.title, bench.description, bench.group]
+                + bench.task_names
+            ).lower()
+            if search.lower() not in hay:
+                continue
+        rows.append(bench.summary())
+    return rows
+
+
 async def handle_list_benchmarks(args: Dict[str, Any]) -> List[TextContent]:
-    """List premade benchmarks, filtered + paginated."""
+    """List premade benchmarks, filtered + paginated.
+
+    Covers BOTH sources: our bundled benchmarks and the installed
+    ``inspect_evals`` catalog. One entry point, so nothing is invisible to a
+    caller who doesn't already know it exists.
+    """
     try:
         search = args.get("search")
         category = args.get("category")
         limit = int(args.get("limit", 20))
         offset = int(args.get("offset", 0))
 
+        bundled = _bundled_summaries(search, category)
+
         evals = _load_evals()
         matched = [e for e in evals if _matches(e, search, category)]
         matched.sort(key=lambda e: ((e.group or "~"), e.id or ""))
 
-        page = matched[offset : offset + limit]
-        rows = [_entry_summary(e) for e in page]
+        # Bundled first, then the upstream catalog, paginated as one list.
+        combined: List[Dict[str, Any]] = bundled + [_entry_summary(e) for e in matched]
+        rows = combined[offset : offset + limit]
 
         # Category histogram helps the agent narrow a follow-up call instead
         # of paging blindly through everything.
         categories: Dict[str, int] = {}
         for e in evals:
             categories[e.group or "Uncategorized"] = categories.get(e.group or "Uncategorized", 0) + 1
+        from eval_mcp.benchmarks.registry import discover
+
+        for bench in discover().values():
+            categories[bench.group] = categories.get(bench.group, 0) + 1
 
         payload = {
             "success": True,
-            "total": len(matched),
-            "totalCatalog": len(evals),
+            "total": len(combined),
+            "totalCatalog": len(evals) + len(discover()),
             "offset": offset,
             "limit": limit,
-            "hasMore": offset + limit < len(matched),
-            "nextOffset": offset + limit if offset + limit < len(matched) else None,
+            "hasMore": offset + limit < len(combined),
+            "nextOffset": offset + limit if offset + limit < len(combined) else None,
             "categories": dict(sorted(categories.items(), key=lambda x: -x[1])),
             "benchmarks": rows,
             "hint": (
                 "Call get_benchmark_details(benchmark_id) for one benchmark's "
                 "task variants and requirements, then run_benchmark(task=...). "
-                "needsExtra/needsSandbox benchmarks require extra setup."
+                "needsExtra/needsSandbox benchmarks require extra setup; "
+                "`bundled: true` ones ship with this package and need none."
             ),
         }
         return [TextContent(type="text", text=json.dumps(payload, indent=2))]
@@ -197,6 +235,18 @@ async def handle_get_benchmark_details(args: Dict[str, Any]) -> List[TextContent
             return [TextContent(type="text", text=json.dumps({
                 "success": False, "error": "benchmark_id is required",
             }))]
+
+        # Bundled benchmarks first — they carry their own metadata (eval.yaml),
+        # including per-task cost and the caveats that make a score readable.
+        from eval_mcp.benchmarks.registry import discover, resolve as resolve_bundled
+
+        bundled = discover().get(benchmark_id)
+        if bundled is None:
+            hit = resolve_bundled(benchmark_id)   # allow a task name too
+            bundled = hit[0] if hit else None
+        if bundled is not None:
+            payload = {"success": True, **bundled.details()}
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
 
         evals = _load_evals()
         e = next((x for x in evals if x.id == benchmark_id), None)
@@ -328,6 +378,17 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
                 "success": False,
                 "error": "At least one provider is required (e.g. ['bedrock/us.anthropic.claude-sonnet-4-6']).",
             }))]
+
+        # Bundled benchmark? Hand off to its runner. Callers use ONE tool for
+        # both catalogs; which source a task came from isn't their problem.
+        from eval_mcp.benchmarks.registry import resolve as resolve_bundled
+
+        if resolve_bundled(task) is not None:
+            from eval_mcp.tools.multiturn_benchmarks import (
+                handle_run_multiturn_benchmark,
+            )
+
+            return await handle_run_multiturn_benchmark(args)
 
         # Resolve id-or-task → runnable task name, and pick up its flags.
         try:

--- a/eval_mcp/tools/multiturn_benchmarks.py
+++ b/eval_mcp/tools/multiturn_benchmarks.py
@@ -1,0 +1,318 @@
+"""Run the bundled multi-turn benchmarks (``eval_mcp/benchmarks/``).
+
+Separate from ``tools/benchmarks.py``, which wraps the installed
+``inspect_evals`` catalog and can only run what that package registers. These
+tasks ship with us, so they're launched by absolute path to the vendored task
+file — verified to work from any cwd, which matters because the subprocess runs
+in the user's storage dir.
+
+Everything downstream is shared with the other runners: same ``_INSPECT_CMD``
+(so ``inspect_patches`` applies), same per-user registry so ``cancel_evaluation``
+works, same log dir so results reach the viewer and S3 sync.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from mcp.types import TextContent
+
+from eval_mcp.core.bedrock_client import raise_if_autodetect_error, resolve_region
+from eval_mcp.core.user_storage import get_user_dir, get_user_log_dir
+from eval_mcp.tools.external_providers import _refresh_keys_from_file
+from eval_mcp.tools.run_eval import (
+    _INSPECT_CMD,
+    _running_evaluations,
+    _terminate_process_gracefully,
+    _validate_providers,
+)
+
+logger = logging.getLogger(__name__)
+
+# A 30-turn conversation per model, plus one judge call over the whole
+# transcript. Slowest observed single model is a few minutes; 2h leaves room for
+# a wide model sweep on a throttled account without hanging forever.
+_TIMEOUT_SECONDS = 2 * 60 * 60
+
+
+def _task_file() -> Path:
+    """Absolute path to the vendored aiwf task file."""
+    from eval_mcp.benchmarks.aiwf import task as aiwf_task
+
+    return Path(aiwf_task.__file__).resolve()
+
+
+def _catalog() -> Dict[str, Dict[str, Any]]:
+    """The bundled multi-turn benchmarks, keyed by task name."""
+    from eval_mcp.benchmarks.aiwf import AIWF_TASKS, turns
+    from eval_mcp.benchmarks.aiwf.data_loader import knowledge_base
+
+    n_turns = len(turns())
+    n_tool_turns = sum(1 for t in turns() if t.expected_tool)
+    catalog: Dict[str, Dict[str, Any]] = {}
+    for name in AIWF_TASKS:
+        kb_chars = len(knowledge_base(name))
+        catalog[name] = {
+            "id": name,
+            "title": (
+                "AI Engineer World's Fair multi-turn conversation "
+                f"({'~12K' if 'medium' in name else '~40K'}-token knowledge base)"
+            ),
+            "category": "Multi-turn",
+            "turns": n_turns,
+            "toolTurns": n_tool_turns,
+            "knowledgeBaseChars": kb_chars,
+            "approxContextTokens": kb_chars // 4,
+            "dimensions": ["tool_use_correct", "instruction_following", "kb_grounding"],
+            "headlineMetric": "turn_pass rate (all 3 dimensions pass on the same turn)",
+            "source": "https://github.com/kwindla/aiewf-eval",
+            "license": "MIT",
+            "mode": "text",
+        }
+    return catalog
+
+
+async def handle_list_multiturn_benchmarks(args: Dict[str, Any]) -> List[TextContent]:
+    """List the bundled multi-turn benchmarks."""
+    try:
+        catalog = _catalog()
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "success": True,
+                        "total": len(catalog),
+                        "benchmarks": list(catalog.values()),
+                        "note": (
+                            "Text-mode port of kwindla/aiewf-eval. Each run is ONE "
+                            "sample per model: a scripted 30-turn conversation where "
+                            "context accumulates. Upstream's speech-to-speech "
+                            "pipelines and its audio-derived turn_taking dimension "
+                            "are not ported."
+                        ),
+                        "costNote": (
+                            "Context grows every turn, so one 30-turn run costs "
+                            "roughly 0.5M input tokens on aiwf_medium_context and "
+                            "~3M on aiwf_long_context, per model. Start with medium."
+                        ),
+                        "hint": (
+                            "run_multiturn_benchmark(task='aiwf_medium_context', "
+                            "providers=[...]) — use max_turns for a cheap smoke run."
+                        ),
+                    },
+                    indent=2,
+                ),
+            )
+        ]
+    except Exception as e:
+        logger.exception("Failed to list multi-turn benchmarks")
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps({"success": False, "error": f"Failed to list: {e}"}),
+            )
+        ]
+
+
+async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextContent]:
+    """Run one bundled multi-turn benchmark against one or more models."""
+    process: Optional[asyncio.subprocess.Process] = None
+    eval_id = f"mtbench_{int(time.time() * 1000)}"
+    user_id = args.get("user_id")
+    try:
+        task = args.get("task")
+        providers = args.get("providers") or []
+        judge_model = args.get("judge_model")
+        max_turns = args.get("max_turns")
+
+        if not user_id:
+            return [_err("user_id is required", eval_id)]
+        if not task:
+            return [_err("task is required", eval_id)]
+        if not providers:
+            return [
+                _err(
+                    "At least one provider is required "
+                    "(e.g. ['bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0']).",
+                    eval_id,
+                )
+            ]
+
+        catalog = _catalog()
+        if task not in catalog:
+            return [
+                _err(
+                    f"Unknown multi-turn benchmark '{task}'. Available: "
+                    f"{sorted(catalog)}. For the inspect_evals catalog use "
+                    f"run_benchmark instead.",
+                    eval_id,
+                )
+            ]
+
+        if max_turns is not None:
+            try:
+                max_turns = int(max_turns)
+            except (TypeError, ValueError):
+                return [_err(f"max_turns must be an integer, got {max_turns!r}", eval_id)]
+            if max_turns < 1:
+                return [_err("max_turns must be >= 1", eval_id)]
+
+        # Fail fast on an unusable model rather than 30 turns deep. Same gate
+        # run_evaluation uses, so the error text is identical and actionable.
+        if any(p.startswith(("bedrock/", "openai/bedrock/")) for p in providers):
+            raise_if_autodetect_error()
+            validation = await _validate_providers(providers)
+            if not validation.get("valid"):
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "success": False,
+                                "evalId": eval_id,
+                                "task": task,
+                                "error": "One or more models failed validation.",
+                                "failedProviders": validation.get("failed_providers"),
+                            },
+                            indent=2,
+                        ),
+                    )
+                ]
+
+        user_dir = get_user_dir(user_id)
+        os.makedirs(user_dir, exist_ok=True)
+        log_dir_str = get_user_log_dir(user_id)
+        if not log_dir_str.startswith("s3://"):
+            Path(log_dir_str).mkdir(parents=True, exist_ok=True)
+
+        _refresh_keys_from_file()
+        env = os.environ.copy()
+        env["INSPECT_LOG_DIR"] = log_dir_str
+        region = resolve_region()
+        env["AWS_REGION"] = region
+        env["AWS_DEFAULT_REGION"] = region
+        if max_turns is not None:
+            # Read by the solver. A CLI -T arg would work too, but this keeps
+            # the smoke-run knob out of the task's public signature.
+            env["EVAL_MCP_AIWF_MAX_TURNS"] = str(max_turns)
+
+        cmd: List[str] = [
+            *_INSPECT_CMD,
+            "eval",
+            f"{_task_file()}@{task}",
+            "--model",
+            ",".join(providers),
+            "--adaptive-connections",
+            "true",
+            "--no-log-images",
+            "--no-fail-on-error",
+            "--log-shared",
+            "10",
+        ]
+        # No --max-tokens: _INSPECT_CMD routes through eval_mcp._inspect_main so
+        # the Bedrock provider omits it and each model gets its own default. A
+        # 30-turn conversation is exactly where a 2048 cap produces empty
+        # completions from reasoning models.
+        if judge_model:
+            cmd.extend(["-T", f"judge_model={judge_model}"])
+
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            cwd=str(user_dir),
+            start_new_session=True,
+        )
+        logger.info(
+            "Started multi-turn benchmark %s (pid %s) for user %s",
+            task, process.pid, user_id,
+        )
+        _running_evaluations[user_id] = {
+            "process": process,
+            "eval_id": eval_id,
+            "config_name": task,
+        }
+
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            await _terminate_process_gracefully(process)
+            return [
+                _err(f"Benchmark timed out after {_TIMEOUT_SECONDS}s.", eval_id, task)
+            ]
+        finally:
+            _running_evaluations.pop(user_id, None)
+
+        stderr_str = ""
+        if process.returncode != 0 and process.stderr:
+            try:
+                b = await asyncio.wait_for(process.stderr.read(), timeout=5)
+                stderr_str = b.decode("utf-8") if b else ""
+            except Exception:
+                stderr_str = "(stderr unavailable)"
+
+        try:
+            from eval_mcp.core.eval_results import precompute_eval_results
+
+            await precompute_eval_results(user_id)
+        except Exception as e:
+            logger.warning("precompute failed: %s", e)
+
+        if process.returncode != 0:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": False,
+                            "evalId": eval_id,
+                            "task": task,
+                            "error": f"Benchmark failed with exit code {process.returncode}",
+                            "stderr": stderr_str[:2000],
+                        },
+                        indent=2,
+                    ),
+                )
+            ]
+
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "success": True,
+                        "evalId": eval_id,
+                        "task": task,
+                        "models": providers,
+                        "message": (
+                            f"Multi-turn benchmark {task} completed. Headline metric "
+                            f"is turn_pass (fraction of turns where all 3 dimensions "
+                            f"pass). Call get_viewer_url or list_evaluations for "
+                            f"results; per-turn detail is in the score metadata."
+                        ),
+                    },
+                    indent=2,
+                ),
+            )
+        ]
+
+    except Exception as e:
+        logger.exception("Multi-turn benchmark failed")
+        if user_id:
+            _running_evaluations.pop(user_id, None)
+        if process and process.returncode is None:
+            await _terminate_process_gracefully(process)
+        return [_err(f"Benchmark failed: {e}", eval_id)]
+
+
+def _err(message: str, eval_id: str, task: Optional[str] = None) -> TextContent:
+    payload: Dict[str, Any] = {"success": False, "evalId": eval_id, "error": message}
+    if task:
+        payload["task"] = task
+    return TextContent(type="text", text=json.dumps(payload, indent=2))

--- a/eval_mcp/tools/multiturn_benchmarks.py
+++ b/eval_mcp/tools/multiturn_benchmarks.py
@@ -39,70 +39,30 @@ logger = logging.getLogger(__name__)
 _TIMEOUT_SECONDS = 2 * 60 * 60
 
 
-def _task_file() -> Path:
-    """Absolute path to the vendored aiwf task file."""
-    from eval_mcp.benchmarks.aiwf import task as aiwf_task
-
-    return Path(aiwf_task.__file__).resolve()
-
-
-def _catalog() -> Dict[str, Dict[str, Any]]:
-    """The bundled multi-turn benchmarks, keyed by task name."""
-    from eval_mcp.benchmarks.aiwf import AIWF_TASKS, turns
-    from eval_mcp.benchmarks.aiwf.data_loader import knowledge_base
-
-    n_turns = len(turns())
-    n_tool_turns = sum(1 for t in turns() if t.expected_tool)
-    catalog: Dict[str, Dict[str, Any]] = {}
-    for name in AIWF_TASKS:
-        kb_chars = len(knowledge_base(name))
-        catalog[name] = {
-            "id": name,
-            "title": (
-                "AI Engineer World's Fair multi-turn conversation "
-                f"({'~12K' if 'medium' in name else '~40K'}-token knowledge base)"
-            ),
-            "category": "Multi-turn",
-            "turns": n_turns,
-            "toolTurns": n_tool_turns,
-            "knowledgeBaseChars": kb_chars,
-            "approxContextTokens": kb_chars // 4,
-            "dimensions": ["tool_use_correct", "instruction_following", "kb_grounding"],
-            "headlineMetric": "turn_pass rate (all 3 dimensions pass on the same turn)",
-            "source": "https://github.com/kwindla/aiewf-eval",
-            "license": "MIT",
-            "mode": "text",
-        }
-    return catalog
-
-
 async def handle_list_multiturn_benchmarks(args: Dict[str, Any]) -> List[TextContent]:
-    """List the bundled multi-turn benchmarks."""
+    """List the bundled benchmarks, with their per-task cost and caveats.
+
+    ``list_benchmarks`` also surfaces these (flagged ``bundled: true``) mixed in
+    with the inspect_evals catalog; this tool is the drill-down that returns the
+    full ``eval.yaml`` for each without paging through 130 upstream entries.
+    """
     try:
-        catalog = _catalog()
+        from eval_mcp.benchmarks.registry import discover
+
+        benches = discover()
         return [
             TextContent(
                 type="text",
                 text=json.dumps(
                     {
                         "success": True,
-                        "total": len(catalog),
-                        "benchmarks": list(catalog.values()),
-                        "note": (
-                            "Text-mode port of kwindla/aiewf-eval. Each run is ONE "
-                            "sample per model: a scripted 30-turn conversation where "
-                            "context accumulates. Upstream's speech-to-speech "
-                            "pipelines and its audio-derived turn_taking dimension "
-                            "are not ported."
-                        ),
-                        "costNote": (
-                            "Context grows every turn, so one 30-turn run costs "
-                            "roughly 0.5M input tokens on aiwf_medium_context and "
-                            "~3M on aiwf_long_context, per model. Start with medium."
-                        ),
+                        "total": len(benches),
+                        "benchmarks": [b.details() for b in benches.values()],
                         "hint": (
-                            "run_multiturn_benchmark(task='aiwf_medium_context', "
-                            "providers=[...]) — use max_turns for a cheap smoke run."
+                            "run_benchmark(task=<task name>, providers=[...]). "
+                            "Pass max_turns for a cheap smoke run, judge_model to "
+                            "override the judge. These need no HuggingFace "
+                            "download, optional extra or sandbox."
                         ),
                     },
                     indent=2,
@@ -110,7 +70,7 @@ async def handle_list_multiturn_benchmarks(args: Dict[str, Any]) -> List[TextCon
             )
         ]
     except Exception as e:
-        logger.exception("Failed to list multi-turn benchmarks")
+        logger.exception("Failed to list bundled benchmarks")
         return [
             TextContent(
                 type="text",
@@ -143,16 +103,19 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
                 )
             ]
 
-        catalog = _catalog()
-        if task not in catalog:
+        from eval_mcp.benchmarks.registry import all_task_names, resolve
+
+        hit = resolve(task)
+        if hit is None:
             return [
                 _err(
-                    f"Unknown multi-turn benchmark '{task}'. Available: "
-                    f"{sorted(catalog)}. For the inspect_evals catalog use "
-                    f"run_benchmark instead.",
+                    f"Unknown bundled benchmark '{task}'. Available: "
+                    f"{sorted(all_task_names())}. For the inspect_evals catalog, "
+                    f"run_benchmark handles those too.",
                     eval_id,
                 )
             ]
+        bench, task = hit
 
         if max_turns is not None:
             try:
@@ -204,7 +167,7 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
         cmd: List[str] = [
             *_INSPECT_CMD,
             "eval",
-            f"{_task_file()}@{task}",
+            f"{bench.task_file}@{task}",
             "--model",
             ",".join(providers),
             "--adaptive-connections",
@@ -291,10 +254,10 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
                         "task": task,
                         "models": providers,
                         "message": (
-                            f"Multi-turn benchmark {task} completed. Headline metric "
-                            f"is turn_pass (fraction of turns where all 3 dimensions "
-                            f"pass). Call get_viewer_url or list_evaluations for "
-                            f"results; per-turn detail is in the score metadata."
+                            f"Benchmark {task} completed. Headline metric is "
+                            f"{bench.headline_metric or 'the first reported metric'}. "
+                            f"Call get_viewer_url or list_evaluations for results; "
+                            f"per-sample detail is in the score metadata."
                         ),
                     },
                     indent=2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ include = ["backend*", "eval_mcp*"]
 [tool.setuptools.package-data]
 eval_mcp = ["viewer_static/**/*", "INSTALL.md"]
 "eval_mcp.core" = ["litellm_pricing_snapshot.json"]
+# Vendored benchmark data (turns, knowledge bases, prompt blocks). Without this
+# the aiwf tasks import fine and then fail at run time with a missing file.
+"eval_mcp.benchmarks.aiwf" = ["data/*.json", "data/*.txt"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,11 @@ include = ["backend*", "eval_mcp*"]
 [tool.setuptools.package-data]
 eval_mcp = ["viewer_static/**/*", "INSTALL.md"]
 "eval_mcp.core" = ["litellm_pricing_snapshot.json"]
-# Vendored benchmark data (turns, knowledge bases, prompt blocks). Without this
-# the aiwf tasks import fine and then fail at run time with a missing file.
+# Bundled benchmarks: every benchmark's eval.yaml (the registry globs these to
+# build the catalog) plus its vendored data. Without the data entry the tasks
+# import fine and then fail at run time with a missing file; without eval.yaml
+# the benchmark is invisible in an installed wheel.
+"eval_mcp.benchmarks" = ["README.md", "*/eval.yaml", "*/NOTICE.md"]
 "eval_mcp.benchmarks.aiwf" = ["data/*.json", "data/*.txt"]
 
 [tool.black]

--- a/tests/test_aiwf_benchmark.py
+++ b/tests/test_aiwf_benchmark.py
@@ -19,10 +19,13 @@ from eval_mcp.benchmarks.aiwf.data_loader import (
 )
 from eval_mcp.benchmarks.aiwf.task import (
     DIMENSIONS,
+    _JUDGE_SYSTEM_PROMPT,
+    _UPSTREAM_JUDGE_PROMPT,
     _extract_judgments,
     _max_turns,
     _rate,
     _render_transcript,
+    _render_user_prompt,
     _turn_rate,
     aiwf_long_context,
     aiwf_medium_context,
@@ -349,20 +352,136 @@ def test_transcript_flags_truncation():
     assert "TRUNCATED" in rendered
 
 
-def test_transcript_flags_a_recovery_nudge():
-    """The judge must know two replies belong to one turn, or it reads the
-    concatenation as rambling."""
-    rendered = _render_transcript([_record(recovery_used=True)])
-    assert "Please go ahead." in rendered
-    assert "combines both replies" in rendered
-
-
-def test_transcript_renders_empty_assistant_text():
-    """A tool-call-only turn is valid; it must not render as a blank field."""
+def test_transcript_hides_the_recovery_attempt():
+    """Upstream's judge SKIPS recovery records, so the nudge reply must not
+    reach the judge — crediting it would let a model that only complied after
+    being prodded look like it complied immediately."""
     rendered = _render_transcript(
-        [_record(assistant_text="", tool_calls=[{"name": "end_session", "args": {}}])]
+        [
+            _record(
+                recovery_used=True,
+                recovery_assistant_text="Sure, submitting that now.",
+                recovery_tool_calls=[{"name": "submit_dietary_request", "args": {}}],
+            )
+        ]
     )
-    assert "(no text)" in rendered
+    assert "Please go ahead." not in rendered
+    assert "Sure, submitting that now." not in rendered
+    assert "submit_dietary_request" not in rendered
+
+
+def test_transcript_leads_with_the_expected_calls_summary():
+    """Upstream's format_turns_for_claude opens with this header."""
+    rendered = _render_transcript(
+        [
+            _record(
+                turn=24,
+                expected_function={
+                    "name": "vote_for_session",
+                    "args": {"name": "Jennifer Smith", "session_id": "936902"},
+                },
+            )
+        ]
+    )
+    assert rendered.startswith("# Expected Function Calls Summary")
+    assert '- Turn 24: vote_for_session({"name": "Jennifer Smith"' in rendered
+    assert "# Conversation Turns" in rendered
+
+
+def test_user_prompt_carries_upstream_closing_instructions():
+    """The two-phase instructions and "Remember" recap are part of upstream's
+    rubric, not decoration — an earlier version of this port dropped them."""
+    prompt = _render_user_prompt([_record(), _record(turn=1)])
+    assert "Please perform your two-phase evaluation:" in prompt
+    assert "MUST contain exactly 2 entries" in prompt
+    assert "Be generous with kb_grounding unless there's a clear factual error" in prompt
+
+
+# --- Judge prompt fidelity vs upstream -----------------------------------
+
+
+def test_judge_prompt_differs_from_upstream_only_by_the_audio_dimension():
+    """The judge prompt IS upstream's, minus the audio-only turn_taking
+    dimension. Pinned line-by-line: paraphrasing the rubric silently changes
+    what the benchmark measures, which happened once already."""
+    import difflib
+
+    # The turn_taking dimension block, verbatim from upstream — every line of
+    # it is expected to disappear.
+    up_lines = _UPSTREAM_JUDGE_PROMPT.splitlines()
+    start = next(i for i, l in enumerate(up_lines)
+                 if l.strip().startswith("1. **turn_taking**"))
+    end = next(i for i in range(start + 1, len(up_lines))
+               if up_lines[i].strip().startswith("2. **"))
+    audio_block = {l.strip() for l in up_lines[start:end] if l.strip()}
+
+    removed, added = [], []
+    for line in difflib.unified_diff(
+        up_lines, _JUDGE_SYSTEM_PROMPT.splitlines(), lineterm="", n=0,
+    ):
+        if line.startswith(("---", "+++", "@@")):
+            continue
+        (removed if line.startswith("-") else added).append(line[1:])
+
+    # Every removed line is either part of that block, mentions audio/
+    # turn_taking, or is a renumbering artefact.
+    for line in removed:
+        s = line.strip()
+        assert (
+            s in audio_block
+            or "turn_taking" in s
+            or "turn-taking" in s.lower()
+            or "audio" in s.lower()
+            or s == "For each turn, evaluate FOUR dimensions:"
+            or s.startswith(("2. **tool_use_correct**",
+                             "3. **instruction_following**",
+                             "4. **kb_grounding**"))
+            or not s
+        ), f"unexpected removal from upstream prompt: {line!r}"
+
+    # Every added line is a renumbering or the THREE-dimensions count.
+    for line in added:
+        assert line.strip().startswith(("1. **tool_use_correct**",
+                                        "2. **instruction_following**",
+                                        "3. **kb_grounding**",
+                                        '{"turn": 0, "reasoning"')) or line.strip() == (
+            "For each turn, evaluate THREE dimensions:"
+        ), f"unexpected addition to upstream prompt: {line!r}"
+
+
+def test_judge_prompt_keeps_upstream_structure():
+    """Sections an earlier rewrite had dropped."""
+    for expected in (
+        "# Two-Phase Evaluation Process",
+        "## PHASE 1: Initial Turn-by-Turn Analysis",
+        "## PHASE 2: Realignment Analysis",
+        "# Critical: Detecting Words-Actions Mismatch",
+        "# Critical: Handling Early Function Calls",
+        "# Critical: Handling Late Function Calls",
+        "Example: If vote_for_session was expected at turn 24 but called at turn 25:",
+    ):
+        assert expected in _JUDGE_SYSTEM_PROMPT, expected
+
+
+def test_judge_prompt_has_no_audio_references():
+    lowered = _JUDGE_SYSTEM_PROMPT.lower()
+    assert "turn_taking" not in lowered
+    assert "audio" not in lowered
+    assert "THREE dimensions" in _JUDGE_SYSTEM_PROMPT
+    assert "FOUR dimensions" not in _JUDGE_SYSTEM_PROMPT
+
+
+def test_judge_dimensions_are_numbered_one_to_three():
+    for n, dim in enumerate(DIMENSIONS, start=1):
+        assert f"{n}. **{dim}** (bool):" in _JUDGE_SYSTEM_PROMPT
+
+
+def test_vendored_upstream_prompt_is_unmodified():
+    """The vendored file must stay byte-identical to upstream's literal, so the
+    diff above is meaningful. 5802 chars @ aiewf-eval d0dabb6."""
+    assert len(_UPSTREAM_JUDGE_PROMPT) == 5802
+    assert _UPSTREAM_JUDGE_PROMPT.startswith("# Role\n")
+    assert "turn_taking" in _UPSTREAM_JUDGE_PROMPT  # untouched copy
 
 
 # --- Vendored data files --------------------------------------------------

--- a/tests/test_aiwf_benchmark.py
+++ b/tests/test_aiwf_benchmark.py
@@ -1,0 +1,383 @@
+"""Tests for the bundled aiwf multi-turn benchmark.
+
+Scope per CLAUDE.md: narrow deterministic logic only — data fidelity against
+upstream, judge-output parsing, metric arithmetic. Whether a model actually
+scores well is not testable here and is verified by running the benchmark.
+"""
+
+import json
+
+import pytest
+
+from eval_mcp.benchmarks.aiwf import data_loader
+from eval_mcp.benchmarks.aiwf.data_loader import (
+    AIWF_TASKS,
+    knowledge_base,
+    system_prompt,
+    tool_defs,
+    turns,
+)
+from eval_mcp.benchmarks.aiwf.task import (
+    DIMENSIONS,
+    _extract_judgments,
+    _max_turns,
+    _rate,
+    _render_transcript,
+    _turn_rate,
+    aiwf_long_context,
+    aiwf_medium_context,
+)
+
+
+# --- Dataset fidelity vs upstream (kwindla/aiewf-eval) --------------------
+
+
+def test_thirty_turns():
+    assert len(turns()) == 30
+
+
+def test_turn_indices_are_sequential():
+    assert [t.index for t in turns()] == list(range(30))
+
+
+def test_six_turns_expect_a_tool_call():
+    """Upstream has exactly 6 golden function calls, at these turn indices."""
+    with_tool = [t.index for t in turns() if t.expected_tool]
+    assert with_tool == [11, 12, 15, 17, 24, 29]
+
+
+def test_expected_tools_match_upstream():
+    by_index = {t.index: t.expected_tool for t in turns() if t.expected_tool}
+    assert by_index == {
+        11: "submit_session_suggestion",
+        12: "submit_session_suggestion",
+        15: "submit_dietary_request",
+        17: "request_tech_support",
+        24: "vote_for_session",
+        29: "end_session",
+    }
+
+
+def test_expected_args_are_exposed():
+    turn = next(t for t in turns() if t.index == 24)
+    assert turn.expected_args == {"name": "Jennifer Smith", "session_id": "936902"}
+    # end_session takes none.
+    assert next(t for t in turns() if t.index == 29).expected_args == {}
+
+
+def test_turns_without_a_tool_call_have_no_expectation():
+    for t in turns():
+        if t.index not in (11, 12, 15, 17, 24, 29):
+            assert t.expected_tool is None
+            assert t.expected_args == {}
+
+
+def test_every_turn_has_input_and_golden_text():
+    for t in turns():
+        assert t.input.strip()
+        assert t.golden_text.strip()
+
+
+def test_five_tools_in_upstream_order():
+    from inspect_ai.tool._tool_def import ToolDef
+
+    assert [ToolDef(t).name for t in tool_defs()] == [
+        "end_session",
+        "submit_dietary_request",
+        "submit_session_suggestion",
+        "vote_for_session",
+        "request_tech_support",
+    ]
+
+
+def test_tool_schemas_match_upstream_parameters():
+    from inspect_ai.tool._tool_def import ToolDef
+
+    expected = {
+        "end_session": ([], []),
+        "submit_dietary_request": (
+            ["name", "dietary_preference"],
+            ["name", "dietary_preference"],
+        ),
+        "submit_session_suggestion": (
+            ["name", "suggestion_text"],
+            ["name", "suggestion_text"],
+        ),
+        "vote_for_session": (["name", "session_id"], ["name", "session_id"]),
+        "request_tech_support": (
+            ["name", "issue_description"],
+            ["name", "issue_description"],
+        ),
+    }
+    for tool in tool_defs():
+        d = ToolDef(tool)
+        params, required = expected[d.name]
+        assert list(d.parameters.properties) == params, d.name
+        assert list(d.parameters.required) == required, d.name
+
+
+@pytest.mark.parametrize("variant", sorted(AIWF_TASKS))
+def test_system_prompt_contains_kb_and_tool_docs(variant):
+    prompt = system_prompt(variant)
+    kb = knowledge_base(variant)
+    assert kb in prompt
+    # Preamble before the KB, tools section after it. rindex for the tools
+    # heading: the preamble also *mentions* "AVAILABLE TOOLS" in its
+    # instructions, so the first occurrence isn't the heading.
+    assert prompt.index("KNOWLEDGE BASE") < prompt.index(kb)
+    assert prompt.index(kb) < prompt.rindex("AVAILABLE TOOLS")
+
+
+def test_long_variant_has_a_bigger_knowledge_base():
+    """The ONLY difference between the two benchmarks is KB size."""
+    medium = knowledge_base("aiwf_medium_context")
+    long = knowledge_base("aiwf_long_context")
+    assert len(long) > len(medium) * 5
+    # Same scaffolding either side of it.
+    assert system_prompt("aiwf_medium_context").replace(medium, "") == system_prompt(
+        "aiwf_long_context"
+    ).replace(long, "")
+
+
+def test_unknown_variant_is_rejected():
+    with pytest.raises(ValueError, match="Unknown aiwf variant"):
+        knowledge_base("aiwf_enormous_context")
+
+
+# --- Task construction ----------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [aiwf_medium_context, aiwf_long_context])
+def test_task_is_one_sample_holding_the_whole_conversation(factory):
+    task = factory()
+    assert len(task.dataset) == 1
+    assert task.dataset[0].metadata["turns"] == 30
+
+
+def test_task_names_match_the_variant_keys():
+    assert aiwf_medium_context().name == "aiwf_medium_context"
+    assert aiwf_long_context().name == "aiwf_long_context"
+    assert set(AIWF_TASKS) == {"aiwf_medium_context", "aiwf_long_context"}
+
+
+# --- Turn cap (smoke-run knob) -------------------------------------------
+
+
+def test_max_turns_unset_means_all_turns(monkeypatch):
+    monkeypatch.delenv("EVAL_MCP_AIWF_MAX_TURNS", raising=False)
+    assert _max_turns() is None
+
+
+@pytest.mark.parametrize("raw", ["not-a-number", "0", "-3", ""])
+def test_max_turns_ignores_junk(monkeypatch, raw):
+    """A bad cap must run the full benchmark, never zero turns."""
+    monkeypatch.setenv("EVAL_MCP_AIWF_MAX_TURNS", raw)
+    assert _max_turns() is None
+
+
+def test_max_turns_reads_a_valid_cap(monkeypatch):
+    monkeypatch.setenv("EVAL_MCP_AIWF_MAX_TURNS", "4")
+    assert _max_turns() == 4
+
+
+# --- Judge output parsing -------------------------------------------------
+
+
+class _FakeToolCall:
+    def __init__(self, function, arguments):
+        self.function = function
+        self.arguments = arguments
+
+
+class _FakeMessage:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+class _FakeOutput:
+    def __init__(self, tool_calls=None, completion=""):
+        self.message = _FakeMessage(tool_calls) if tool_calls is not None else None
+        self.completion = completion
+
+
+def _judgment(turn, tool=True, instr=True, kb=True, reasoning="ok"):
+    return {
+        "turn": turn,
+        "tool_use_correct": tool,
+        "instruction_following": instr,
+        "kb_grounding": kb,
+        "reasoning": reasoning,
+    }
+
+
+def test_extract_judgments_parses_the_tool_call():
+    out = _FakeOutput(
+        [
+            _FakeToolCall(
+                "submit_judgments",
+                {"judgments": [_judgment(0), _judgment(1, kb=False)]},
+            )
+        ]
+    )
+    judgments, err = _extract_judgments(out, 2)
+    assert err is None
+    assert judgments[0]["kb_grounding"] is True
+    assert judgments[1]["kb_grounding"] is False
+    assert judgments[1]["tool_use_correct"] is True
+
+
+def test_extract_judgments_without_a_tool_call_is_an_error():
+    judgments, err = _extract_judgments(_FakeOutput(None, "I refuse"), 30)
+    assert judgments is None
+    assert "No tool call" in err
+
+
+def test_extract_judgments_ignores_a_different_tool():
+    out = _FakeOutput([_FakeToolCall("something_else", {"judgments": [_judgment(0)]})])
+    judgments, err = _extract_judgments(out, 1)
+    assert judgments is None
+    assert "No submit_judgments" in err
+
+
+def test_extract_judgments_skips_unparseable_entries():
+    """A judge that emits one malformed entry shouldn't void the whole run."""
+    out = _FakeOutput(
+        [
+            _FakeToolCall(
+                "submit_judgments",
+                {"judgments": [_judgment(0), {"no_turn_key": True}, "garbage"]},
+            )
+        ]
+    )
+    judgments, err = _extract_judgments(out, 3)
+    assert err is None
+    assert list(judgments) == [0]
+
+
+def test_extract_judgments_defaults_missing_dimensions_to_false():
+    """Absent dimension == not demonstrated, not silently passed."""
+    out = _FakeOutput(
+        [_FakeToolCall("submit_judgments", {"judgments": [{"turn": 0}]})]
+    )
+    judgments, _ = _extract_judgments(out, 1)
+    assert all(judgments[0][d] is False for d in DIMENSIONS)
+
+
+# --- Metric arithmetic ----------------------------------------------------
+
+
+class _FakeScore:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+
+class _FakeSampleScore:
+    def __init__(self, metadata):
+        self.score = _FakeScore(metadata)
+
+
+def test_turn_rate_pools_turns_across_samples():
+    """Rates are per-TURN, so a 2-model run pools 60 turns, not 2 samples."""
+    scores = [
+        _FakeSampleScore({"turns_judged": 30, "turn_pass": 30}),
+        _FakeSampleScore({"turns_judged": 30, "turn_pass": 15}),
+    ]
+    assert _turn_rate(scores, "turn_pass") == pytest.approx(45 / 60)
+
+
+def test_turn_rate_with_no_turns_is_zero_not_a_crash():
+    assert _turn_rate([_FakeSampleScore({})], "turn_pass") == 0.0
+
+
+def test_rate_guards_zero_denominator():
+    assert _rate(0, 0) == 0.0
+    assert _rate(3, 4) == 0.75
+
+
+# --- Transcript rendering (what the judge sees) ---------------------------
+
+
+def _record(**kw):
+    base = {
+        "turn": 0,
+        "user_text": "when are the workshops?",
+        "assistant_text": "Tuesday, June 3rd.",
+        "tool_calls": [],
+        "expected_function": None,
+        "golden_text": "Workshop day is Tuesday, June 3rd.",
+        "stop_reason": "stop",
+    }
+    base.update(kw)
+    return base
+
+
+def test_transcript_omits_the_knowledge_base():
+    """Upstream's judge doesn't get the KB; including it would change what
+    kb_grounding measures (and add ~92K tokens per judge call on long)."""
+    rendered = _render_transcript([_record()])
+    kb = knowledge_base("aiwf_medium_context")
+    assert kb not in rendered
+    # A distinctive KB line must not leak in either.
+    assert kb.splitlines()[10].strip() not in rendered
+
+
+def test_transcript_includes_golden_and_expected_function():
+    rendered = _render_transcript(
+        [
+            _record(
+                turn=24,
+                expected_function={
+                    "name": "vote_for_session",
+                    "args": {"name": "Jennifer Smith", "session_id": "936902"},
+                },
+                tool_calls=[{"name": "vote_for_session", "args": {"session_id": "936902"}}],
+            )
+        ]
+    )
+    assert "## Turn 24" in rendered
+    assert "Workshop day is Tuesday" in rendered
+    assert "vote_for_session" in rendered
+    assert "**Expected Function**" in rendered
+
+
+def test_transcript_marks_no_expected_function_as_none():
+    assert "**Expected Function**: none" in _render_transcript([_record()])
+
+
+def test_transcript_flags_truncation():
+    rendered = _render_transcript([_record(stop_reason="max_tokens")])
+    assert "TRUNCATED" in rendered
+
+
+def test_transcript_flags_a_recovery_nudge():
+    """The judge must know two replies belong to one turn, or it reads the
+    concatenation as rambling."""
+    rendered = _render_transcript([_record(recovery_used=True)])
+    assert "Please go ahead." in rendered
+    assert "combines both replies" in rendered
+
+
+def test_transcript_renders_empty_assistant_text():
+    """A tool-call-only turn is valid; it must not render as a blank field."""
+    rendered = _render_transcript(
+        [_record(assistant_text="", tool_calls=[{"name": "end_session", "args": {}}])]
+    )
+    assert "(no text)" in rendered
+
+
+# --- Vendored data files --------------------------------------------------
+
+
+def test_data_files_ship_with_the_package():
+    for name in ("turns.json", "kb_medium.txt", "kb_long.txt",
+                 "system_preamble.txt", "system_tools_section.txt"):
+        assert (data_loader._DATA / name).is_file(), name
+
+
+def test_turns_json_is_valid_and_has_no_audio_references():
+    raw = json.loads((data_loader._DATA / "turns.json").read_text())
+    assert len(raw) == 30
+    # audio_file was dropped at vendor time (speech-only).
+    assert all("audio_file" not in t for t in raw)
+    assert all(set(t) == {"index", "input", "golden_text", "required_function_call"}
+               for t in raw)

--- a/tests/test_benchmark_port_fidelity.py
+++ b/tests/test_benchmark_port_fidelity.py
@@ -1,0 +1,141 @@
+"""Repo-wide guard: every ported benchmark must keep its instrument verbatim.
+
+Docs get skimmed; tests don't. This file enforces the porting contract in
+CLAUDE.md ("copy the instrument, adapt the plumbing") for EVERY benchmark under
+``eval_mcp/benchmarks/``, present and future. The contract needs a mechanical
+check because the way it breaks is quiet: a rubric that has been reworded still
+runs, still scores, and still passes every test — it just measures something
+other than what the original measured.
+
+It is deliberately structural rather than content-specific: it checks that each
+port declares its provenance and vendors its prompts as data, not that any
+particular prompt says any particular thing. Per-benchmark diff tests (see
+``test_aiwf_benchmark.py``) pin the actual text.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+BENCHMARKS_DIR = Path(__file__).parent.parent / "eval_mcp" / "benchmarks"
+
+# A ported benchmark = a package under eval_mcp/benchmarks/ with a task module.
+PORTS = sorted(
+    p for p in BENCHMARKS_DIR.iterdir()
+    if p.is_dir() and not p.name.startswith(("_", ".")) and (p / "task.py").exists()
+) if BENCHMARKS_DIR.is_dir() else []
+
+# Prompt-ish text that must live in data/ rather than inline in Python. Matches
+# a triple-quoted literal long enough to be a prompt (not a docstring one-liner)
+# whose content looks like rubric/instruction text.
+_PROMPT_MARKERS = (
+    "you are an expert",
+    "you are a helpful",
+    "you must output",
+    "evaluate each turn",
+    "for each turn, evaluate",
+    "score the following",
+    "rate the following",
+    "you will judge",
+    "your task is to grade",
+)
+
+
+_IDS = [p.name for p in PORTS]
+
+
+@pytest.mark.skipif(not PORTS, reason="no ported benchmarks yet")
+@pytest.mark.parametrize("port", PORTS, ids=_IDS)
+def test_port_has_a_notice_with_provenance(port: Path):
+    """Every port must state where it came from and pin the exact commit.
+
+    Without a pinned SHA there is no way to re-verify fidelity later: upstream
+    moves, and "we copied it from their repo" stops being checkable.
+    """
+    notice = port / "NOTICE.md"
+    assert notice.is_file(), (
+        f"{port.name} has no NOTICE.md. Every ported benchmark needs one: "
+        f"upstream URL, license, pinned commit SHA, and what was copied vs "
+        f"adapted vs not ported. See eval_mcp/benchmarks/aiwf/NOTICE.md."
+    )
+    text = notice.read_text(encoding="utf-8")
+    assert re.search(r"https?://\S+", text), f"{port.name}: NOTICE.md has no upstream URL"
+    assert re.search(r"\b[0-9a-f]{40}\b", text), (
+        f"{port.name}: NOTICE.md must pin a full 40-char upstream commit SHA, so "
+        f"the port can be re-diffed against the exact source it came from."
+    )
+    assert re.search(r"licen[cs]e|MIT|Apache|BSD", text, re.I), (
+        f"{port.name}: NOTICE.md must state the upstream license"
+    )
+
+
+@pytest.mark.skipif(not PORTS, reason="no ported benchmarks yet")
+@pytest.mark.parametrize("port", PORTS, ids=_IDS)
+def test_port_vendors_its_data(port: Path):
+    """Datasets/prompts live in data/, so fidelity is checkable by diff."""
+    data = port / "data"
+    assert data.is_dir() and any(data.iterdir()), (
+        f"{port.name} has no data/ directory. Vendor datasets and prompts as "
+        f"data files (even when upstream keeps them in Python) so a future edit "
+        f"to the measuring instrument shows up in a diff."
+    )
+
+
+@pytest.mark.skipif(not PORTS, reason="no ported benchmarks yet")
+@pytest.mark.parametrize("port", PORTS, ids=_IDS)
+def test_port_does_not_inline_long_prompts_in_python(port: Path):
+    """Prompts belong in data/, not in a Python string literal.
+
+    A prompt in a .py string literal *looks* like code, and code invites
+    adaptation — that framing is the trap. Keeping prompts in data files makes an
+    edit to the measuring instrument show up as a data diff rather than hiding
+    inside a refactor.
+    """
+    offenders = []
+    for py in port.rglob("*.py"):
+        src = py.read_text(encoding="utf-8")
+        for literal in re.findall(r'"""(.*?)"""', src, re.S):
+            if len(literal) < 400:
+                continue  # docstrings, short templates
+            low = literal.lower()
+            if any(m in low for m in _PROMPT_MARKERS):
+                offenders.append(f"{py.relative_to(port)} ({len(literal)} chars)")
+    assert not offenders, (
+        f"{port.name}: prompt-like text inlined in Python: {offenders}. Move it "
+        f"to data/ and load it, so porting fidelity is diff-checkable. If an "
+        f"edit to a vendored prompt is required, transform the verbatim original "
+        f"in code and pin the result with a diff test."
+    )
+
+
+@pytest.mark.skipif(not PORTS, reason="no ported benchmarks yet")
+@pytest.mark.parametrize("port", PORTS, ids=_IDS)
+def test_port_routes_through_inspect_patches(port: Path):
+    """Ports must import eval_mcp.inspect_patches so max_tokens is omitted.
+
+    Otherwise Inspect's Bedrock provider injects a constant 2048 and reasoning
+    models return empty completions that score 0 — see CLAUDE.md.
+    """
+    src = (port / "task.py").read_text(encoding="utf-8")
+    assert "eval_mcp.inspect_patches" in src, (
+        f"{port.name}/task.py must import eval_mcp.inspect_patches"
+    )
+
+
+@pytest.mark.skipif(not PORTS, reason="no ported benchmarks yet")
+@pytest.mark.parametrize("port", PORTS, ids=_IDS)
+def test_port_records_the_judge_in_score_metadata(port: Path):
+    """If a port is judge-scored, every score must name its judge.
+
+    The judge is part of the measuring instrument — swapping it can move the
+    headline metric by several points — so a score that doesn't name its judge
+    isn't interpretable.
+    """
+    src = (port / "task.py").read_text(encoding="utf-8")
+    if "judge" not in src.lower():
+        pytest.skip(f"{port.name} is not judge-scored")
+    assert '"judge_model"' in src or "'judge_model'" in src, (
+        f"{port.name}: judge-scored ports must record judge_model in the score "
+        f"metadata so results are self-describing."
+    )

--- a/tests/test_benchmark_registry.py
+++ b/tests/test_benchmark_registry.py
@@ -1,0 +1,180 @@
+"""Tests for bundled-benchmark auto-discovery and the unified tool surface.
+
+The contract these pin: adding a benchmark is dropping a directory in, and
+callers reach both catalogs through one set of tools. Both are easy to
+accidentally regress — the discovery by hardcoding a benchmark somewhere, the
+unified surface by splitting the tools apart again.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from eval_mcp.benchmarks import registry
+
+
+def test_discovers_the_bundled_benchmarks():
+    found = registry.discover()
+    assert "aiwf" in found, f"expected aiwf, discovered {list(found)}"
+
+
+def test_discovery_is_driven_by_eval_yaml_not_python():
+    """No benchmark may be named in the registry or the MCP tools.
+
+    The whole point of eval.yaml discovery is that a new benchmark needs no code
+    change. If an id leaks into these modules, the next port will need one.
+    """
+    from pathlib import Path
+
+    for module in (
+        Path(registry.__file__),
+        Path(registry.__file__).parent.parent / "tools" / "multiturn_benchmarks.py",
+    ):
+        src = module.read_text(encoding="utf-8")
+        for bench_id in registry.discover():
+            # Allow it in comments/docstrings, not in code.
+            code = "\n".join(
+                line for line in src.splitlines()
+                if not line.lstrip().startswith("#")
+            )
+            assert f'"{bench_id}"' not in code and f"'{bench_id}'" not in code, (
+                f"{module.name} references benchmark id {bench_id!r} in code. "
+                f"Discovery must be data-driven so a new benchmark needs no "
+                f"Python edit."
+            )
+
+
+def test_every_declared_task_exists_in_task_py():
+    """A name in eval.yaml with no matching @task fails only at run time."""
+    for bench in registry.discover().values():
+        src = bench.task_file.read_text(encoding="utf-8")
+        for name in bench.task_names:
+            assert f"def {name}(" in src, (
+                f"{bench.id}: eval.yaml declares task {name!r} but "
+                f"{bench.task_file.name} has no such function"
+            )
+
+
+def test_task_file_resolves_absolute():
+    """Inspect is invoked as <abs path>@<task>; the eval subprocess runs in the
+    user's storage dir, so a relative path would break."""
+    for bench in registry.discover().values():
+        assert bench.task_file.is_absolute()
+        assert bench.task_file.is_file()
+
+
+def test_resolve_accepts_a_task_name():
+    hit = registry.resolve("aiwf_medium_context")
+    assert hit is not None
+    bench, task = hit
+    assert bench.id == "aiwf"
+    assert task == "aiwf_medium_context"
+
+
+def test_resolve_rejects_a_multi_task_id():
+    """An ambiguous id must not silently pick a variant."""
+    bench = registry.discover()["aiwf"]
+    assert len(bench.task_names) > 1
+    assert registry.resolve("aiwf") is None
+
+
+def test_resolve_returns_none_for_unknown():
+    assert registry.resolve("definitely_not_a_benchmark") is None
+
+
+def test_every_benchmark_declares_metrics_and_a_headline():
+    for bench in registry.discover().values():
+        assert bench.metrics, f"{bench.id}: eval.yaml declares no metrics"
+        assert bench.headline_metric, f"{bench.id}: no headline metric"
+
+
+def test_judge_scored_benchmarks_declare_a_default_judge():
+    for bench in registry.discover().values():
+        if not bench.judge:
+            continue
+        assert bench.default_judge, (
+            f"{bench.id}: judge block present but no default. The judge is part "
+            f"of the measurement; it can't be implicit."
+        )
+
+
+def test_eval_yaml_declares_per_task_cost():
+    """Cost must be visible before a run — some of these are millions of tokens."""
+    for bench in registry.discover().values():
+        for t in bench.tasks:
+            assert t.approx_input_tokens_per_model, (
+                f"{bench.id}/{t.name}: eval.yaml must state "
+                f"approx_input_tokens_per_model so callers aren't surprised."
+            )
+
+
+def test_eval_yaml_is_parseable_and_has_required_keys():
+    for bench in registry.discover().values():
+        raw = yaml.safe_load((bench.path / "eval.yaml").read_text(encoding="utf-8"))
+        for key in ("title", "description", "group", "tasks", "source"):
+            assert key in raw, f"{bench.id}: eval.yaml missing {key!r}"
+
+
+def test_details_payload_is_json_serialisable():
+    """It goes straight out over MCP as JSON."""
+    for bench in registry.discover().values():
+        json.dumps(bench.details())
+        json.dumps(bench.summary())
+
+
+# --- Unified tool surface -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_benchmarks_includes_bundled_and_upstream():
+    from eval_mcp.tools.benchmarks import handle_list_benchmarks
+
+    payload = json.loads((await handle_list_benchmarks({"limit": 200}))[0].text)
+    ids = [b["id"] for b in payload["benchmarks"]]
+    assert "aiwf" in ids, "bundled benchmark missing from list_benchmarks"
+    assert "gsm8k" in ids, "upstream catalog missing from list_benchmarks"
+    # Bundled sort first — cheapest to run, no external deps.
+    assert payload["benchmarks"][0].get("bundled") is True
+
+
+@pytest.mark.asyncio
+async def test_list_benchmarks_search_finds_bundled():
+    from eval_mcp.tools.benchmarks import handle_list_benchmarks
+
+    payload = json.loads(
+        (await handle_list_benchmarks({"search": "conversation"}))[0].text
+    )
+    assert "aiwf" in [b["id"] for b in payload["benchmarks"]]
+
+
+@pytest.mark.asyncio
+async def test_get_benchmark_details_resolves_bundled_by_id_and_task():
+    from eval_mcp.tools.benchmarks import handle_get_benchmark_details
+
+    for key in ("aiwf", "aiwf_long_context"):
+        payload = json.loads((await handle_get_benchmark_details({"benchmark_id": key}))[0].text)
+        assert payload["success"] and payload["id"] == "aiwf", key
+        assert payload["bundled"] is True
+        assert payload["caveats"], "bundled details must carry caveats"
+
+
+@pytest.mark.asyncio
+async def test_get_benchmark_details_still_resolves_upstream():
+    from eval_mcp.tools.benchmarks import handle_get_benchmark_details
+
+    payload = json.loads((await handle_get_benchmark_details({"benchmark_id": "gsm8k"}))[0].text)
+    assert payload["success"] and payload["id"] == "gsm8k"
+    assert not payload.get("bundled", False)
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_rejects_missing_providers_for_bundled():
+    """Dispatch reaches the bundled runner's validation, not upstream's."""
+    from eval_mcp.tools.benchmarks import handle_run_benchmark
+
+    payload = json.loads(
+        (await handle_run_benchmark({"task": "aiwf_medium_context", "user_id": "t"}))[0].text
+    )
+    assert payload["success"] is False
+    assert "provider" in payload["error"].lower()


### PR DESCRIPTION
## Summary

- Adds the repo's first **multi-turn conversation benchmark**: a text-mode port of [kwindla/aiewf-eval](https://github.com/kwindla/aiewf-eval) (MIT, pinned at `d0dabb6`), as `aiwf_medium_context` (~12K-token KB) and `aiwf_long_context` (~40K). 30 turns, 5 conference tools, 6 golden tool calls.
- **Restructures bundled benchmarks to be discovered from `eval.yaml`** and unifies the MCP surface, so adding the next benchmark needs no Python change.
- Adds a **porting contract** (CLAUDE.md + skill + repo-wide test guard) so future ports stay faithful.
- Switches the default Claude judge to **Opus 5**, based on measurement.

## Why

Everything here measured single-shot Q&A. This measures whether a model holds up as context accumulates over a long conversation — right tool at the right moment, following its system prompt, staying factually grounded. `inspect_evals` has no benchmark of this shape, and [stopped accepting new eval code](https://github.com/UKGovernmentBEIS/inspect_evals/blob/main/EVAL_REGISTER.md) on 2026-05-08 (register entries aren't shipped in its wheel — verified `internal: 129, external: 0`), so bundling is the only path that runs.

## Fidelity

The target-facing side is **byte-identical** to upstream (verified by SHA): system prompt, both knowledge bases, all 30 utterances, all 30 golden answers, all 6 golden tool calls, 5 tool schemas.

The judge prompt is upstream's **verbatim**, with the audio-only `turn_taking` dimension removed *programmatically* at load time rather than by hand-editing a copy — a test diffs ours against the vendored original and fails on any non-audio difference.

Two upstream behaviours ported deliberately, both of which move scores:
- A turn **ends at the tool call** — no second generate after the tool result (`default_tool_result_run_llm = False`), which would hand the model a free retry.
- The **recovery nudge** is injected but **not scored**: upstream writes it as a separate transcript record and its judge skips those (`if rec.get("recovery_turn"): continue`). A tool call made only after being prodded earns the turn no credit.

Deliberately not ported: all speech-to-speech (~5,900 lines upstream) — four Pipecat pipelines, 31 turn WAVs, and the audio-derived `turn_taking` dimension. Inspect has no duplex-audio transport. Full provenance and every deviation in [`eval_mcp/benchmarks/aiwf/NOTICE.md`](eval_mcp/benchmarks/aiwf/NOTICE.md).

## Structure — adding the next benchmark

Drop in a directory; **edit no Python**. `registry.py` globs `*/eval.yaml`, the same mechanism `inspect_evals` uses, with a schema mirroring theirs.

```
eval_mcp/benchmarks/<name>/
    eval.yaml   tasks (+ turn count, token cost), metrics, judge, source, caveats
    task.py     @task functions
    data/       vendored datasets + prompts
    NOTICE.md   provenance
```

One tool surface for both catalogs — `list_benchmarks` returns bundled (flagged `bundled: true`, sorted first) alongside the 129 upstream; `get_benchmark_details` and `run_benchmark` resolve either.

## Judge: Opus 5

Scored against **hand-adjudicated** verdicts, transcript held fixed, 16 calls each:

| Judge | Errors | False pos | False neg | Exact-match |
|---|---:|---:|---:|---|
| **opus-5** | **2** | 2 | 0 | 14/16 |
| opus-4-5 (upstream's) | 5 | 0 | 5 | 11/16 |
| sonnet-4-6 (previous default) | 9 | 8 | 1 | 7/16 |

Sonnet 4.6's errors were almost all false positives — it failed a turn on 8/8 calls where the model was factually correct and merely added detail verifiably present in the KB. This is the shared `JUDGE_MODELS["claude"]`, so it moves every jury-scored eval. Sonnet 5 was tried and rejected: 0.100 `pass_rate` swing on identical input.

## Test plan

- [x] `pytest` — **614 passed**. Pre-existing failure `test_mcp_eval::test_mcp_eval_pass_rate` (mcp-1.x `inputSchema` leftover) also fails on clean `main`; untouched here.
- [x] Target-facing prompt byte-compared against upstream's own assembly (both variants).
- [x] Judge prompt diffed against vendored upstream original — audio-only differences.
- [x] **Full 30-turn run, 2 models in one run, real Bedrock** (never mockllm): haiku-4-5 0.867, nova-pro 0.833. Nova's failures are exactly the 5 tool-call turns with 5 recovery nudges; haiku's are scattered instruction-following. Both 30/30 judged, no truncation.
- [x] Every failing turn hand-adjudicated against the golden answers + KB.
- [x] MCP handler exercised including rejection paths; results verified in the viewer with all 5 metrics.
- [x] Zero-Python-edit porting proven by adding a throwaway benchmark (discovered, ran, auto-covered by the fidelity guard), then removing it.
- [x] `eval.yaml` + vendored data confirmed present in the built wheel.

## Notes for review

- Two commits (`31f5fee` + revert `d2cc150`) are a Sonnet 5 switch and its reversal, kept visible rather than rewritten, with `a8da787` correcting the superseded conclusion.
- Run-to-run variance in the *target* is real (~0.03); hold the judge fixed and average runs before reading a small gap as meaningful. Upstream averages 10.
- `aiwf_long_context` is ~3M input tokens per model per run. `eval.yaml` surfaces that up front, and `max_turns` gives a cheap smoke run (marked non-comparable).