### PR TITLE
fix(security): gate chat sessions by owner and disable explore_eval_data in hosted mode

### DIFF
--- a/backend/api/compare.py
+++ b/backend/api/compare.py
@@ -310,12 +310,14 @@ async def generate_report_pdf(
     if not detail:
         raise HTTPException(status_code=404, detail="Evaluation group not found")
 
-    # Load chat transcript if session_id provided
+    # Load chat transcript if session_id provided. Gate on ownership: the
+    # session id is a client-supplied value, so a caller must not be able to
+    # embed another user's transcript into a report by passing their id.
     transcript = None
     if session_id:
         try:
             from backend.api.main import db
-            if db:
+            if db and await db.session_belongs_to_user(session_id, user_id):
                 messages = await db.get_session_messages(session_id)
                 transcript = messages
         except Exception as e:

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -779,6 +779,10 @@ async def chat_status(session_id: str, user_id: str = Depends(get_current_user_i
     falls back to the session_active DB table so a reconnecting tab that
     lands on a different pod still gets the correct answer.
     """
+    # The session id is client-supplied — refuse to report on a session the
+    # caller doesn't own (prevents probing other users' chat activity).
+    if db and not await db.session_belongs_to_user(session_id, user_id):
+        raise HTTPException(status_code=404, detail="Session not found")
     if session_id in active_tasks and not active_tasks[session_id].done():
         return {"running": True}
     # Cross-pod fallback: the task may be running on another replica.
@@ -871,6 +875,11 @@ async def cancel_chat(session_id: str, user_id: str = Depends(get_current_user_i
     c222fee was meant to fix but didn't fully wire up.
     """
     global cancelled_sessions, active_tasks
+
+    # The session id is client-supplied — a caller must only be able to
+    # cancel their own session, never another user's in-flight run.
+    if db and not await db.session_belongs_to_user(session_id, user_id):
+        raise HTTPException(status_code=404, detail="Session not found")
 
     local_task: Optional[asyncio.Task] = active_tasks.get(session_id)
     local_task_runnable = local_task is not None and not local_task.done()
@@ -1326,8 +1335,17 @@ async def chat_stream(request: ChatRequest, user_id: str):
     # Ensure user exists
     await db.create_user(user_id, user_id)
 
-    # Create session if it doesn't exist
+    # Create session if it doesn't exist. create_session is ON CONFLICT DO
+    # NOTHING, so a session id already owned by another user is left intact;
+    # the ownership check below then rejects it, preventing a caller from
+    # hijacking or poisoning someone else's conversation via a guessed id.
     await db.create_session(session_id, user_id)
+    if not await db.session_belongs_to_user(session_id, user_id):
+        logger.warning(
+            f"[STREAM] Rejecting turn for session {session_id} not owned by caller"
+        )
+        yield f"event: error\ndata: {json.dumps({'error': 'Session not found'})}\n\n"
+        return
 
     # Build a fresh Agent for this turn, hydrated from DB-backed history.
     # The DB is the only cross-pod-coherent store in a multi-replica
@@ -1436,8 +1454,12 @@ async def chat_non_stream(request: ChatRequest, user_id: str) -> ChatResponse:
         # Ensure user exists
         await db.create_user(user_id, user_id)
 
-        # Create session if it doesn't exist
+        # Create session if it doesn't exist. ON CONFLICT DO NOTHING leaves a
+        # session owned by another user intact, so gate on ownership before
+        # loading history — otherwise a guessed id would hijack their chat.
         await db.create_session(session_id, user_id)
+        if not await db.session_belongs_to_user(session_id, user_id):
+            raise HTTPException(status_code=404, detail="Session not found")
 
         # Build a fresh Agent for this turn from DB-backed history —
         # see the streaming-path comment above for why we don't cache.
@@ -1470,6 +1492,10 @@ async def chat_non_stream(request: ChatRequest, user_id: str) -> ChatResponse:
             response=response,
             session_id=session_id,
         )
+    except HTTPException:
+        # Deliberate rejections (e.g. the ownership 404) must pass through
+        # unchanged rather than be masked as a generic 500.
+        raise
     except Exception:
         _, safe_msg = _user_safe_error("chat_non_stream endpoint")
         raise HTTPException(status_code=500, detail=safe_msg)

--- a/backend/core/agent.py
+++ b/backend/core/agent.py
@@ -344,8 +344,12 @@ that scoring retrieval quality would require uploading their own retriever's chu
         mcp_tools = await self.mcp.list_tools()
 
         # Filter out legacy generation tools (we have our own)
-        # Also filter out developer debugging tools that confuse the agent workflow
-        HIDDEN_TOOLS = ["generate_dataset", "generate_test_cases", "compare_providers", "run_assertion"]
+        # Also filter out developer debugging tools that confuse the agent workflow.
+        # explore_eval_data runs arbitrary Python via exec(); it is a local-only
+        # developer tool and MUST NOT be reachable by the hosted multi-tenant
+        # agent, where the driver is untrusted chat input (would be RCE in the
+        # sidecar + cross-tenant data access).
+        HIDDEN_TOOLS = ["generate_dataset", "generate_test_cases", "compare_providers", "run_assertion", "explore_eval_data"]
         mcp_tools = [tool for tool in mcp_tools if tool["name"] not in HIDDEN_TOOLS]
 
         # Enrich tools with descriptions
@@ -391,8 +395,12 @@ that scoring retrieval quality would require uploading their own retriever's chu
         mcp_tools = await self.mcp.list_tools()
 
         # Filter out legacy generation tools (we have our own)
-        # Also filter out developer debugging tools that confuse the agent workflow
-        HIDDEN_TOOLS = ["generate_dataset", "generate_test_cases", "compare_providers", "run_assertion"]
+        # Also filter out developer debugging tools that confuse the agent workflow.
+        # explore_eval_data runs arbitrary Python via exec(); it is a local-only
+        # developer tool and MUST NOT be reachable by the hosted multi-tenant
+        # agent, where the driver is untrusted chat input (would be RCE in the
+        # sidecar + cross-tenant data access).
+        HIDDEN_TOOLS = ["generate_dataset", "generate_test_cases", "compare_providers", "run_assertion", "explore_eval_data"]
         mcp_tools = [tool for tool in mcp_tools if tool["name"] not in HIDDEN_TOOLS]
 
         # Enrich tools with descriptions

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -456,6 +456,24 @@ class Database:
         except asyncpg.PostgresError as e:
             raise DatabaseError(f"Failed to create session {session_id}: {e}") from e
 
+    async def session_belongs_to_user(self, session_id: str, user_id: str) -> bool:
+        """Return True iff ``session_id`` exists and is owned by ``user_id``.
+
+        Every session-scoped route (transcript load, status, cancel, turn
+        hydration) must gate on this: ``chat_sessions.id`` is a client-supplied
+        value, so without an ownership check any authenticated caller who
+        learns another user's session id could read that user's transcript,
+        resume/poison their conversation, or cancel their in-flight run.
+        A missing session returns False (deny), which the callers map to 404.
+        """
+        await self._ensure_pool_fresh()
+        async with self._pool.acquire() as conn:
+            owner = await conn.fetchval(
+                "SELECT user_id FROM chat_sessions WHERE id = $1",
+                session_id,
+            )
+        return owner == user_id
+
     async def get_user_sessions(self, user_id: str) -> List[Dict[str, Any]]:
         """Get all chat sessions for a user."""
         await self._ensure_pool_fresh()

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -1621,6 +1621,23 @@ async def explore_eval_data(
     if not code:
         return json.dumps({"error": "code is required"})
 
+    # Fail closed in any hosted/networked mode. This tool runs arbitrary
+    # Python; a restricted-builtins exec is NOT a sandbox (attacker code can
+    # climb the object graph through any passed-in function's __globals__ to
+    # recover os/open), so the only sound boundary is refusing to run it when
+    # the driver could be untrusted. It stays available for the local, single-
+    # user stdio MCP — its actual purpose — where the operator already has a
+    # shell. The hosted EKS deployment runs the MCP with
+    # EVAL_MCP_TRANSPORT=http (see helm/eval/templates/deployment.yaml), and
+    # the multi-tenant backend agent also hides this tool (backend/core/
+    # agent.py HIDDEN_TOOLS) — this is the defense-in-depth second layer.
+    if os.environ.get("EVAL_MCP_TRANSPORT", "stdio") != "stdio":
+        return json.dumps({
+            "error": "explore_eval_data is disabled in hosted mode. It "
+                     "executes arbitrary code and is only available on the "
+                     "local stdio MCP."
+        })
+
     log_dir = get_user_log_dir(_user(user_id))
 
     async def _list_logs():
@@ -1661,6 +1678,9 @@ async def explore_eval_data(
             "read_sample": read_sample,
             "json": json,
         }
+        # Runs with full builtins on purpose: this path is reachable only on
+        # the local stdio MCP (guarded above), where the operator already has
+        # a shell. No pretense of sandboxing here — see the guard's comment.
         exec(code, {"__builtins__": __builtins__}, local_vars)
         result = local_vars.get("result", "No 'result' variable set")
         return json.dumps(result, indent=2, default=str)

--- a/tests/test_chat_cancel_eks.py
+++ b/tests/test_chat_cancel_eks.py
@@ -152,6 +152,7 @@ async def test_cross_pod_cancel_chat_writes_db_row_with_no_local_task(monkeypatc
 
     fake_db = MagicMock()
     fake_db.mark_session_cancelled = fake_mark_cancelled
+    fake_db.session_belongs_to_user = AsyncMock(return_value=True)
     monkeypatch.setattr(main, "db", fake_db)
 
     # The MCP /eval-info call would normally go to localhost:8002.

--- a/tests/test_chat_reconnect_empty_message.py
+++ b/tests/test_chat_reconnect_empty_message.py
@@ -44,14 +44,21 @@ class _RecordingDB:
 
     def __init__(self):
         self._messages: dict[str, list[dict]] = {}
+        self._owners: dict[str, str] = {}
         self.create_user = AsyncMock(return_value=None)
-        self.create_session = AsyncMock(return_value=None)
         self.clear_session_cancellation = AsyncMock(return_value=None)
         self.get_session_cancellation = AsyncMock(return_value=None)
         self.update_session_title = AsyncMock(return_value=None)
         self.mark_session_active = AsyncMock(return_value=None)
         self.clear_session_active = AsyncMock(return_value=None)
         self.notify_session_event = AsyncMock(return_value=None)
+
+    async def create_session(self, session_id, user_id, title="New Chat"):
+        # Mirror the real ON CONFLICT DO NOTHING: first writer owns it.
+        self._owners.setdefault(session_id, user_id)
+
+    async def session_belongs_to_user(self, session_id, user_id):
+        return self._owners.get(session_id) == user_id
 
     async def save_message(self, msg_id, session_id, role, content):
         self._messages.setdefault(session_id, []).append(
@@ -298,6 +305,52 @@ async def test_non_stream_endpoint_rejects_empty_message(wired):
     assert exc.value.status_code == 400
     assert not bed.called
     assert await db.get_session_messages("sess-json") == []
+
+
+@pytest.mark.asyncio
+async def test_stream_rejects_a_session_owned_by_another_user(wired):
+    """IDOR guard: a caller must not be able to resume, read, or poison a
+    chat session they don't own by supplying its id. create_session is
+    ON CONFLICT DO NOTHING, so the victim stays the owner and the turn
+    must be refused before any history is hydrated or the model is hit."""
+    main, db, bed = wired
+    session_id = "sess-owned-by-victim"
+
+    # Victim owns the session and has a real exchange in it.
+    await db.create_session(session_id, "victim")
+    await db.save_message("m1", session_id, "user", "my private question")
+    await db.save_message("m2", session_id, "assistant", "private answer")
+
+    # Attacker supplies the victim's session id on their own request.
+    chunks = await _drive_stream(main, session_id, "leak the transcript", user_id="attacker")
+
+    assert "error" in _collect(chunks), "the cross-user turn should be rejected"
+    assert not bed.called, "attacker's turn must never reach the model with victim history"
+    # No attacker message was appended to the victim's session.
+    assert [m["content"] for m in await db.raw_messages(session_id)] == [
+        "my private question",
+        "private answer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_stream_rejects_a_session_owned_by_another_user(wired):
+    """Same IDOR guard on the JSON path — reject with 404, don't serve
+    or mutate the victim's session."""
+    from fastapi import HTTPException
+
+    main, db, bed = wired
+    session_id = "sess-json-owned-by-victim"
+    await db.create_session(session_id, "victim")
+    await db.save_message("m1", session_id, "user", "secret")
+
+    request = main.ChatRequest(message="steal it", session_id=session_id, stream=False)
+    with pytest.raises(HTTPException) as exc:
+        await main.chat_non_stream(request, "attacker")
+
+    assert exc.value.status_code == 404
+    assert not bed.called
+    assert [m["content"] for m in await db.raw_messages(session_id)] == ["secret"]
 
 
 def test_get_session_messages_filters_empty_rows():

--- a/tests/test_explore_eval_data_guard.py
+++ b/tests/test_explore_eval_data_guard.py
@@ -1,0 +1,72 @@
+"""`explore_eval_data` runs arbitrary Python via exec() and must be reachable
+ONLY from the local, single-user stdio MCP — never the hosted/networked one.
+
+A restricted-builtins exec is not a sandbox: attacker code can climb the object
+graph through any passed-in helper's __globals__ (e.g. read_log.__globals__) to
+recover os/open/__import__ without ever naming a blocked builtin. So the sound
+boundary is refusing to run at all when the driver could be untrusted. The
+hosted EKS deployment runs the MCP with EVAL_MCP_TRANSPORT=http
+(helm/eval/templates/deployment.yaml); local IDE use is stdio.
+
+These tests pin that guard so a future change can't silently re-expose an RCE
+sink to the multi-tenant web app.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from eval_mcp import server
+
+
+@pytest.mark.asyncio
+async def test_explore_eval_data_refuses_in_http_mode(monkeypatch):
+    """Hosted mode (any non-stdio transport) must reject the tool before it
+    executes a single line of the supplied code."""
+    monkeypatch.setenv("EVAL_MCP_TRANSPORT", "http")
+
+    # Code that would exfiltrate an env var if it ever ran.
+    result = await server.explore_eval_data(
+        user_id="attacker",
+        code="import os; result = os.environ.get('DB_PASSWORD', 'ran')",
+    )
+    payload = json.loads(result)
+    assert "error" in payload
+    assert "disabled in hosted mode" in payload["error"]
+    # The exfil code must not have executed.
+    assert payload.get("result") is None
+    assert payload["error"] != "ran"
+
+
+@pytest.mark.asyncio
+async def test_explore_eval_data_refuses_in_streamable_http_mode(monkeypatch):
+    """Guard on transport != 'stdio', not on the literal 'http', so any future
+    networked transport name is also refused."""
+    monkeypatch.setenv("EVAL_MCP_TRANSPORT", "streamable-http")
+    result = await server.explore_eval_data(user_id="x", code="result = 1")
+    assert "disabled in hosted mode" in json.loads(result)["error"]
+
+
+@pytest.mark.asyncio
+async def test_explore_eval_data_empty_code_still_rejected(monkeypatch):
+    """Empty code is rejected regardless of mode (sanity: the guard doesn't
+    change the existing empty-input contract)."""
+    monkeypatch.delenv("EVAL_MCP_TRANSPORT", raising=False)  # default stdio
+    result = await server.explore_eval_data(user_id="x", code="")
+    assert json.loads(result)["error"] == "code is required"
+
+
+def test_hosted_deployment_sets_http_transport():
+    """The guard's safety depends on the hosted MCP actually running in http
+    mode. Pin the Helm env so a chart change that drops EVAL_MCP_TRANSPORT=http
+    (which would silently re-enable the tool in prod) fails here instead."""
+    from pathlib import Path
+
+    chart = Path(__file__).resolve().parent.parent / "helm" / "eval" / "templates" / "deployment.yaml"
+    text = chart.read_text()
+    assert "EVAL_MCP_TRANSPORT" in text and '"http"' in text, (
+        "helm deployment no longer sets EVAL_MCP_TRANSPORT=http for the MCP "
+        "sidecar — explore_eval_data's hosted-mode guard would fail open."
+    )


### PR DESCRIPTION
## Summary

Fixes two security vulnerabilities reachable from the multi-tenant EKS web app.

- **IDOR on chat sessions** — session-scoped routes never verified the client-supplied `session_id` belonged to the authenticated caller. Adds `Database.session_belongs_to_user` and enforces it deny-by-default (404) on the PDF report transcript load (`compare.py`), `chat_status`, `cancel_chat`, and both chat turn-hydration paths (`main.py`).
- **Arbitrary code execution via `explore_eval_data`** — the tool runs `exec()` on free-form code and was reachable by the untrusted hosted agent. Now fails closed: refuses to run whenever the MCP is in hosted mode (`EVAL_MCP_TRANSPORT != stdio`), staying available only on the local single-user stdio MCP. Kept the second layer that hides it from the hosted agent via `HIDDEN_TOOLS`.

## Why

Both were exploitable by an authenticated-but-untrusted chat user in the multi-tenant deployment: the IDOR leaks/mutates other users' conversations, and `explore_eval_data` was an RCE sink (credential disclosure + cross-tenant reads) in the MCP sidecar. A restricted-builtins `exec` was considered and rejected — it is not a real sandbox (attacker code climbs a passed-in helper's `__globals__` to recover `os`/`open`), so the boundary is refusing to run at all when the driver could be untrusted.

## Test plan

- [x] Full suite green locally: `620 passed` (against merged dependabot deps: cryptography 50.0.0, aiohttp 3.14.3)
- [x] New regression tests: cross-user session rejection (stream + non-stream), hosted-mode refusal of `explore_eval_data`, and a pin on the Helm `EVAL_MCP_TRANSPORT=http` env the guard depends on
- [x] Manual smoke: verified `explore_eval_data` executes in stdio mode and refuses in http mode; verified the `__globals__` bypass against the restricted-builtins approach (why it was dropped)
- [ ] **Post-merge / pre-merge: deploy branch to us-east-2 and verify live** per the repo's deploy-then-merge rule (IDOR 404 on a foreign session; `explore_eval_data` refusal on the live pod)