### PR TITLE
fix(mcp): raise anthropic floor to inspect-ai's runtime minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,13 @@ dependencies = [
     # so thinking gates and effort-aware max_tokens come from the upstream SDK
     # provider instead of Inspect's Converse mirror. See
     # eval_mcp/core/model_routing.py. Same SigV4 credential chain as boto3.
-    "anthropic>=0.80.0",
+    # Floor matches inspect-ai's runtime MIN_VERSION for its anthropic
+    # provider (enforced at generate() time but declared only in inspect's
+    # own extra, same trap as openai above). A fresh resolve picked 0.100.0
+    # and every Claude judge call failed with "requires at least 0.109.1"
+    # while the run reported success with score 0.0 (verified live on
+    # 0.17.0). Bump this floor whenever inspect-ai bumps theirs.
+    "anthropic>=0.109.1",
     "aws-bedrock-token-generator>=1.1.0",
     "click>=8.1.7",
     "rich>=13.7.0",
@@ -96,7 +102,13 @@ dependencies = [
 # only install the extra if you plan to evaluate models from those providers.
 providers = [
     "openai>=2.26.0",
-    "anthropic>=0.80.0",
+    # Floor matches inspect-ai's runtime MIN_VERSION for its anthropic
+    # provider (enforced at generate() time but declared only in inspect's
+    # own extra, same trap as openai above). A fresh resolve picked 0.100.0
+    # and every Claude judge call failed with "requires at least 0.109.1"
+    # while the run reported success with score 0.0 (verified live on
+    # 0.17.0). Bump this floor whenever inspect-ai bumps theirs.
+    "anthropic>=0.109.1",
     "google-genai>=1.69.0",
     "azure-identity",
     "azure-ai-inference",

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.100.0"
+version = "0.125.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -230,9 +230,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/f8/6f0560884b5363848347bd640b6c1d04abc25e7aa61787a232f790c6b60a/anthropic-0.125.0.tar.gz", hash = "sha256:e0cdd336580cb7411c1cdab69f80973e9bf4bff7f8e08141811d46307d45c682", size = 1112593, upload-time = "2026-08-19T22:00:42.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/1a/b1bd30cda3790557e8791bec5922a6ec8fabb6fa8b008c76a39cf7be6152/anthropic-0.125.0-py3-none-any.whl", hash = "sha256:3486013602eca76d8b12540764e53654f02cf4951110bca86cf06e67428a9f21", size = 1184067, upload-time = "2026-08-19T22:00:44.596Z" },
 ]
 
 [[package]]
@@ -1680,8 +1680,8 @@ providers = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.80.0" },
-    { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.80.0" },
+    { name = "anthropic", specifier = ">=0.109.1" },
+    { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.109.1" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "asyncpg", marker = "extra == 'backend'", specifier = ">=0.30.0" },
     { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary
- anthropic>=0.80.0 → >=0.109.1 (inspect-ai's runtime MIN_VERSION for its anthropic provider); uv.lock regenerated (0.100.0 → 0.125.0)

## Why
Fresh installs of 0.17.0 resolve anthropic 0.100.0, every Claude judge call errors ("requires at least version 0.109.1"), and the jury reports success with score 0.0. Verified live: Grok 4.6 smoke eval scored 0.0 on 0.17.0, 1.0 with the bump — identical config.

Warrants a 0.17.1 patch release on merge.

## Test plan
- [x] live: same eval config 0.0 (broken judges) → 1.0 (fixed) with anthropic 0.125.0 in a fresh resolve
- [ ] known follow-up (separate): all-judges-errored should fail loud instead of scoring 0.0