### PR TITLE
feat(benchmarks): opt-in multi-judge jury for judge-scored bundled benchmarks

### DIFF
--- a/eval_mcp/benchmarks/aiwf/eval.yaml
+++ b/eval_mcp/benchmarks/aiwf/eval.yaml
@@ -42,6 +42,10 @@ metrics:
 judge:
   default: bedrock/us.anthropic.claude-opus-5
   overridable: true
+  # judge_models=[...] opts into a jury: each judge scores the full transcript
+  # independently, verdicts are majority-voted per turn per dimension (ties
+  # fail). Single judge stays the default — it's the upstream-faithful mode.
+  jury_supported: true
 
 source:
   repository_url: https://github.com/kwindla/aiewf-eval
@@ -59,3 +63,7 @@ caveats:
     max_turns caps the conversation for a cheap smoke run; those scores are NOT
     comparable to a full run, since the tool-call turns cluster late (11, 12,
     15, 17, 24, 29).
+  - >-
+    judge_models (jury mode) scores are NOT comparable to single-judge runs or
+    to upstream's published numbers — the jury is a different measuring
+    instrument. Hold the jury fixed when comparing target models.

--- a/eval_mcp/benchmarks/aiwf/task.py
+++ b/eval_mcp/benchmarks/aiwf/task.py
@@ -21,6 +21,7 @@ headline ``pass_rate = turn_pass / total_turns``, where a turn passes only if
 all three hold on that same turn.
 """
 
+import asyncio
 import json
 import os
 import re
@@ -451,6 +452,77 @@ def _extract_judgments(
     return by_turn, None
 
 
+def _split_judges(
+    judge_model: Optional[str], judge_models: Optional[Any]
+) -> List[str]:
+    """Normalize the two judge parameters into an ordered, deduped list.
+
+    ``judge_models`` wins when both are set (it's the superset form) and
+    accepts either a real list or a comma-separated string — the latter is how
+    it survives the ``-T judge_models=a,b`` CLI boundary, where Inspect parses
+    the value as one YAML scalar. Model ids never contain commas.
+    """
+    models: List[str] = []
+    if judge_models:
+        raw = (
+            judge_models.split(",")
+            if isinstance(judge_models, str)
+            else list(judge_models)
+        )
+        models = [str(m).strip() for m in raw if str(m).strip()]
+    elif judge_model:
+        models = [judge_model]
+    if not models:
+        models = [JUDGE_MODELS["claude"]]
+    seen = set()
+    deduped = []
+    for m in models:
+        if m not in seen:
+            seen.add(m)
+            deduped.append(m)
+    return deduped
+
+
+def _merge_judgments(
+    per_judge: Dict[str, Dict[int, Dict[str, Any]]],
+) -> tuple[Dict[int, Dict[str, Any]], Dict[int, Dict[str, str]]]:
+    """Majority-vote the per-judge verdicts into one judgment per turn.
+
+    A dimension passes a turn when STRICTLY more than half of the judges who
+    returned that turn said True — a tie fails, so an even jury is stricter,
+    not random. A turn counts as judged if at least one judge returned it;
+    judges that skipped it shrink that turn's denominator rather than voting
+    False, mirroring how the single-judge path excludes unjudged turns.
+
+    With one judge this is the identity (1/1 > 1/2), so the single-judge
+    fidelity path flows through unchanged. Returns ``(merged, votes)`` where
+    votes records the per-dimension tally (``"2/3"``) for the metadata.
+    """
+    merged: Dict[int, Dict[str, Any]] = {}
+    votes: Dict[int, Dict[str, str]] = {}
+    solo = len(per_judge) == 1
+    for turn in sorted({t for j in per_judge.values() for t in j}):
+        verdicts = {m: j[turn] for m, j in per_judge.items() if turn in j}
+        n = len(verdicts)
+        entry: Dict[str, Any] = {}
+        tally: Dict[str, str] = {}
+        for d in DIMENSIONS:
+            yes = sum(1 for v in verdicts.values() if v[d])
+            entry[d] = yes * 2 > n
+            tally[d] = f"{yes}/{n}"
+        if solo:
+            entry["reasoning"] = next(iter(verdicts.values()))["reasoning"]
+        else:
+            entry["reasoning"] = " | ".join(
+                f"{m}: {v['reasoning']}"
+                for m, v in verdicts.items()
+                if v.get("reasoning")
+            )
+        merged[turn] = entry
+        votes[turn] = tally
+    return merged, votes
+
+
 def _rate(numerator: int, denominator: int) -> float:
     return numerator / denominator if denominator else 0.0
 
@@ -532,13 +604,25 @@ def truncated_turns() -> Metric:
         truncated_turns(),
     ]
 )
-def aiwf_turn_judge(judge_model: Optional[str] = None):
-    """Judge the whole conversation in one call, score per turn.
+def aiwf_turn_judge(
+    judge_model: Optional[str] = None,
+    judge_models: Optional[Any] = None,
+):
+    """Judge the whole conversation, score per turn.
 
-    Single judge, not our usual jury: upstream uses one strong judge over the
-    full conversation, and the realignment logic depends on seeing every turn
-    together. Three jurors would each need the whole 30-turn transcript, and
-    majority-voting per turn would still not make the turns independent.
+    Default is a SINGLE judge, matching upstream: one strong judge over the
+    full conversation, whose realignment logic depends on seeing every turn
+    together. That stays the fidelity mode — its scores are the comparable
+    ones.
+
+    ``judge_models`` opts into a jury: each juror independently judges the
+    SAME verbatim prompt over the whole transcript (so each can realign), and
+    the per-turn, per-dimension verdicts are majority-voted (ties fail). This
+    trades upstream comparability for robustness to single-judge noise —
+    per-judge agreement lands in the score metadata so the disagreement is
+    visible, not averaged away. A judge that errors or returns unparseable
+    output is excluded from every vote (recorded in ``judge_errors``), not
+    counted as all-False.
     """
 
     async def score(state: TaskState, target: Target) -> Score:
@@ -551,40 +635,44 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
             )
 
         truncated = sum(1 for r in records if r.get("stop_reason") == "max_tokens")
-        model_id = judge_model or JUDGE_MODELS["claude"]
+        jury = _split_judges(judge_model, judge_models)
 
-        try:
-            judge = get_model(model_id)
-            output = await judge.generate(
-                [
-                    ChatMessageSystem(content=_JUDGE_SYSTEM_PROMPT),
-                    ChatMessageUser(content=_render_user_prompt(records)),
-                ],
-                tools=[_build_judgment_tool(len(records))],
-                tool_choice="any",
-            )
-        except Exception as e:  # judge failure is a measurement failure
+        messages = [
+            ChatMessageSystem(content=_JUDGE_SYSTEM_PROMPT),
+            ChatMessageUser(content=_render_user_prompt(records)),
+        ]
+        tools = [_build_judgment_tool(len(records))]
+
+        async def judge_one(model_id: str) -> tuple[str, Any, Optional[str]]:
+            try:
+                output = await get_model(model_id).generate(
+                    messages, tools=tools, tool_choice="any"
+                )
+            except Exception as e:
+                return model_id, None, f"judge_failed: {e}"
+            judgments, err = _extract_judgments(output, len(records))
+            if judgments is None:
+                return model_id, None, f"unparseable_judge_output: {err}"
+            return model_id, judgments, None
+
+        results = await asyncio.gather(*(judge_one(m) for m in jury))
+        per_judge = {m: j for m, j, err in results if j is not None}
+        judge_errors = {m: err for m, j, err in results if err is not None}
+
+        if not per_judge:  # every judge failed — a measurement failure
+            detail = "; ".join(f"{m}: {e}" for m, e in judge_errors.items())
             return Score(
                 value=0.0,
-                explanation=f"Judge call failed: {e}",
+                explanation=f"All {len(jury)} judge call(s) failed: {detail}",
                 metadata={
                     "turns_judged": 0,
                     "truncated_turns": truncated,
-                    "error": f"judge_failed: {e}",
+                    "error": f"judge_failed: {detail}",
+                    "judge_errors": judge_errors,
                 },
             )
 
-        judgments, err = _extract_judgments(output, len(records))
-        if judgments is None:
-            return Score(
-                value=0.0,
-                explanation=f"Could not parse judge output: {err}",
-                metadata={
-                    "turns_judged": 0,
-                    "truncated_turns": truncated,
-                    "error": f"unparseable_judge_output: {err}",
-                },
-            )
+        judgments, turn_votes = _merge_judgments(per_judge)
 
         # Only turns the judge actually returned count toward the denominator.
         # Silently scoring a skipped turn 0 would blame the model for the
@@ -600,18 +688,19 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
             turn_pass += int(passed)
             for d in DIMENSIONS:
                 counters[d] += int(j[d])
-            per_turn.append(
-                {
-                    "turn": r["turn"],
-                    **{d: j[d] for d in DIMENSIONS},
-                    "turn_pass": passed,
-                    "reasoning": j["reasoning"],
-                    "recovery_used": bool(r.get("recovery_used")),
-                    "tools_called": [c["name"] for c in (r.get("tool_calls") or [])],
-                    "expected_tool": (r.get("expected_function") or {}).get("name"),
-                    "response_seconds": r.get("response_seconds"),
-                }
-            )
+            entry = {
+                "turn": r["turn"],
+                **{d: j[d] for d in DIMENSIONS},
+                "turn_pass": passed,
+                "reasoning": j["reasoning"],
+                "recovery_used": bool(r.get("recovery_used")),
+                "tools_called": [c["name"] for c in (r.get("tool_calls") or [])],
+                "expected_tool": (r.get("expected_function") or {}).get("name"),
+                "response_seconds": r.get("response_seconds"),
+            }
+            if len(per_judge) > 1:
+                entry["votes"] = turn_votes.get(r["turn"], {})
+            per_turn.append(entry)
 
         judged = len(per_turn)
         unjudged = len(records) - judged
@@ -631,6 +720,20 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
             f"  instruction_following: {counters['instruction_following']}/{judged}",
             f"  kb_grounding:          {counters['kb_grounding']}/{judged}",
         ]
+        if len(jury) > 1:
+            lines += [
+                "",
+                f"Jury mode: {len(per_judge)} of {len(jury)} judges voted "
+                f"({', '.join(per_judge)}); per-dimension majority, ties fail. "
+                f"NOT comparable to single-judge (upstream-fidelity) runs.",
+            ]
+        if judge_errors:
+            lines += [
+                "",
+                f"WARNING: {len(judge_errors)} judge(s) failed and are excluded "
+                f"from every vote: "
+                + "; ".join(f"{m} ({e[:80]})" for m, e in judge_errors.items()),
+            ]
         recoveries = sum(1 for t in per_turn if t["recovery_used"])
         if recoveries:
             lines += [
@@ -686,7 +789,10 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
                 "truncated_turns": truncated,
                 "median_response_seconds": median_seconds,
                 "recoveries_used": recoveries,
-                "judge_model": model_id,
+                "judge_model": jury[0] if len(jury) == 1 else None,
+                "judge_models": jury,
+                "jury_mode": len(jury) > 1,
+                **({"judge_errors": judge_errors} if judge_errors else {}),
                 "task_version": TASK_VERSION,
                 "turn_cap": cap,
                 **counters,
@@ -697,7 +803,11 @@ def aiwf_turn_judge(judge_model: Optional[str] = None):
     return score
 
 
-def _aiwf_task(variant: str, judge_model: Optional[str]) -> Task:
+def _aiwf_task(
+    variant: str,
+    judge_model: Optional[str],
+    judge_models: Optional[Any] = None,
+) -> Task:
     n_turns = len(turns())
     return Task(
         name=variant,
@@ -712,21 +822,27 @@ def _aiwf_task(variant: str, judge_model: Optional[str]) -> Task:
             )
         ],
         solver=[aiwf_conversation(variant)],
-        scorer=aiwf_turn_judge(judge_model),
+        scorer=aiwf_turn_judge(judge_model, judge_models),
         version=TASK_VERSION,
     )
 
 
 @task
-def aiwf_medium_context(judge_model: Optional[str] = None) -> Task:
+def aiwf_medium_context(
+    judge_model: Optional[str] = None,
+    judge_models: Optional[str] = None,
+) -> Task:
     """30-turn conference-assistant conversation, ~12K-token knowledge base."""
-    return _aiwf_task("aiwf_medium_context", judge_model)
+    return _aiwf_task("aiwf_medium_context", judge_model, judge_models)
 
 
 @task
-def aiwf_long_context(judge_model: Optional[str] = None) -> Task:
+def aiwf_long_context(
+    judge_model: Optional[str] = None,
+    judge_models: Optional[str] = None,
+) -> Task:
     """30-turn conference-assistant conversation, ~40K-token knowledge base."""
-    return _aiwf_task("aiwf_long_context", judge_model)
+    return _aiwf_task("aiwf_long_context", judge_model, judge_models)
 
 
 # Names exposed by run_multiturn_benchmark. Keys match the @task function names.

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -1239,6 +1239,7 @@ async def run_benchmark(
     limit: int = None,
     task_args: dict = None,
     judge_model: str = None,
+    judge_models: list = None,
     max_turns: int = None,
     user_id: str = None,
 ) -> str:
@@ -1269,6 +1270,12 @@ async def run_benchmark(
         judge_model: Judge override for judge-scored bundled benchmarks. Hold it
             fixed when comparing target models — the judge is part of the
             measurement.
+        judge_models: Opt into a multi-judge jury for judge-scored bundled
+            benchmarks: each judge scores the whole transcript independently
+            and verdicts are majority-voted per turn (ties fail). Mutually
+            exclusive with judge_model. Jury scores are NOT comparable to
+            single-judge (upstream-fidelity) runs — hold the jury fixed when
+            comparing target models.
         max_turns: Cap the conversation for a cheap smoke run of a multi-turn
             bundled benchmark. Those scores are NOT comparable to a full run.
 
@@ -1281,6 +1288,7 @@ async def run_benchmark(
         "limit": limit,
         "task_args": task_args,
         "judge_model": judge_model,
+        "judge_models": judge_models,
         "max_turns": max_turns,
         "user_id": _user(user_id),
     }

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -390,6 +390,23 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
 
             return await handle_run_multiturn_benchmark(args)
 
+        # These knobs only exist on the bundled (judge-scored) benchmarks.
+        # Silently ignoring them on the inspect_evals branch would let a caller
+        # believe a judge override took effect when it didn't — reject instead.
+        unsupported = [
+            k for k in ("judge_model", "judge_models", "max_turns") if args.get(k)
+        ]
+        if unsupported:
+            return [TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    f"{', '.join(unsupported)} only apply to bundled judge-scored "
+                    f"benchmarks; '{task}' is an inspect_evals task, which brings "
+                    f"its own scorer. Drop the parameter(s), or pass scorer "
+                    f"options via task_args if the benchmark exposes them."
+                ),
+            }))]
+
         # Resolve id-or-task → runnable task name, and pick up its flags.
         try:
             evals = _load_evals()

--- a/eval_mcp/tools/multiturn_benchmarks.py
+++ b/eval_mcp/tools/multiturn_benchmarks.py
@@ -61,7 +61,8 @@ async def handle_list_multiturn_benchmarks(args: Dict[str, Any]) -> List[TextCon
                         "hint": (
                             "run_benchmark(task=<task name>, providers=[...]). "
                             "Pass max_turns for a cheap smoke run, judge_model to "
-                            "override the judge. These need no HuggingFace "
+                            "override the judge, or judge_models=[...] for a "
+                            "majority-vote jury. These need no HuggingFace "
                             "download, optional extra or sandbox."
                         ),
                     },
@@ -88,7 +89,19 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
         task = args.get("task")
         providers = args.get("providers") or []
         judge_model = args.get("judge_model")
+        judge_models = args.get("judge_models") or []
         max_turns = args.get("max_turns")
+
+        if isinstance(judge_models, str):
+            judge_models = [m.strip() for m in judge_models.split(",") if m.strip()]
+        if judge_model and judge_models:
+            return [
+                _err(
+                    "Pass judge_model (single judge, upstream-comparable) OR "
+                    "judge_models (jury, majority vote) — not both.",
+                    eval_id,
+                )
+            ]
 
         if not user_id:
             return [_err("user_id is required", eval_id)]
@@ -127,9 +140,17 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
 
         # Fail fast on an unusable model rather than 30 turns deep. Same gate
         # run_evaluation uses, so the error text is identical and actionable.
-        if any(p.startswith(("bedrock/", "openai/bedrock/")) for p in providers):
+        # Judges are validated too: a typo'd judge otherwise surfaces only
+        # AFTER the full conversation has been generated and paid for, as a
+        # 0-score with judge_failed metadata.
+        to_validate = list(providers) + [
+            j
+            for j in ([judge_model] if judge_model else judge_models)
+            if j and j not in providers
+        ]
+        if any(p.startswith(("bedrock/", "openai/bedrock/")) for p in to_validate):
             raise_if_autodetect_error()
-            validation = await _validate_providers(providers)
+            validation = await _validate_providers(to_validate)
             if not validation.get("valid"):
                 return [
                     TextContent(
@@ -183,6 +204,10 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
         # completions from reasoning models.
         if judge_model:
             cmd.extend(["-T", f"judge_model={judge_model}"])
+        elif judge_models:
+            # Comma-joined: -T passes one scalar; the task splits it back.
+            # Model ids never contain commas.
+            cmd.extend(["-T", f"judge_models={','.join(judge_models)}"])
 
         process = await asyncio.create_subprocess_exec(
             *cmd,

--- a/tests/test_aiwf_benchmark.py
+++ b/tests/test_aiwf_benchmark.py
@@ -500,3 +500,115 @@ def test_turns_json_is_valid_and_has_no_audio_references():
     assert all("audio_file" not in t for t in raw)
     assert all(set(t) == {"index", "input", "golden_text", "required_function_call"}
                for t in raw)
+
+
+# --- Jury mode (judge_models) ---------------------------------------------
+#
+# Single judge stays the default and the upstream-faithful mode; the jury is
+# opt-in. These pin the deterministic half: parameter normalization and the
+# per-turn, per-dimension majority vote.
+
+from eval_mcp.benchmarks.aiwf.task import _merge_judgments, _split_judges
+
+
+def _verdict(tool=True, instr=True, kb=True, reasoning=""):
+    return {
+        "tool_use_correct": tool,
+        "instruction_following": instr,
+        "kb_grounding": kb,
+        "reasoning": reasoning,
+    }
+
+
+def test_split_judges_defaults_to_the_claude_judge():
+    from eval_mcp.core.judge_config import JUDGE_MODELS
+
+    assert _split_judges(None, None) == [JUDGE_MODELS["claude"]]
+
+
+def test_split_judges_single_judge_passthrough():
+    assert _split_judges("bedrock/j1", None) == ["bedrock/j1"]
+
+
+def test_split_judges_list_wins_over_single():
+    assert _split_judges("bedrock/j1", ["bedrock/a", "bedrock/b"]) == [
+        "bedrock/a",
+        "bedrock/b",
+    ]
+
+
+def test_split_judges_parses_the_comma_scalar_from_the_cli_boundary():
+    # -T judge_models=a,b arrives as ONE string; the task splits it back.
+    assert _split_judges(None, "bedrock/a, bedrock/b") == [
+        "bedrock/a",
+        "bedrock/b",
+    ]
+
+
+def test_split_judges_dedupes_preserving_order():
+    assert _split_judges(None, ["b", "a", "b"]) == ["b", "a"]
+
+
+def test_merge_single_judge_is_the_identity():
+    merged, votes = _merge_judgments(
+        {"j1": {0: _verdict(kb=False, reasoning="kb wrong")}}
+    )
+    assert merged[0]["kb_grounding"] is False
+    assert merged[0]["tool_use_correct"] is True
+    assert merged[0]["reasoning"] == "kb wrong"  # no judge prefix when solo
+    assert votes[0]["kb_grounding"] == "0/1"
+
+
+def test_merge_majority_vote_per_dimension():
+    merged, votes = _merge_judgments(
+        {
+            "j1": {0: _verdict(tool=True, instr=False)},
+            "j2": {0: _verdict(tool=True, instr=True)},
+            "j3": {0: _verdict(tool=False, instr=False)},
+        }
+    )
+    assert merged[0]["tool_use_correct"] is True  # 2/3
+    assert merged[0]["instruction_following"] is False  # 1/3
+    assert votes[0]["tool_use_correct"] == "2/3"
+
+
+def test_merge_tie_fails():
+    merged, _ = _merge_judgments(
+        {
+            "j1": {0: _verdict(kb=True)},
+            "j2": {0: _verdict(kb=False)},
+        }
+    )
+    assert merged[0]["kb_grounding"] is False
+
+
+def test_merge_a_turn_skipped_by_one_judge_uses_the_smaller_denominator():
+    # j2 never returned turn 1: it must not count as a False vote there.
+    merged, votes = _merge_judgments(
+        {
+            "j1": {0: _verdict(), 1: _verdict(kb=True)},
+            "j2": {0: _verdict()},
+        }
+    )
+    assert merged[1]["kb_grounding"] is True  # 1/1, not 1/2
+    assert votes[1]["kb_grounding"] == "1/1"
+
+
+def test_merge_jury_reasoning_is_attributed_per_judge():
+    merged, _ = _merge_judgments(
+        {
+            "j1": {0: _verdict(reasoning="fine")},
+            "j2": {0: _verdict(reasoning="also fine")},
+        }
+    )
+    assert "j1: fine" in merged[0]["reasoning"]
+    assert "j2: also fine" in merged[0]["reasoning"]
+
+
+def test_task_signature_accepts_judge_models():
+    import inspect as _inspect
+
+    for factory in (aiwf_medium_context, aiwf_long_context):
+        params = _inspect.signature(factory).parameters
+        assert "judge_models" in params
+        assert params["judge_models"].default is None

--- a/tests/test_multiturn_benchmark_runner.py
+++ b/tests/test_multiturn_benchmark_runner.py
@@ -1,0 +1,168 @@
+"""Runner-level tests for the bundled multi-turn benchmark tool.
+
+Scope per CLAUDE.md: deterministic plumbing only — argument validation, the
+judge fail-fast gate, and what lands on the launched inspect command line. The
+subprocess and provider validation are intercepted; whether a jury actually
+judges well is verified by running the benchmark for real.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from eval_mcp.tools import multiturn_benchmarks as mt
+
+
+def _fake_exec(captured):
+    async def fake(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.wait = AsyncMock(return_value=0)
+        proc.pid = 4242
+        return proc
+
+    return fake
+
+
+async def _run(args, captured, validated=None):
+    async def fake_validate(providers):
+        if validated is not None:
+            validated.extend(providers)
+        return {"valid": True}
+
+    with patch.object(mt, "raise_if_autodetect_error", lambda: None), \
+         patch.object(mt, "_validate_providers", side_effect=fake_validate), \
+         patch.object(mt, "_refresh_keys_from_file", lambda: None), \
+         patch.object(mt.asyncio, "create_subprocess_exec",
+                      side_effect=_fake_exec(captured)):
+        out = await mt.handle_run_multiturn_benchmark(
+            {"task": "aiwf_medium_context", "user_id": "t", **args}
+        )
+    return json.loads(out[0].text)
+
+
+@pytest.mark.asyncio
+async def test_judge_models_lands_as_a_comma_joined_task_arg():
+    captured = {}
+    res = await _run(
+        {"providers": ["bedrock/x"],
+         "judge_models": ["bedrock/j1", "bedrock/j2"]},
+        captured,
+    )
+    assert res["success"], res
+    cmd = captured["cmd"]
+    assert "judge_models=bedrock/j1,bedrock/j2" in cmd
+    assert not any(c.startswith("judge_model=") for c in cmd)
+
+
+@pytest.mark.asyncio
+async def test_judge_models_accepts_a_comma_separated_string():
+    captured = {}
+    res = await _run(
+        {"providers": ["bedrock/x"], "judge_models": "bedrock/j1, bedrock/j2"},
+        captured,
+    )
+    assert res["success"], res
+    assert "judge_models=bedrock/j1,bedrock/j2" in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_single_judge_model_still_lands_as_its_own_task_arg():
+    captured = {}
+    res = await _run(
+        {"providers": ["bedrock/x"], "judge_model": "bedrock/j1"}, captured
+    )
+    assert res["success"], res
+    assert "judge_model=bedrock/j1" in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_judge_model_and_judge_models_are_mutually_exclusive():
+    captured = {}
+    res = await _run(
+        {"providers": ["bedrock/x"], "judge_model": "bedrock/j1",
+         "judge_models": ["bedrock/j2"]},
+        captured,
+    )
+    assert not res["success"]
+    assert "not both" in res["error"]
+    assert "cmd" not in captured  # rejected before any launch
+
+
+@pytest.mark.asyncio
+async def test_judges_are_validated_alongside_targets():
+    """A typo'd judge must fail BEFORE the 30-turn conversation is paid for."""
+    captured = {}
+    validated = []
+    res = await _run(
+        {"providers": ["bedrock/x"],
+         "judge_models": ["bedrock/j1", "bedrock/j2"]},
+        captured,
+        validated=validated,
+    )
+    assert res["success"], res
+    assert set(validated) == {"bedrock/x", "bedrock/j1", "bedrock/j2"}
+
+
+@pytest.mark.asyncio
+async def test_judge_validation_failure_blocks_the_run():
+    async def fail_validate(providers):
+        return {"valid": False, "failed_providers": [
+            {"provider": "bedrock/typo", "error": "no such model"}]}
+
+    captured = {}
+    with patch.object(mt, "raise_if_autodetect_error", lambda: None), \
+         patch.object(mt, "_validate_providers", side_effect=fail_validate), \
+         patch.object(mt.asyncio, "create_subprocess_exec",
+                      side_effect=_fake_exec(captured)):
+        out = await mt.handle_run_multiturn_benchmark({
+            "task": "aiwf_medium_context", "user_id": "t",
+            "providers": ["bedrock/x"], "judge_model": "bedrock/typo",
+        })
+    res = json.loads(out[0].text)
+    assert not res["success"]
+    assert "cmd" not in captured
+
+
+@pytest.mark.asyncio
+async def test_inspect_evals_branch_rejects_judge_params_loudly():
+    """judge_model/judge_models/max_turns silently ignored on an inspect_evals
+    task would let a caller believe an override took effect — must error."""
+    from eval_mcp.tools import benchmarks as bm
+
+    class _Task:
+        def __init__(self, name):
+            self.name = name
+            self.dataset_samples = None
+
+    class _Entry:
+        def __init__(self, id, tasks):
+            self.id = id
+            self.title = self.description = ""
+            self.group = "Mathematics"
+            self.tasks = tasks
+            self.dependency = self.dependency_group = None
+            self.isolated = False
+            self.external_assets = []
+            self.arxiv = None
+
+        def model_dump(self):
+            return {"isolated": False, "runtime_metadata": None}
+
+    g = _Entry("gsm8k", tasks=[_Task("gsm8k")])
+    for key, value in (
+        ("judge_model", "bedrock/j1"),
+        ("judge_models", ["bedrock/j1", "bedrock/j2"]),
+        ("max_turns", 5),
+    ):
+        with patch.object(bm, "_load_evals", return_value=[g]):
+            out = await bm.handle_run_benchmark({
+                "task": "gsm8k", "user_id": "t",
+                "providers": ["bedrock/x"], key: value,
+            })
+        res = json.loads(out[0].text)
+        assert not res["success"], key
+        assert key in res["error"], res["error"]


### PR DESCRIPTION
## What

`run_benchmark` now accepts `judge_models=[...]` for judge-scored bundled benchmarks (currently aiwf): each judge independently scores the **whole transcript with the verbatim upstream prompt** (preserving the realignment logic that needs all 30 turns in one call), and per-turn per-dimension verdicts are **majority-voted, ties fail**. A judge that errors or returns unparseable output is excluded from every vote (recorded in `judge_errors`), not counted as all-False.

**Single judge stays the default** — it is the upstream-fidelity mode; jury scores are flagged as not comparable to it (explanation banner + `eval.yaml` caveat).

Also fixes two gaps from review:
- Judge models now go through the same fail-fast Converse/Mantle smoke test as targets — a typo'd judge fails before the 30-turn conversation is paid for, not after.
- `judge_model` / `judge_models` / `max_turns` passed to an `inspect_evals` task now error loudly instead of being silently ignored.

Custom evals (`run_evaluation`) already supported `judge_models` juries; this brings benchmarks to parity without touching that path. The two jury implementations are deliberately separate: different unit (turn vs sample), different prompt ownership (upstream's verbatim rubric vs ours), different aggregation (boolean majority vs averaged fractions).

## Verification

- 632 tests pass (18 new: vote-merge semantics incl. ties/skips/dedup, CLI plumbing, mutual exclusion, judge validation, loud rejection). `tests/test_mcp_eval.py` collection error pre-exists on main.
- Live Bedrock smoke runs: haiku+nova jury and nova solo (`max_turns=3`) — jury_mode, votes, explanations all land in the log.
- **Full-scale live run**: 5 parallel repeats × 2 targets (Haiku 4.5, GPT-5.6 Luna) × all 30 turns, judged by an Opus 5 + GPT-5.6 Sol jury — 10/10 conversations succeeded, both judge families voted on every verdict (900 total), zero judge errors. Cross-family judge agreement measured at 96–97%, splits concentrated in `instruction_following` (the subjective dimension), none in factual grounding beyond 1.7%.