### PR TITLE
docs(examples): model-comparison harness + Luna-vs-4o-mini results

### DIFF
--- a/examples/model_comparison/README.md
+++ b/examples/model_comparison/README.md
@@ -1,0 +1,27 @@
+# Model comparison examples
+
+Scripts for comparing two target models on the bundled **aiwf** multi-turn
+benchmark, with repeats and a paired significance test — plus a streaming TTFT
+latency probe. Thin drivers over the shipped `run_multiturn_benchmark` handler;
+they add repetition and arithmetic, not new measurement.
+
+| File | What it does |
+|---|---|
+| `compare_models.py` | Runs two models through the same conversation N times (single judge or `--jury`), reports per-model pass_rate mean/std, per-dimension counters, latency, and a paired t-test. |
+| `ttft_probe.py` | Streams both providers and times the first token — true TTFT, which the benchmark (non-streaming) can't measure. |
+| `RESULTS.md` | A worked run: GPT-5.6 Luna (Bedrock) vs GPT-4o-mini (OpenAI), single-judge + jury + TTFT, with how to read it and what not to conclude. |
+
+## Auth
+
+- **Bedrock / Mantle** models (`bedrock/*`, `openai/bedrock/*`): ambient AWS
+  credentials, and `AWS_REGION` (defaults to `us-east-2`).
+- **OpenAI** models (`openai/gpt-*`): `OPENAI_API_KEY` in the environment. These
+  scripts read only the env var — nothing is written to disk — so a temporary
+  key can be used and revoked afterward.
+
+## Caveats worth reading before trusting numbers
+
+- Quality comparisons are fair (identical conversation, fixed judge). Latency is
+  a **platform** comparison (different network paths), not model-isolated.
+- Small samples: a paired t-test assumes ~Normal differences; at ~10 repeats
+  treat `p` as a guide. `RESULTS.md` spells out the full set of caveats.

--- a/examples/model_comparison/RESULTS.md
+++ b/examples/model_comparison/RESULTS.md
@@ -1,0 +1,163 @@
+# GPT-5.6 Luna (Bedrock) vs GPT-4o-mini (OpenAI) — aiwf comparison
+
+A worked comparison of two target models on the bundled **aiwf** 30-turn
+multi-turn benchmark, produced with the scripts in this directory. It doubles as
+a reference for how to read the benchmark's outputs (pass_rate, per-dimension
+counters, latency) and how far you can trust a small-sample model comparison.
+
+**Reproduce:**
+
+```bash
+# quality, single fixed judge (10 repeats)
+OPENAI_API_KEY=sk-... AWS_REGION=us-east-2 python compare_models.py \
+  --models openai/bedrock/gpt-5.6-luna openai/gpt-4o-mini \
+  --repeats 10 --judge bedrock/us.anthropic.claude-opus-5 --user-prefix cmp10
+
+# quality, jury (Opus 5 + GPT-5.6 Sol, majority vote)
+OPENAI_API_KEY=sk-... AWS_REGION=us-east-2 python compare_models.py \
+  --models openai/bedrock/gpt-5.6-luna openai/gpt-4o-mini \
+  --repeats 10 --jury \
+  --judge bedrock/us.anthropic.claude-opus-5 openai/bedrock/gpt-5.6-sol \
+  --user-prefix cmpjury
+
+# latency (true TTFT, streaming)
+OPENAI_API_KEY=sk-... AWS_REGION=us-east-2 python ttft_probe.py
+```
+
+The numbers below are from one measured session (dates/machine noted per
+section). They are illustrative — rerun for current figures; model behaviour and
+network conditions drift.
+
+---
+
+## 1. Quality — single fixed judge (Opus 5), 10 repeats
+
+Both models saw the identical 30-turn conversation each repeat; the same single
+judge (`claude-opus-5`) graded both. Per-repeat `pass_rate`:
+
+| rep | Luna | mini |
+|----:|-----:|-----:|
+| 1 | 1.000 | 0.867 |
+| 2 | 0.867 | 0.833 |
+| 3 | 0.833 | 0.867 |
+| 4 | 0.900 | 0.833 |
+| 5 | 0.867 | 0.800 |
+| 6 | 0.933 | 0.833 |
+| 7 | 0.867 | 0.867 |
+| 8 | 0.900 | 0.867 |
+| 9 | 1.000 | 0.833 |
+| 10 | 0.800 | 0.867 |
+
+| metric | GPT-5.6 Luna | GPT-4o-mini |
+|---|---|---|
+| pass_rate mean | **0.897** | 0.847 |
+| pass_rate std | 0.066 | **0.023** |
+| range | 0.800 – 1.000 | 0.800 – 0.867 |
+| tool_use_correct | 27.3 / 30 | 26.8 / 30 |
+| instruction_following | 26.9 / 30 | 25.8 / 30 |
+| kb_grounding | 30.0 / 30 | 29.6 / 30 |
+| median latency* | 0.99 s | 1.89 s |
+| recovery nudges (mean) | 2.0 | 3.2 |
+| truncated / unjudged turns | 0 / 0 | 0 / 0 |
+
+**Paired difference (Luna − mini):** mean **+0.050**, sd 0.072, t = 2.18, df = 9,
+two-sided **p = 0.0571**.
+
+\* Benchmark latency is total generate time (non-streaming), an upper bound on
+TTFT — see §3 for the real TTFT measurement.
+
+---
+
+## 2. Quality — jury (Opus 5 + GPT-5.6 Sol), 9 repeats
+
+Same setup, but a two-judge majority-vote jury. **Jury scores are NOT comparable
+to the single-judge numbers in §1** (a different, slightly more lenient measuring
+instrument); only the *gap between the two target models* carries across.
+
+One repeat (rep 2) aborted before running: GPT-5.6 Sol hit a transient Mantle
+validation error, and the fail-fast judge check (added so a bad judge doesn't
+cost a full 30-turn run) correctly stopped that repeat. 9 of 10 completed.
+
+Per-repeat `pass_rate`:
+
+| rep | Luna | mini |
+|----:|-----:|-----:|
+| 1 | 0.933 | 0.900 |
+| 3 | 0.967 | 0.900 |
+| 4 | 0.867 | 0.900 |
+| 5 | 0.967 | 0.867 |
+| 6 | 0.967 | 0.867 |
+| 7 | 1.000 | 0.833 |
+| 8 | 1.000 | 0.833 |
+| 9 | 0.833 | 0.900 |
+| 10 | 1.000 | 0.900 |
+
+| metric | GPT-5.6 Luna | GPT-4o-mini |
+|---|---|---|
+| pass_rate mean | **0.948** | 0.878 |
+| pass_rate std | 0.060 | **0.029** |
+| range | 0.833 – 1.000 | 0.833 – 0.900 |
+| tool_use_correct | 28.7 / 30 | 27.6 / 30 |
+| instruction_following | 28.4 / 30 | 26.6 / 30 |
+| kb_grounding | 30.0 / 30 | 29.7 / 30 |
+| median latency | 1.15 s | 1.87 s |
+| recovery nudges (mean) | 1.0 | 2.4 |
+
+**Paired difference (Luna − mini):** mean **+0.070**, sd 0.081, t = 2.61, df = 8,
+two-sided **p = 0.0309**.
+
+The jury tightened the measurement (two judges agreeing → less noise), moving the
+same-signed gap from borderline (p ≈ 0.057) to significant at the 5% level
+(p ≈ 0.031). The effect is *real but modest* (~5–7 points); significance is not
+magnitude.
+
+---
+
+## 3. Latency — true TTFT, streaming, 12 trials (separate probe)
+
+Measured with `ttft_probe.py`, which streams both providers and times the first
+content token — the responsiveness a user actually perceives, which the
+benchmark's non-streaming column cannot capture. Run in `us-west-2` (this
+session's ambient region — a *different* region from §1–2, so treat as its own
+experiment; only the ranking should be compared across sections).
+
+| metric | GPT-5.6 Luna (Bedrock Mantle) | GPT-4o-mini (OpenAI public) |
+|---|---|---|
+| TTFT p50 | **0.446 s** | 0.638 s |
+| TTFT p95 | 0.669 s | 0.897 s |
+| TTFT mean | 0.457 s | 0.691 s |
+| Total p50 | **0.673 s** | 1.306 s |
+| Total p95 | 1.122 s | 1.580 s |
+
+Luna is ~30 % quicker to first token and ~2× quicker to full completion, and
+tighter at the p95. The total-time ranking agrees with the benchmark's latency
+column in §1–2, cross-validating both measurements.
+
+---
+
+## How to read this (and what NOT to conclude)
+
+- **Quality comparison is fair.** Byte-identical conversation, same judge/jury,
+  provider/network irrelevant to correctness. Luna's ~5–7 point edge is real but
+  modest; **GPT-4o-mini is the more *consistent* model** (lower std in both
+  experiments) and is far cheaper — the value pick if its ~0.85–0.88 clears your
+  bar.
+- **Latency is a PLATFORM comparison, not a model-isolated one.** The two models
+  are reached over different network paths (AWS endpoint vs OpenAI's public API
+  from this machine). The result — "Bedrock/Luna as I'd call it is faster than
+  OpenAI/mini as I'd call it" — is a real, decision-relevant thing to know, but
+  is not "Luna the model is intrinsically faster." Part of the edge is AWS
+  proximity.
+- **`p` is not the probability the models are equal.** It is the probability of
+  seeing a gap this large *if they were equal* — small `p` means "unlikely to be
+  luck," nothing about effect size.
+- **Small sample.** 9–10 repeats, one workload, one machine, one time window. The
+  paired t-test assumes ~Normal differences; at this n a Wilcoxon signed-rank
+  test (symmetry only) is a more robust cross-check. `truncated`/`unjudged` were
+  0 across all runs, so no token-ceiling or judge-omission artifacts polluted the
+  data.
+
+**Bottom line for this workload:** Bedrock/Luna is faster (clearly, both TTFT and
+total) and modestly higher-quality (probably — significant under the jury);
+OpenAI/GPT-4o-mini is more consistent run-to-run and cheaper. Pick on cost vs the
+quality/latency edge, not on a single headline number.

--- a/examples/model_comparison/compare_models.py
+++ b/examples/model_comparison/compare_models.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Compare two target models on the aiwf benchmark, repeated N times.
+
+Runs both models through the SAME 30-turn conversation each repeat (so they
+face identical inputs) and scores them with a fixed judge or jury. Reports
+per-model pass_rate mean/std, per-dimension breakdown, the benchmark's latency
+column, and a paired t-test on the per-repeat difference.
+
+This is a thin driver over the shipped `run_multiturn_benchmark` handler — it
+adds nothing to the measurement, it just repeats it and does the arithmetic.
+For a quality comparison of two *target* models, hold the judge fixed (default:
+a single Opus 5 judge); pass --jury to use a majority-vote panel instead (the
+scores are then not comparable to single-judge runs — see the benchmark's
+eval.yaml caveats).
+
+Auth:
+  - Bedrock / Mantle models (bedrock/*, openai/bedrock/*): ambient AWS creds.
+  - OpenAI models (openai/gpt-*): set OPENAI_API_KEY in the environment. The
+    repo also reads it from ~/.eval-mcp/.env.keys; this script only reads the
+    env var, so a temporary key can be passed without persisting it.
+
+Example:
+  OPENAI_API_KEY=sk-... AWS_REGION=us-east-2 \
+    python compare_models.py \
+      --models openai/bedrock/gpt-5.6-luna openai/gpt-4o-mini \
+      --repeats 10 --judge bedrock/us.anthropic.claude-opus-5
+"""
+import argparse
+import asyncio
+import glob
+import json
+import math
+import os
+import statistics
+from collections import defaultdict
+
+DIMS = ("tool_use_correct", "instruction_following", "kb_grounding")
+
+
+def _paired_t_pvalue(diffs):
+    """Two-sided paired t-test p-value via the Student-t tail integral.
+
+    Kept dependency-free (no scipy): integrates the t density directly, which
+    is the definition of the p-value and needs no special-function library.
+    Assumes the differences are ~Normal; at small n prefer this as a guide, not
+    gospel (a Wilcoxon signed-rank test assumes only symmetry).
+    """
+    n = len(diffs)
+    if n < 2:
+        return None
+    mean = statistics.mean(diffs)
+    sd = statistics.stdev(diffs)
+    if sd == 0:
+        return {"mean": mean, "sd": 0.0, "t": math.inf, "df": n - 1, "p": 0.0}
+    se = sd / math.sqrt(n)
+    t = mean / se
+    nu = n - 1
+
+    def density(x):
+        c = math.gamma((nu + 1) / 2) / (math.sqrt(nu * math.pi) * math.gamma(nu / 2))
+        return c * (1 + x * x / nu) ** (-(nu + 1) / 2)
+
+    # two-sided p = 2 * integral_{|t|}^inf f(x) dx, Simpson's rule
+    lo, hi, steps = abs(t), abs(t) + 80, 200_000
+    h = (hi - lo) / steps
+    s = density(lo) + density(hi)
+    for i in range(1, steps):
+        s += (4 if i % 2 else 2) * density(lo + i * h)
+    p = 2 * s * h / 3
+    return {"mean": mean, "sd": sd, "se": se, "t": t, "df": nu, "p": min(1.0, p)}
+
+
+async def _run_one(rep, models, judge, jury, user_prefix, region):
+    from eval_mcp.tools.multiturn_benchmarks import handle_run_multiturn_benchmark
+
+    args = {
+        "task": "aiwf_medium_context",
+        "user_id": f"{user_prefix}-rep{rep}",
+        "providers": models,
+    }
+    if jury:
+        args["judge_models"] = judge if isinstance(judge, list) else [judge]
+    else:
+        args["judge_model"] = judge[0] if isinstance(judge, list) else judge
+    out = await handle_run_multiturn_benchmark(args)
+    res = json.loads(out[0].text)
+    print(f"  rep{rep}: success={res.get('success')} {res.get('error', '')[:120]}", flush=True)
+    return res
+
+
+def _read_results(user_prefix):
+    """Pull per-model, per-rep metrics from the eval logs on disk."""
+    from inspect_ai.log import read_eval_log  # sync read is fine post-hoc
+
+    bases = [".smoke/users", os.path.expanduser("~/.eval-mcp/users"), "backend/users"]
+    data = defaultdict(dict)
+    for base in bases:
+        for rep_dir in sorted(glob.glob(f"{base}/{user_prefix}-rep*/logs")):
+            rep = int(rep_dir.split(f"{user_prefix}-rep")[1].split("/")[0])
+            for path in sorted(glob.glob(rep_dir + "/*.eval"), key=os.path.getmtime):
+                log = read_eval_log(path)
+                model = log.eval.model.split("/")[-1]
+                for s in (log.samples or []):
+                    sc = s.scores.get("aiwf_turn_judge")
+                    if not sc:
+                        continue
+                    md = sc.metadata
+                    data[model][rep] = {
+                        "pass_rate": sc.value,
+                        **{d: md.get(d) for d in DIMS},
+                        "median_latency": md.get("median_response_seconds"),
+                    }
+    return data
+
+
+def _report(data):
+    models = sorted(data)
+    for m in models:
+        reps = sorted(data[m])
+        vals = [data[m][r]["pass_rate"] for r in reps]
+        print(f"\n=== {m} ===  (n={len(reps)})")
+        print(f"  pass_rate: {[f'{v:.3f}' for v in vals]}")
+        if len(vals) > 1:
+            print(f"  mean {statistics.mean(vals):.3f}  std {statistics.stdev(vals):.3f}"
+                  f"  min {min(vals):.3f}  max {max(vals):.3f}")
+        for d in DIMS:
+            xs = [data[m][r][d] for r in reps if data[m][r][d] is not None]
+            if xs:
+                print(f"  {d}: mean {statistics.mean(xs):.1f}/30")
+        lats = [data[m][r]["median_latency"] for r in reps if data[m][r]["median_latency"]]
+        if lats:
+            print(f"  median latency: mean {statistics.mean(lats):.2f}s")
+
+    if len(models) == 2:
+        reps = sorted(set(data[models[0]]) & set(data[models[1]]))
+        diffs = [data[models[0]][r]["pass_rate"] - data[models[1]][r]["pass_rate"] for r in reps]
+        stat = _paired_t_pvalue(diffs)
+        print(f"\npaired diff ({models[0]} - {models[1]}): {[f'{d:+.3f}' for d in diffs]}")
+        if stat:
+            print(f"  mean {stat['mean']:+.3f}  t={stat['t']:.2f}  df={stat['df']}"
+                  f"  two-sided p={stat['p']:.4f}")
+
+
+async def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models", nargs=2, required=True, help="two model ids to compare")
+    ap.add_argument("--repeats", type=int, default=10)
+    ap.add_argument("--judge", nargs="+", default=["bedrock/us.anthropic.claude-opus-5"],
+                    help="one judge (default) or several with --jury")
+    ap.add_argument("--jury", action="store_true", help="majority-vote panel over --judge models")
+    ap.add_argument("--user-prefix", default="cmp")
+    args = ap.parse_args()
+
+    region = os.environ.get("AWS_REGION", "us-east-2")
+    os.environ.setdefault("AWS_REGION", region)
+    print(f"region={region}  repeats={args.repeats}  "
+          f"{'jury' if args.jury else 'single judge'}={args.judge}")
+
+    results = await asyncio.gather(*(
+        _run_one(r, args.models, args.judge, args.jury, args.user_prefix, region)
+        for r in range(1, args.repeats + 1)
+    ))
+    ok = sum(1 for r in results if r.get("success"))
+    print(f"\n{ok}/{args.repeats} runs succeeded")
+    _report(_read_results(args.user_prefix))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/model_comparison/ttft_probe.py
+++ b/examples/model_comparison/ttft_probe.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Streaming time-to-first-token (TTFT) probe for a Bedrock/Mantle model vs an
+OpenAI model.
+
+Why this is separate from compare_models.py: the aiwf benchmark does NOT stream,
+so its latency column is total generate time (an upper bound on TTFT), not the
+first-token latency a user actually feels. This probe streams both providers and
+times the first content token, so it measures TTFT directly.
+
+Honest scope: the two models are reached over DIFFERENT network paths (an OpenAI
+model hits OpenAI's public API; a Mantle model hits the AWS endpoint), so this is
+a PLATFORM comparison ("provider X as I would call it"), not a model-isolated one.
+The ranking is trustworthy; don't quote the absolute seconds as the model's
+intrinsic latency.
+
+Auth: OPENAI_API_KEY in the env for the OpenAI model; ambient AWS creds for the
+Mantle model (a bearer token is minted per run).
+
+Example:
+  OPENAI_API_KEY=sk-... AWS_REGION=us-east-2 python ttft_probe.py \
+    --mantle-model openai.gpt-5.6-luna --openai-model gpt-4o-mini --trials 12
+"""
+import argparse
+import os
+import statistics
+import time
+
+PROMPT = "In two sentences, explain what a knowledge base is for a conference assistant."
+
+
+def _pct(xs, p):
+    xs = sorted(xs)
+    k = min(len(xs) - 1, int(round((p / 100) * (len(xs) - 1))))
+    return xs[k]
+
+
+def _summarize(name, ttfts, totals):
+    print(f"\n=== {name} ===  (n={len(ttfts)})")
+    print(f"  TTFT  p50 {statistics.median(ttfts):.3f}s  p95 {_pct(ttfts, 95):.3f}s"
+          f"  min {min(ttfts):.3f}  max {max(ttfts):.3f}  mean {statistics.mean(ttfts):.3f}")
+    print(f"  TOTAL p50 {statistics.median(totals):.3f}s  p95 {_pct(totals, 95):.3f}s"
+          f"  mean {statistics.mean(totals):.3f}")
+
+
+def probe_openai(model, trials):
+    from openai import OpenAI
+
+    client = OpenAI()
+    ttfts, totals = [], []
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        first = None
+        stream = client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": PROMPT}], stream=True,
+        )
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content and first is None:
+                first = time.perf_counter()
+        end = time.perf_counter()
+        if first:
+            ttfts.append(first - t0)
+            totals.append(end - t0)
+    return ttfts, totals
+
+
+def probe_mantle(model, trials, region):
+    from aws_bedrock_token_generator import provide_token
+    from openai import OpenAI
+
+    client = OpenAI(
+        base_url=f"https://bedrock-mantle.{region}.api.aws/openai/v1",
+        api_key=provide_token(region=region),
+    )
+    ttfts, totals = [], []
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        first = None
+        stream = client.responses.create(model=model, input=PROMPT, stream=True)
+        for event in stream:
+            et = getattr(event, "type", "")
+            if et.endswith(".delta") and first is None:
+                first = time.perf_counter()
+        end = time.perf_counter()
+        if first:
+            ttfts.append(first - t0)
+            totals.append(end - t0)
+    return ttfts, totals
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--mantle-model", default="openai.gpt-5.6-luna")
+    ap.add_argument("--openai-model", default="gpt-4o-mini")
+    ap.add_argument("--trials", type=int, default=12)
+    args = ap.parse_args()
+    region = os.environ.get("AWS_REGION", "us-east-2")
+
+    print(f"region={region}  trials={args.trials}")
+    lt, lo = probe_mantle(args.mantle_model, args.trials, region)
+    _summarize(f"{args.mantle_model} (Bedrock Mantle, streaming)", lt, lo)
+    mt, mo = probe_openai(args.openai_model, args.trials)
+    _summarize(f"{args.openai_model} (OpenAI public API, streaming)", mt, mo)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `examples/model_comparison/` — a reusable harness for comparing two target models on the bundled **aiwf** benchmark, plus a worked result comparing **GPT-5.6 Luna (Bedrock)** vs **GPT-4o-mini (OpenAI)**.

| File | Purpose |
|---|---|
| `compare_models.py` | Runs two models through the same 30-turn conversation N times (single fixed judge, or `--jury` for majority vote), reports per-model pass_rate mean/std, per-dimension counters, latency, and a dependency-free paired t-test. |
| `ttft_probe.py` | Streams both providers to measure true time-to-first-token (the benchmark is non-streaming and can't). |
| `RESULTS.md` | The worked comparison + how to read it and what not to conclude. |
| `README.md` | Auth + caveats. |

## Findings (one measured session; illustrative, rerun for current numbers)

- **Quality, single judge (Opus 5), 10 reps:** Luna 0.897 vs mini 0.847; paired gap +0.050, p = 0.057 (borderline).
- **Quality, jury (Opus 5 + GPT-5.6 Sol), 9 reps:** Luna 0.948 vs mini 0.878; gap +0.070, p = 0.031 (significant). Jury tightened the measurement; scores not comparable to single-judge.
- **Consistency:** GPT-4o-mini is steadier both times (lower std) — the value pick if its score clears your bar.
- **Latency (streaming TTFT):** Luna ~0.45s vs mini ~0.64s p50; ~2× on total. Framed as a platform comparison (different network paths), not model-isolated.

## Notes

- Thin drivers over the shipped `run_multiturn_benchmark` handler — **no change to the benchmark or its measurement**.
- **No secrets committed**: scripts read `OPENAI_API_KEY` from the environment only; nothing written to disk.
- `compare_models.py` verified end-to-end against Bedrock; both CLIs compile and parse.
- Relies on the `judge_models` jury (merged in #147); branches off current `main`.