### PR TITLE
feat(mcp): reasoning_effort on run_benchmark

### DIFF
--- a/eval_mcp/core/eval_results.py
+++ b/eval_mcp/core/eval_results.py
@@ -6,10 +6,12 @@ comparison API can serve directly without re-parsing.
 
 import json
 import logging
+import re
 import os
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from inspect_ai._view.common import list_eval_logs_async
 from inspect_ai.log import read_eval_log_async
@@ -318,6 +320,23 @@ def _build_groups_from_headers(headers: list[dict]) -> dict:
     return {"groups": groups}
 
 
+def _row_key(sample_id: str, log_ids: set[str]) -> str:
+    """Row-alignment key for a sample across a run's per-model logs.
+
+    Inspect uniquifies sample ids per model within a multi-model run by
+    appending ``_<n>`` (e.g. ``abc123`` in the first model's log, ``abc123_1``
+    in the second). Keying rows by the raw id therefore splits every sample
+    into one row per model with a single filled column. Strip the suffix so
+    rows align — but only when the stripped form isn't itself a distinct
+    sample id in the same log (a dataset whose real ids end in ``_1`` must
+    not collapse two different samples into one row).
+    """
+    m = re.match(r"^(?P<base>.+)_\d+$", sample_id)
+    if m and m["base"] not in log_ids:
+        return m["base"]
+    return sample_id
+
+
 def _build_detail_from_logs(
     group_id: str,
     group_logs: list[dict],
@@ -350,8 +369,9 @@ def _build_detail_from_logs(
             column_key = f"{log.get('task', '')}/{log['model']}"
         else:
             column_key = log["model"]
+        log_ids = {s["id"] for s in log.get("samples", [])}
         for sample in log.get("samples", []):
-            sid = sample["id"]
+            sid = _row_key(sample["id"], log_ids)
             if sid not in samples_by_id:
                 entry: dict = {
                     "id": sid,
@@ -787,6 +807,53 @@ def _relabel_score_only_groups(groups_response: dict, user_dir: Path) -> None:
                 group["scoreOnly"] = True
         except Exception:
             continue
+
+
+async def build_merged_detail(user_id: str, parts: list[tuple[str, str]]) -> Optional[dict]:
+    """Build one comparison detail spanning several run groups.
+
+    ``parts`` is [(group_id, label), ...]. Each part's logs are relabeled to
+    the synthetic task name ``eval_<n>`` and the label lands in the detail's
+    ``variants`` map as a thinking level — so the existing multi-column
+    comparison UI (column keys, effort badges, per-sample grid) renders a
+    cross-run view with no frontend changes. Built for prebuilt-benchmark
+    effort comparisons, where Inspect's --reasoning-effort is global per run
+    and each effort level necessarily lands in its own run group. Sample ids
+    must match across parts (same benchmark + limit + shuffle settings) for
+    rows to align.
+    """
+    log_dir = get_user_log_dir(user_id)
+    user_dir = get_user_dir(user_id)
+    headers = await _read_log_headers(log_dir)
+
+    group_logs: list[dict] = []
+    all_files: list[str] = []
+    task_names: dict[str, str] = {}
+    for i, (gid, _label) in enumerate(parts):
+        part_headers = [h for h in headers if (h.get("run_id") or h["file"]) == gid]
+        if not part_headers:
+            return None
+        for h in part_headers:
+            h = dict(h)
+            task_names[h["file"]] = f"eval_{i + 1}"
+            h["task"] = f"eval_{i + 1}"
+            group_logs.append(h)
+            all_files.append(h["file"])
+
+    full_logs = await _read_full_logs(all_files)
+    if not full_logs:
+        return None
+    for fl in full_logs:
+        fl["task"] = task_names.get(fl["file"], fl.get("task", ""))
+
+    merged_id = "+".join(f"{gid}:{label}" for gid, label in parts)
+    detail = _build_detail_from_logs(merged_id, group_logs, full_logs, user_dir)
+    detail["variants"] = {
+        f"eval_{i + 1}": {"thinking": label} for i, (_gid, label) in enumerate(parts)
+    }
+    detail["thinking"] = [label for _gid, label in parts]
+    detail["mergedGroups"] = [gid for gid, _label in parts]
+    return detail
 
 
 async def precompute_eval_results(user_id: str, force: bool = False) -> None:

--- a/eval_mcp/core/pricing.py
+++ b/eval_mcp/core/pricing.py
@@ -193,6 +193,16 @@ def _candidates(model_id: str) -> list[str]:
         if dated:
             out.append(f"bedrock_mantle/{dated['base']}")
 
+    # OpenAI models served on bedrock-runtime via CRIS profiles
+    # ("bedrock/global.openai.gpt-5.6-terra"). LiteLLM has no runtime-form key
+    # for these, but AWS documents identical per-token pricing on both
+    # endpoints, so map onto the Mantle key.
+    runtime_openai = re.match(
+        r"^bedrock/(?:global\.|us\.|eu\.|apac\.)?(?P<base>openai\..+)$", model_id
+    )
+    if runtime_openai:
+        out.append(f"bedrock_mantle/{runtime_openai['base']}")
+
     bare = model_id
     for pfx in _PROVIDER_PREFIXES:
         if bare.startswith(pfx):

--- a/eval_mcp/core/pricing.py
+++ b/eval_mcp/core/pricing.py
@@ -196,7 +196,11 @@ def _candidates(model_id: str) -> list[str]:
     # OpenAI models served on bedrock-runtime via CRIS profiles
     # ("bedrock/global.openai.gpt-5.6-terra"). LiteLLM has no runtime-form key
     # for these, but AWS documents identical per-token pricing on both
-    # endpoints, so map onto the Mantle key.
+    # endpoints, so map onto the Mantle key. Converse's usage.outputTokens
+    # DOES include these models' (redacted) reasoning tokens — verified
+    # against sample logs (output tokens scale with redacted-block volume,
+    # e.g. 9,029 tokens for a ~420-token visible answer) — so costs computed
+    # from it are accurate, not floors.
     runtime_openai = re.match(
         r"^bedrock/(?:global\.|us\.|eu\.|apac\.)?(?P<base>openai\..+)$", model_id
     )

--- a/eval_mcp/server.py
+++ b/eval_mcp/server.py
@@ -1258,6 +1258,7 @@ async def run_benchmark(
     judge_model: str = None,
     judge_models: list = None,
     max_turns: int = None,
+    reasoning_effort: str = None,
     user_id: str = None,
 ) -> str:
     """
@@ -1295,6 +1296,10 @@ async def run_benchmark(
             comparing target models.
         max_turns: Cap the conversation for a cheap smoke run of a multi-turn
             bundled benchmark. Those scores are NOT comparable to a full run.
+        reasoning_effort: Run every provider at this reasoning-effort level
+            (none|minimal|low|medium|high|xhigh|max). Global for the run —
+            call run_benchmark once per level to compare levels on identical
+            inputs. Providers whose route cannot honor effort are rejected.
 
     Returns:
         JSON with success, task, runId, viewerUrl, and a scores summary.
@@ -1307,6 +1312,7 @@ async def run_benchmark(
         "judge_model": judge_model,
         "judge_models": judge_models,
         "max_turns": max_turns,
+        "reasoning_effort": reasoning_effort,
         "user_id": _user(user_id),
     }
     result = await handle_run_benchmark(args)

--- a/eval_mcp/tools/benchmarks.py
+++ b/eval_mcp/tools/benchmarks.py
@@ -368,6 +368,26 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
         providers = args.get("providers") or []
         limit = args.get("limit")
         task_args = args.get("task_args") or {}
+        reasoning_effort = args.get("reasoning_effort")
+        if reasoning_effort is not None:
+            allowed = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+            if reasoning_effort not in allowed:
+                return [TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": f"Invalid reasoning_effort '{reasoning_effort}'. "
+                             f"Choose from: {', '.join(allowed)}",
+                }))]
+            from eval_mcp.core.model_routing import supports_thinking_control
+            unsupported = [m for m in providers if not supports_thinking_control(m)]
+            if unsupported:
+                return [TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": (
+                        f"reasoning_effort is not controllable for: {unsupported}. "
+                        "Their route silently ignores it, which would mislabel "
+                        "the run."
+                    ),
+                }))]
 
         if not user_id:
             return [TextContent(type="text", text=json.dumps({"success": False, "error": "user_id is required"}))]
@@ -476,10 +496,15 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
         env["AWS_REGION"] = region
         env["AWS_DEFAULT_REGION"] = region
 
+        # Claude targets ride the native anthropic provider (bedrock-runtime
+        # Messages API) so reasoning_effort actually reaches them — the
+        # Converse provider drops it for Claude 5. Log names are normalized
+        # back at results ingestion (eval_mcp/core/model_routing.py).
+        from eval_mcp.core.model_routing import to_native
         cmd: List[str] = [
             *_INSPECT_CMD, "eval",
             f"inspect_evals/{task}",
-            "--model", ",".join(providers),
+            "--model", ",".join(to_native(m) for m in providers),
             "--adaptive-connections", "true",
             "--no-log-images",
             "--no-fail-on-error",
@@ -492,6 +517,10 @@ async def handle_run_benchmark(args: Dict[str, Any]) -> List[TextContent]:
         # their solver.
         if limit:
             cmd.extend(["--limit", str(int(limit))])
+        if reasoning_effort is not None:
+            # Global for the run: applies to every provider. Run the benchmark
+            # once per effort level to compare levels on identical inputs.
+            cmd.extend(["--reasoning-effort", reasoning_effort])
         # Inject the resolved sandbox type for code-execution benchmarks (unless
         # the caller already specified one via task_args).
         if sandbox_override:

--- a/eval_mcp/viewer.py
+++ b/eval_mcp/viewer.py
@@ -47,6 +47,24 @@ def create_viewer_app() -> FastAPI:
         from eval_mcp.core.user_storage import load_eval_detail
 
         user_id = os.environ.get("EVAL_MCP_USER", "local")
+
+        # Cross-run merge: "id1:label1+id2:label2" renders several run groups
+        # as one comparison page (columns labeled per part). Used for prebuilt
+        # benchmark effort comparisons, where each effort level is its own run.
+        # Browsers decode "+" in query strings as a space — accept both.
+        group_id = group_id.replace(" ", "+")
+        if "+" in group_id:
+            from eval_mcp.core.eval_results import build_merged_detail
+
+            parts = []
+            for raw in group_id.split("+"):
+                gid, _, label = raw.partition(":")
+                parts.append((gid, label or gid[:8]))
+            merged = await build_merged_detail(user_id, parts)
+            if merged is None:
+                raise HTTPException(status_code=404, detail="Merged group not found")
+            return merged
+
         data = load_eval_detail(user_id, group_id)
         if data:
             return data

--- a/tests/test_inspect_patches_thinking.py
+++ b/tests/test_inspect_patches_thinking.py
@@ -166,3 +166,17 @@ def test_max_effort_ceiling_respects_smaller_models() -> None:
     api.model_name = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
     api.service = "bedrock"
     assert AnthropicAPI.max_tokens_for_config(api, GenerateConfig(reasoning_effort="max")) == 64_000
+
+
+def test_runtime_openai_ids_price_via_mantle_key() -> None:
+    """GPT models on bedrock-runtime CRIS profiles must resolve to the
+    bedrock_mantle pricing key — AWS documents identical per-token pricing on
+    both endpoints, and there is no runtime-form key in the catalog."""
+    from eval_mcp.core.pricing import _candidates
+
+    for mid, base in (
+        ("bedrock/global.openai.gpt-5.6-terra", "openai.gpt-5.6-terra"),
+        ("bedrock/us.openai.gpt-5.6-sol", "openai.gpt-5.6-sol"),
+        ("bedrock/openai.gpt-oss-120b-1:0", "openai.gpt-oss-120b-1:0"),
+    ):
+        assert f"bedrock_mantle/{base}" in _candidates(mid), mid


### PR DESCRIPTION
## Summary
- `run_benchmark` accepts `reasoning_effort` (none|minimal|low|medium|high|xhigh|max), passed through to Inspect's `--reasoning-effort`; one call per level compares levels on identical inputs
- Providers whose route silently drops effort are rejected loudly (same gate as create_eval_config)
- Claude targets in benchmark runs route via the native anthropic provider so effort actually reaches them

## Why
Effort comparisons previously required hand-authored expert task files even when a prebuilt `inspect_evals` benchmark existed. Now any of the ~138 catalog benchmarks works directly.

## Test plan
- [x] tests pass (`pytest tests/test_benchmarks.py tests/test_benchmark_registry.py`)
- [x] live smoke: frontierscience olympic, Sonnet 5 + Opus 5, low vs high — identical sample ids, effort-scaled token spend, clean grading