### PR TITLE
fix(security): reject traversal ids in the JSON-store read paths

### DIFF
--- a/eval_mcp/core/user_storage.py
+++ b/eval_mcp/core/user_storage.py
@@ -244,6 +244,25 @@ def _generate_id(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:12]}"
 
 
+def _safe_store_id(kind: str, value: str) -> str:
+    """Reject a JSON-store record id that isn't a bare filename component.
+
+    The JSON-store readers build ``{store_dir}/{id}.json`` and hand it to
+    ``_load_json_file``, whose containment check is against the shared users
+    *base* dir — NOT the per-user dir. So an id like
+    ``../../victim/store/optimizations/opt-xyz`` still resolves under the base
+    and would read another tenant's record with no grant. Record ids are always
+    server-generated (`_generate_id`) or S3 keys where ``..`` doesn't normalize,
+    so a well-behaved caller never trips this; it exists to keep a
+    client-supplied id (e.g. the ``?id=`` query param on /detail routes) from
+    traversing on local-disk deployments. ``delete_*_from_db`` already enforces
+    the same invariant — this brings the read paths in line.
+    """
+    if not value or value in (".", "..") or os.path.basename(value) != value:
+        raise ValueError(f"invalid {kind}: {value!r}")
+    return value
+
+
 def _ensure_under_base(path: Path) -> Path:
     """Verify `path` stays within get_user_base_dir() using realpath+startswith."""
     base_real = os.path.realpath(str(get_user_base_dir()))
@@ -372,6 +391,7 @@ def save_judge_to_db(user_id: str, name: str, config: dict[str, Any]) -> str:
 
 
 def get_judge_from_db(user_id: str, judge_id: str) -> Optional[dict[str, Any]]:
+    judge_id = _safe_store_id("judge_id", judge_id)
     if _s3_enabled():
         data = _s3_load_json(user_id, "judges", f"{judge_id}.json")
     else:
@@ -544,6 +564,7 @@ def save_dataset_to_db(
 
 
 def get_dataset_from_db(user_id: str, dataset_id: str) -> Optional[dict[str, Any]]:
+    dataset_id = _safe_store_id("dataset_id", dataset_id)
     if _s3_enabled():
         data = _s3_load_json(user_id, "datasets", f"{dataset_id}.json")
     else:
@@ -688,6 +709,7 @@ def save_optimization_to_db(user_id: str, record: dict[str, Any]) -> str:
 def get_optimization_from_db(
     user_id: str, optimization_id: str
 ) -> Optional[dict[str, Any]]:
+    optimization_id = _safe_store_id("optimization_id", optimization_id)
     if _s3_enabled():
         data = _s3_load_json(user_id, "optimizations", f"{optimization_id}.json")
     else:

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -297,6 +297,37 @@ def test_delete_judge_rejects_path_traversal(client):
         us.delete_judge_from_db(USER, "../../etc/passwd")
 
 
+def test_read_paths_reject_cross_tenant_traversal(client, tmp_path):
+    """The JSON-store READERS must reject a traversal id, not just the delete
+    paths. _load_json_file's containment barrier is the shared users *base*,
+    so an id like '../../victim/store/optimizations/opt-x' resolves under the
+    base and — without this guard — reads another tenant's record with no
+    grant. Pin all three readers (optimization/dataset/judge)."""
+    import eval_mcp.core.user_storage as us
+    import json as _json
+    import pytest
+
+    # Seed a victim optimization record on disk.
+    victim_dir = us._get_json_store_dir("victim", "optimizations")
+    victim_dir.mkdir(parents=True, exist_ok=True)
+    (victim_dir / "opt-secret.json").write_text(_json.dumps({
+        "id": "opt-secret", "type": "optimization",
+        "winner_prompt": "TOP SECRET", "created_at": 1700000000000,
+    }))
+
+    # An attacker in their own namespace tries to climb into victim's dir.
+    traversal = "../../victim/store/optimizations/opt-secret"
+    with pytest.raises(ValueError, match="invalid optimization_id"):
+        us.get_optimization_from_db("attacker", traversal)
+    with pytest.raises(ValueError, match="invalid dataset_id"):
+        us.get_dataset_from_db("attacker", "../../victim/store/datasets/ds-x")
+    with pytest.raises(ValueError, match="invalid judge_id"):
+        us.get_judge_from_db("attacker", "../../victim/store/judges/j-x")
+
+    # A well-formed id still works (the guard doesn't break normal reads).
+    assert us.get_optimization_from_db("victim", "opt-secret")["winner_prompt"] == "TOP SECRET"
+
+
 def test_legacy_dataset_without_source_defaults_imported(client, tmp_path):
     """Records saved before provenance existed should still surface a source
     in API responses (defaulting to 'imported')."""


### PR DESCRIPTION
## Summary

Closes a cross-tenant path-traversal in the filesystem-backed JSON store. The readers `get_optimization_from_db` / `get_dataset_from_db` / `get_judge_from_db` passed a client-influenceable `id` into `_load_json_file`, whose containment check is the shared users **base** dir — not the per-user dir. An id like `../../victim/store/optimizations/opt-secret` (reachable via the non-slash-restricted `?id=` query param on `/api/optimizations/detail`) resolved under the base and returned another tenant's record **with no grant check**.

- Adds a shared `_safe_store_id()` guard (rejects `..`, `.`, absolute paths, any path separator) and applies it to all three readers.
- The sibling `delete_*_from_db` functions already enforced this; the read paths didn't — this removes that asymmetry.

## Why

Cross-tenant data disclosure with no authorization. **Exploitable on local-disk / self-host deployments**; **not** on production EKS (reads go through S3, where `../` doesn't normalize in a key). Fixing anyway because local/self-host is a supported, documented mode, and the read/delete asymmetry is a latent trap for future callers.

## Test plan

- [x] New regression test: all three readers reject `../../victim/...` traversal ids while a well-formed id still reads normally (`tests/test_data_api.py`)
- [x] Full suite green locally: `621 passed`
- [ ] Post-merge: covered by the production S3 path already; verify on the local-disk `make dev` stack if desired