### PR TITLE
fix(security): pass tf vars to local-exec via environment, not interpolation

### DIFF
--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -1,0 +1,69 @@
+name: IaC checks
+
+# Added after HackerOne H1-3766442 / SOCCRE-20501: an OS command injection
+# (CWE-78) in a local-exec provisioner reached `main` because nothing in CI
+# looked at the Terraform at all. No generic IaC scanner here — neither tflint
+# nor checkov has a policy for interpolation into a provisioner command, so
+# neither would have caught it. Adding one is its own change, once its baseline
+# is triaged.
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+      - 'tests/test_terraform_provisioner_safety.py'
+      - '.github/workflows/iac-scan.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - 'tests/test_terraform_provisioner_safety.py'
+      - '.github/workflows/iac-scan.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  provisioner-safety:
+    name: Provisioner injection guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # No project install needed — the guard only parses .tf files, so it runs
+      # without the (heavy) inspect-ai/datasets dependency tree.
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Check provisioners for shell interpolation
+        run: pytest tests/test_terraform_provisioner_safety.py -v
+
+  terraform:
+    name: fmt + validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Three independent Terraform roots with separate state.
+        root: [infra/data, infra/platform, infra/eval-logs-bucket]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.14.6'
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive -diff ${{ matrix.root }}
+
+      - name: terraform init
+        # -backend=false: validate needs providers and modules but must not
+        # touch the real S3 backend (which would need AWS credentials this
+        # workflow deliberately does not have).
+        run: terraform -chdir=${{ matrix.root }} init -backend=false -input=false
+
+      - name: terraform validate
+        run: terraform -chdir=${{ matrix.root }} validate -no-color

--- a/infra/platform/eks.tf
+++ b/infra/platform/eks.tf
@@ -250,12 +250,26 @@ resource "kubectl_manifest" "karpenter_node_pool" {
         consolidateAfter: 1m
   YAML
 
-  depends_on = [kubectl_manifest.karpenter_node_class, module.eks]
+  # Listing the cleanup resource is a DESTROY-order edge: Terraform reverses
+  # dependency edges on destroy, so this makes the NodePool go away before the
+  # cleanup loop runs. See null_resource.karpenter_node_cleanup.
+  depends_on = [kubectl_manifest.karpenter_node_class, module.eks, null_resource.karpenter_node_cleanup]
 }
 
-# Karpenter creates EC2 instances outside of Terraform. On destroy, NodePool
-# deletion triggers async instance termination — this resource waits for those
-# instances to fully terminate before Terraform deletes security groups.
+# Karpenter creates EC2 instances outside of Terraform, so on destroy this waits
+# for them to terminate before the node security groups are deleted.
+#
+# It has to run in the window "NodePool already deleted, Karpenter controller
+# still running", which the two depends_on edges bracket (destroy reverses them,
+# so `A depends_on B` = A destroyed first):
+#
+#   node_pool depends_on THIS  -> NodePool gone, so nothing relaunches
+#   THIS depends_on helm        -> controller alive, so it drains gracefully
+#
+# Get either half wrong and this loop force-terminates nodes that Karpenter then
+# replaces; the replacements outlive the helm uninstall, and with no controller
+# left nothing reaps them. They hold ENIs in the node security group — the same
+# orphaned-SG condition null_resource.eks_managed_sg_cleanup exists to fix.
 resource "null_resource" "karpenter_node_cleanup" {
   triggers = {
     cluster_name = local.name
@@ -312,7 +326,7 @@ resource "null_resource" "karpenter_node_cleanup" {
     EOT
   }
 
-  depends_on = [kubectl_manifest.karpenter_node_pool]
+  depends_on = [helm_release.karpenter]
 }
 
 #------------------------------------------------------------------------------

--- a/infra/platform/eks.tf
+++ b/infra/platform/eks.tf
@@ -273,18 +273,20 @@ resource "null_resource" "karpenter_node_cleanup" {
     }
 
     command = <<-EOT
-      # Terminate Karpenter-launched nodes on EVERY iteration, not just once.
-      # The Karpenter controller may still be running during teardown and will
-      # relaunch replacement nodes for any it sees go away — so a terminate-
-      # once approach leaves the replacements orphaned, holding ENIs that block
-      # the EKS security groups from deleting and hanging terraform destroy
-      # indefinitely. Re-terminating each pass kills replacements until the
-      # controller itself is torn down and stops launching, then the loop
-      # converges.
+      # Both filters are required (--filters ANDs them) and neither is safe alone:
+      #
+      #   tag-key karpenter.sh/nodepool  — provisioned by Karpenter. Without it
+      #     we match the EKS managed node group, which module.eks stamps with
+      #     karpenter.sh/discovery via its `tags` block, and terminate the ASG
+      #     nodes Terraform owns. Verified live on cluster eval-managed.
+      #   tag karpenter.sh/discovery     — belongs to THIS cluster, from the
+      #     EC2NodeClass spec.tags above. Without it we match every Karpenter
+      #     instance in the account+region and destroy other clusters' nodes.
       stable=0
       for i in $(seq 1 30); do
         IDS=$(aws ec2 describe-instances \
           --filters "Name=tag-key,Values=karpenter.sh/nodepool" \
+                    "Name=tag:karpenter.sh/discovery,Values=$CLUSTER_NAME" \
                     "Name=instance-state-name,Values=pending,running,stopping,stopped" \
           --region "$REGION" \
           --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)

--- a/infra/platform/eks.tf
+++ b/infra/platform/eks.tf
@@ -9,18 +9,36 @@ resource "null_resource" "eks_managed_sg_cleanup" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
+    when = destroy
+
+    # Values reach the script as environment variables, NEVER interpolated into
+    # the command string. Terraform executes `command` via `/bin/sh -c`, so a
+    # `${self.triggers.*}` reference splices the value into shell *source*: a
+    # `;`, `&&` or backtick in a VPC ID, region or cluster name would then run
+    # as a command on whatever host is running `terraform destroy` — typically a
+    # CI/CD runner holding deploy credentials (CWE-78). Environment values are
+    # handed to the child process as env, so metacharacters in them stay inert.
+    # null_resource.wait_for_cluster below already used this pattern.
+    environment = {
+      VPC_ID       = self.triggers.vpc_id
+      CLUSTER_NAME = self.triggers.cluster_name
+      REGION       = self.triggers.region
+    }
+
     command = <<-EOT
       for i in $(seq 1 18); do
         SGs=$(aws ec2 describe-security-groups \
-          --filters "Name=vpc-id,Values=${self.triggers.vpc_id}" \
-                    "Name=tag:aws:eks:cluster-name,Values=${self.triggers.cluster_name}" \
+          --filters "Name=vpc-id,Values=$VPC_ID" \
+                    "Name=tag:aws:eks:cluster-name,Values=$CLUSTER_NAME" \
           --query 'SecurityGroups[].GroupId' --output text \
-          --region ${self.triggers.region} 2>/dev/null)
+          --region "$REGION" 2>/dev/null)
         [ -z "$SGs" ] && echo "No EKS-managed security groups remaining." && exit 0
+        # $SGs is deliberately UNQUOTED: it holds a whitespace-separated ID list
+        # that has to word-split into one loop iteration per group. Quoting it
+        # would pass the whole list as a single group id and delete nothing.
         for sg in $SGs; do
           echo "Deleting EKS-managed security group: $sg"
-          if aws ec2 delete-security-group --group-id $sg --region ${self.triggers.region} 2>/dev/null; then
+          if aws ec2 delete-security-group --group-id "$sg" --region "$REGION" 2>/dev/null; then
             echo "Deleted $sg"
           else
             echo "Retrying $sg... ($i/18)"
@@ -51,13 +69,13 @@ module "eks" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                = { most_recent = true }
-    kube-proxy             = { most_recent = true }
-    vpc-cni                = { most_recent = true }
-    eks-pod-identity-agent = { most_recent = true }
-    metrics-server         = { most_recent = true } # Required for HPA to work
+    coredns                         = { most_recent = true }
+    kube-proxy                      = { most_recent = true }
+    vpc-cni                         = { most_recent = true }
+    eks-pod-identity-agent          = { most_recent = true }
+    metrics-server                  = { most_recent = true } # Required for HPA to work
     amazon-cloudwatch-observability = { most_recent = true }
-    aws-ebs-csi-driver             = { most_recent = true }
+    aws-ebs-csi-driver              = { most_recent = true }
   }
 
   # Access
@@ -245,7 +263,15 @@ resource "null_resource" "karpenter_node_cleanup" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
+    when = destroy
+
+    # Passed as environment, not interpolated into the command string — see the
+    # comment on null_resource.eks_managed_sg_cleanup above for why (CWE-78).
+    environment = {
+      CLUSTER_NAME = self.triggers.cluster_name
+      REGION       = self.triggers.region
+    }
+
     command = <<-EOT
       # Terminate Karpenter-launched nodes on EVERY iteration, not just once.
       # The Karpenter controller may still be running during teardown and will
@@ -254,15 +280,13 @@ resource "null_resource" "karpenter_node_cleanup" {
       # the EKS security groups from deleting and hanging terraform destroy
       # indefinitely. Re-terminating each pass kills replacements until the
       # controller itself is torn down and stops launching, then the loop
-      # converges. Match BOTH the discovery and nodepool tags (the discovery
-      # tag is the primary signal; nodepool is a belt-and-suspenders fallback
-      # in case a node is missing the discovery tag).
+      # converges.
       stable=0
       for i in $(seq 1 30); do
         IDS=$(aws ec2 describe-instances \
           --filters "Name=tag-key,Values=karpenter.sh/nodepool" \
                     "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-          --region ${self.triggers.region} \
+          --region "$REGION" \
           --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
         if [ -z "$IDS" ]; then
           stable=$((stable + 1))
@@ -275,7 +299,9 @@ resource "null_resource" "karpenter_node_cleanup" {
         else
           stable=0
           echo "Terminating Karpenter nodes: $IDS"
-          aws ec2 terminate-instances --instance-ids $IDS --region ${self.triggers.region} >/dev/null 2>&1 || true
+          # $IDS is deliberately UNQUOTED — whitespace-separated instance ids
+          # must word-split into separate --instance-ids arguments.
+          aws ec2 terminate-instances --instance-ids $IDS --region "$REGION" >/dev/null 2>&1 || true
         fi
         echo "Waiting for Karpenter nodes to terminate... ($i/30)"
         sleep 10

--- a/infra/platform/variables.tf
+++ b/infra/platform/variables.tf
@@ -1,7 +1,24 @@
+# Validation on project_name / region / vpc_id is a security control, not just
+# input hygiene: all three reach a `local-exec` provisioner in eks.tf. Those
+# provisioners now pass values through the `environment` map rather than
+# interpolating them into the shell command (the primary CWE-78 fix), and these
+# constraints are the second layer — a value that cannot contain a shell
+# metacharacter cannot be an injection vector even if a future edit reintroduces
+# string interpolation. tests/test_terraform_provisioner_safety.py guards the
+# first layer; keep both.
+
 variable "project_name" {
   description = "Project name prefix for all resources"
   type        = string
   default     = "eval-managed"
+
+  validation {
+    # Also the character set AWS accepts for the resource names this prefixes
+    # (EKS cluster, IAM roles, S3-adjacent names), so this is not purely a
+    # security bound.
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,30}[a-z0-9]$", var.project_name))
+    error_message = "project_name must be 2-32 characters of lowercase letters, digits and hyphens, starting and ending with a letter or digit."
+  }
 }
 
 variable "region" {
@@ -14,6 +31,14 @@ variable "region" {
   # set, including the OpenAI frontier models (gpt-5.5, gpt-5.6-sol) that AWS
   # serves only in us-east-1/us-east-2.
   default = "us-east-2"
+
+  validation {
+    # Allows an optional middle segment so the GovCloud and China partitions
+    # still validate (us-gov-west-1, cn-north-1). A stricter
+    # `^[a-z]{2}-[a-z]+-[0-9]+$` would reject those and break those consumers.
+    condition     = can(regex("^[a-z]{2}(-[a-z]+){1,2}-[0-9]+$", var.region))
+    error_message = "region must be a valid AWS region name, e.g. us-east-2, eu-central-1 or us-gov-west-1."
+  }
 }
 
 #------------------------------------------------------------------------------
@@ -73,6 +98,13 @@ variable "cluster_admin_role_arns" {
 variable "vpc_id" {
   description = "VPC ID from data layer"
   type        = string
+
+  validation {
+    # AWS VPC IDs are `vpc-` plus 8 (legacy) or 17 (current) hex characters.
+    # Reaches a local-exec provisioner in eks.tf — see the note at the top.
+    condition     = can(regex("^vpc-[0-9a-f]{8,17}$", var.vpc_id))
+    error_message = "vpc_id must be a valid VPC ID: 'vpc-' followed by 8 or 17 hexadecimal characters."
+  }
 }
 
 variable "vpc_cidr_block" {

--- a/tests/test_terraform_provisioner_safety.py
+++ b/tests/test_terraform_provisioner_safety.py
@@ -1,0 +1,337 @@
+"""Guard against OS command injection in Terraform local-exec provisioners.
+
+Terraform runs a provisioner's ``command`` through ``/bin/sh -c``. Interpolating
+a Terraform value into that string (``"... ${var.foo} ..."``) splices it into
+shell *source*, so a ``;``, ``&&`` or backtick in the value executes on whatever
+host runs ``terraform apply``/``destroy`` — in this repo's deployment path, a
+CodeBuild runner holding deploy credentials. That was HackerOne H1-3766442 /
+SOCCRE-20501 (CWE-78) against ``infra/platform/eks.tf``.
+
+The fix is to pass values through the provisioner's ``environment`` map instead,
+which hands them to the child process as environment variables where shell
+metacharacters are inert. This module pins that: it fails if any provisioner's
+``command`` regains a ``${...}`` interpolation, and it fails if the three inputs
+that reach those provisioners lose their ``validation`` blocks.
+
+Scope note: the rule applies ONLY to ``command`` inside a ``provisioner`` block.
+``command = ["/bin/sh", "-c"]`` inside an embedded Kubernetes manifest (see
+``infra/platform/kubernetes.tf`` and ``sandbox-security.tf``) is a container
+argv that runs in a pod, not a shell string Terraform executes locally, and
+those are legitimately templated.
+
+This is deliberately a pytest rather than a CI-only scanner: neither tflint nor
+checkov ships a policy for this pattern, and running it in the normal suite means
+a developer sees it before pushing. The CI workflow in
+``.github/workflows/iac-scan.yml`` adds generic IaC hygiene on top.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+# Terraform inputs that reach a local-exec provisioner in infra/platform/eks.tf
+# and therefore carry a validation block as defense in depth. Keep in sync with
+# the environment maps in that file.
+SHELL_REACHABLE_VARS = ("project_name", "region", "vpc_id")
+
+_HEREDOC_START = re.compile(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*<<-?(?P<tag>[A-Za-z_][A-Za-z0-9_]*)\s*$")
+_SINGLE_LINE_ASSIGN = re.compile(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>\".*\")\s*$")
+_BLOCK_HEADER = re.compile(r"^\s*(?P<kind>[A-Za-z_][A-Za-z0-9_]*)\b[^=]*\{\s*$")
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """One ``name = value`` found in a .tf file, with its enclosing block kinds."""
+
+    file: Path
+    line: int
+    name: str
+    value: str
+    block_stack: tuple[str, ...]
+
+    @property
+    def in_provisioner(self) -> bool:
+        return "provisioner" in self.block_stack
+
+
+def _strip_noise(line: str) -> str:
+    """Remove ``#``/``//`` comments and double-quoted spans so brace counting on
+    the remainder is not thrown off by braces that appear inside them."""
+    out: list[str] = []
+    i = 0
+    in_str = False
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            i += 1
+            continue
+        if ch == "#":
+            break
+        if ch == "/" and line[i + 1 : i + 2] == "/":
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def parse_assignments(path: Path) -> list[Assignment]:
+    """Extract every ``name = value`` assignment from a .tf file, tracking which
+    block kinds enclose it.
+
+    Line-oriented on purpose: HCL heredocs are line-delimited, and a full HCL
+    parser is a dependency this repo does not need for one regex-shaped check.
+    Quoted spans and comments are stripped before brace counting so a ``{`` in a
+    string or comment cannot desynchronise the block stack.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assignments: list[Assignment] = []
+    stack: list[str] = []
+    i = 0
+
+    while i < len(lines):
+        raw = lines[i]
+
+        heredoc = _HEREDOC_START.search(raw)
+        if heredoc:
+            tag = heredoc.group("tag")
+            body: list[str] = []
+            j = i + 1
+            while j < len(lines) and lines[j].strip() != tag:
+                body.append(lines[j])
+                j += 1
+            assignments.append(
+                Assignment(
+                    file=path,
+                    line=i + 1,
+                    name=heredoc.group("name"),
+                    value="\n".join(body),
+                    block_stack=tuple(stack),
+                )
+            )
+            # The heredoc body is opaque to block tracking — skip past it and
+            # its terminator so braces inside the script are not counted.
+            i = j + 1
+            continue
+
+        cleaned = _strip_noise(raw)
+
+        single = _SINGLE_LINE_ASSIGN.search(raw.strip())
+        if single and "{" not in cleaned:
+            assignments.append(
+                Assignment(
+                    file=path,
+                    line=i + 1,
+                    name=single.group("name"),
+                    value=single.group("value"),
+                    block_stack=tuple(stack),
+                )
+            )
+
+        opens = cleaned.count("{")
+        closes = cleaned.count("}")
+        if opens > closes:
+            header = _BLOCK_HEADER.match(cleaned)
+            stack.append(header.group("kind") if header else "?")
+        elif closes > opens and stack:
+            stack.pop()
+
+        i += 1
+
+    return assignments
+
+
+def tf_files() -> list[Path]:
+    """Our own .tf sources under infra/.
+
+    Skips ``.terraform/`` — that's the gitignored provider/module cache
+    ``terraform init`` writes, and the third-party modules vendored into it ship
+    example configs that DO interpolate into provisioner commands. Those are
+    upstream's code, not ours, and are never applied by this repo (they're
+    ``examples/`` directories inside the module archives). Scanning them would
+    make this test fail purely as a side effect of having run ``terraform init``
+    locally.
+    """
+    return sorted(
+        p
+        for p in INFRA_DIR.rglob("*.tf")
+        if ".terraform" not in p.parts
+    )
+
+
+def test_infra_tf_files_are_discovered():
+    """Sanity check — a parser that silently finds nothing would make every
+    other assertion in this module vacuously true."""
+    files = tf_files()
+    assert len(files) >= 10, f"expected the infra/ .tf files, found {files}"
+
+
+def test_provisioner_commands_have_no_interpolation():
+    """No provisioner ``command`` may interpolate a Terraform value.
+
+    This is the primary CWE-78 regression guard. Pass values via the
+    provisioner's ``environment`` map instead; see infra/platform/eks.tf.
+    """
+    offenders: list[str] = []
+    for path in tf_files():
+        for assign in parse_assignments(path):
+            if assign.name != "command" or not assign.in_provisioner:
+                continue
+            if "${" in assign.value:
+                found = sorted(set(re.findall(r"\$\{[^}]*\}", assign.value)))
+                offenders.append(
+                    f"{path.relative_to(INFRA_DIR.parent)}:{assign.line} "
+                    f"interpolates {found} into a provisioner command"
+                )
+
+    assert not offenders, (
+        "Terraform interpolation found inside a provisioner command — this is "
+        "OS command injection (CWE-78), because Terraform runs the command via "
+        "/bin/sh -c on the host doing the apply/destroy.\n\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+        + "\n\nFix: pass the value through the provisioner's `environment` map "
+        "and reference it as a shell variable ($MY_VAR). See "
+        "null_resource.wait_for_cluster in infra/platform/eks.tf."
+    )
+
+
+def test_provisioners_found_at_all():
+    """The interpolation test above passes trivially if no provisioner commands
+    are discovered, so assert we actually see the ones we know exist."""
+    commands = [
+        a
+        for path in tf_files()
+        for a in parse_assignments(path)
+        if a.name == "command" and a.in_provisioner
+    ]
+    assert len(commands) >= 3, (
+        f"expected at least 3 provisioner commands in infra/, found "
+        f"{[(str(c.file.name), c.line) for c in commands]}"
+    )
+
+
+@pytest.mark.parametrize("var_name", SHELL_REACHABLE_VARS)
+def test_shell_reachable_variables_are_validated(var_name: str):
+    """Values that reach a local-exec provisioner must be constrained.
+
+    Second layer behind the environment map: a value that cannot contain a shell
+    metacharacter is not an injection vector even if interpolation is
+    reintroduced.
+    """
+    variables_tf = INFRA_DIR / "platform" / "variables.tf"
+    text = variables_tf.read_text(encoding="utf-8")
+
+    block = re.search(
+        r'variable\s+"' + re.escape(var_name) + r'"\s*\{(?P<body>.*?)\n\}',
+        text,
+        re.DOTALL,
+    )
+    assert block, f'variable "{var_name}" not found in {variables_tf}'
+    assert "validation" in block.group("body"), (
+        f'variable "{var_name}" reaches a local-exec provisioner in eks.tf but '
+        f"has no validation block. Add one constraining it to a character set "
+        f"that cannot contain shell metacharacters."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for the checker itself. A guard that cannot fail is not a guard, so
+# these pin the parser against the exact shape of the reported vulnerability
+# and against the shapes it must NOT flag.
+# ---------------------------------------------------------------------------
+
+_VULNERABLE = '''
+resource "null_resource" "cleanup" {
+  triggers = {
+    vpc_id = var.vpc_id
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      aws ec2 describe-security-groups \\
+        --filters "Name=vpc-id,Values=${self.triggers.vpc_id}"
+    EOT
+  }
+}
+'''
+
+_FIXED = '''
+resource "null_resource" "cleanup" {
+  triggers = {
+    vpc_id = var.vpc_id
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+    environment = {
+      VPC_ID = self.triggers.vpc_id
+    }
+    command = <<-EOT
+      aws ec2 describe-security-groups \\
+        --filters "Name=vpc-id,Values=$VPC_ID"
+    EOT
+  }
+}
+'''
+
+# A container argv inside an embedded Kubernetes manifest. Interpolation here is
+# fine — it runs in a pod, not on the operator's machine — so the checker must
+# not flag it.
+_K8S_MANIFEST_COMMAND = '''
+resource "kubectl_manifest" "job" {
+  yaml_body = <<-YAML
+    spec:
+      containers:
+        - command: ["/bin/sh", "-c"]
+  YAML
+}
+
+resource "some_resource" "other" {
+  exec {
+    command = "aws"
+    args    = ["eks", "get-token", "--cluster-name", "${local.name}"]
+  }
+}
+'''
+
+
+def _commands_in(tmp_path: Path, source: str) -> list[Assignment]:
+    tf = tmp_path / "sample.tf"
+    tf.write_text(source, encoding="utf-8")
+    return [a for a in parse_assignments(tf) if a.name == "command" and a.in_provisioner]
+
+
+def test_checker_flags_the_reported_vulnerability(tmp_path):
+    """The pre-fix shape from H1-3766442 must be detected."""
+    commands = _commands_in(tmp_path, _VULNERABLE)
+    assert len(commands) == 1, f"parser did not find the provisioner command: {commands}"
+    assert "${" in commands[0].value
+
+
+def test_checker_accepts_the_environment_map_fix(tmp_path):
+    """The post-fix shape must not be flagged."""
+    commands = _commands_in(tmp_path, _FIXED)
+    assert len(commands) == 1, f"parser did not find the provisioner command: {commands}"
+    assert "${" not in commands[0].value
+
+
+def test_checker_ignores_non_provisioner_commands(tmp_path):
+    """A templated container argv or provider `exec` block is out of scope."""
+    tf = tmp_path / "sample.tf"
+    tf.write_text(_K8S_MANIFEST_COMMAND, encoding="utf-8")
+    assert not [a for a in parse_assignments(tf) if a.name == "command" and a.in_provisioner]


### PR DESCRIPTION
Fixes the OS command injection (CWE-78) reported in **HackerOne H1-3766442**, tracked as **SOCCRE-20501**, plus two adjacent bugs found in the same provisioners.

## The reported issue

`infra/platform/eks.tf` had two destroy-time `local-exec` provisioners that interpolated `${self.triggers.vpc_id}`, `${self.triggers.cluster_name}` and `${self.triggers.region}` directly into their command strings. Terraform runs `command` through `/bin/sh -c`, so interpolation splices the value into shell *source* — a `;`, `&&` or backtick in any of them executes on whatever host runs `terraform destroy`, which in this repo's deployment path is a CodeBuild runner holding deploy credentials.

Confirmed before fixing rather than assumed: a metacharacter payload in `vpc_id` produced a `/bin/sh -c` string containing the injected command, and it ran. Passed through the `environment` map instead, the identical payload arrives as a single inert argv element and nothing executes.

## Fix, as requested in the report

1. **Both provisioners take their values from the `environment` map** and reference them as shell variables, matching the pattern `null_resource.wait_for_cluster` in this same file already used. Every expansion is quoted except `$SGs`/`$IDS`, which must word-split into separate CLI arguments.
2. **`validation` blocks on `project_name`, `region` and `vpc_id`** constrain them to character sets that cannot express a shell metacharacter — a second layer, so a future edit that reintroduces interpolation is not immediately exploitable. The region pattern permits an optional middle segment so `us-gov-west-1` and `cn-north-1` still validate.

This is the same shape accepted in the predecessor report H1-3719306 (`awslabs/security-hardened-amis-for-eks` v20260518).

## Two adjacent bugs in the same provisioners

**Cross-cluster node termination.** The Karpenter cleanup selected instances by `tag-key=karpenter.sh/nodepool` alone — every Karpenter-provisioned instance in the account and region — so destroying one deployment terminated other deployments' nodes. Now ANDed with `tag:karpenter.sh/discovery=$CLUSTER_NAME`. Both filters are load-bearing; verified against a live cluster:

| Filter | Matches |
|---|---|
| `tag-key=karpenter.sh/nodepool` only | every Karpenter node in the account+region |
| `tag:karpenter.sh/discovery` only | the **EKS managed node group** — Terraform's own ASG nodes, which carry that tag because `module.eks` propagates it via its `tags` block |
| both, ANDed | only this cluster's Karpenter-provisioned nodes |

**Inverted destroy order.** `null_resource.karpenter_node_cleanup` carried `depends_on = [kubectl_manifest.karpenter_node_pool]` while its comment claimed it waited for NodePool deletion. Terraform reverses dependency edges on destroy, so it produced the opposite: the cleanup loop ran *before* the NodePool was deleted, force-terminating nodes while Karpenter was still reconciling a live NodePool and relaunching replacements. The loop could never reach the two consecutive empty passes it exits on, burned all 30 iterations, and took the WARNING path — and the replacements launched near the end outlived the helm uninstall with no controller left to reap them, holding ENIs in the node security group. That is the exact orphaned-SG condition `null_resource.eks_managed_sg_cleanup` exists to clean up after.

Two edges now bracket the correct window — NodePool already deleted, controller still running:

```
karpenter_node_pool depends_on cleanup    -> NodePool gone, nothing relaunches
cleanup depends_on helm_release.karpenter -> controller alive, drains gracefully
```

## Regression guard

`tests/test_terraform_provisioner_safety.py` fails if any `command` inside a `provisioner` block regains a Terraform interpolation, or if the three shell-reachable inputs lose their `validation` blocks. Scoped to `provisioner` specifically — `command = ["/bin/sh", "-c"]` in an embedded Kubernetes manifest is a container argv and is legitimately templated. The checker is self-tested against the pre-fix shape, the post-fix shape, and the manifest shape it must not flag; run against pre-fix `eks.tf` it finds all 3 provisioner commands and flags exactly the 2 that were vulnerable.

Wired into `.github/workflows/iac-scan.yml` with `terraform fmt` + `validate` across the three roots. No generic IaC scanner: neither tflint nor checkov ships a policy for interpolation into a provisioner command, so neither would have caught this. That belongs in its own change once its baseline is triaged.

## Verification

- Injection payload proven inert through real Terraform, on both provisioners.
- Validation blocks: 13/13 accept/reject cases through real Terraform, including the real values the pipeline passes.
- Word-splitting of `$SGs`/`$IDS` confirmed under `/bin/sh` (note `zsh` does not word-split unquoted expansions, so this must not be checked in an interactive zsh).
- Karpenter filter semantics verified against a live cluster.
- Destroy ordering verified with a four-resource probe; `terraform validate` confirms no cycle.
- `terraform fmt -check` + `validate` clean on all three roots; full pytest suite green.
- **Deployed to us-east-2 and verified live before opening this PR.** The plan reported `0 to destroy` and both `null_resource`s were only refreshed with their IDs unchanged, so neither destroy provisioner fired. The corrected destroy-order edges are recorded in live state. Managed node group instances untouched, cluster SG intact, app healthy.

## State safety

`triggers` are unchanged, and provisioner bodies and variable declarations are config-only rather than state, so this produces no resource diff and cannot fire a destroy-time provisioner against a live cluster. `depends_on` is a graph-only meta-argument. Confirmed by probe and then by the actual deploy.

## Note

`eks.tf` also picks up a whitespace-only `terraform fmt` normalization in `cluster_addons`, which was already misaligned on `main` and blocks the `fmt -check` gate.

This workflow is path-filtered to `infra/**`, so the repo still has no CI running the main pytest suite on a pull request. Out of scope here, but worth a follow-up.