### PR TITLE
fix(mcp): drop redacted reasoning instead of emptying it; stop hiding…

### DIFF
--- a/eval_mcp/inspect_patches.py
+++ b/eval_mcp/inspect_patches.py
@@ -248,11 +248,22 @@ def _patch_bedrock_redacted_reasoning() -> None:
     schema requires ``reasoningText``, so every such response crashes with a
     pydantic ValidationError (verified live on gpt-5.6-sol, 2026-08-19).
 
-    Fix: make ``reasoningText`` optional and accept ``redactedContent`` in
-    the schema, then map redacted-only blocks to an empty reasoning text
-    before conversion — the content is encrypted and unreadable by design;
-    what matters is that the run doesn't die and usage still counts. Remove
-    when upstream models redacted reasoning.
+    Fix: make ``reasoningText`` optional so the response parses, then DROP
+    redacted-only blocks before conversion — the content is encrypted and
+    unreadable by design, so there is nothing to carry forward.
+
+    Do not substitute an empty ``reasoningText`` instead of dropping. That
+    keeps a contentless reasoning block in the message history, and on the
+    next turn Inspect serializes it back as ``reasoningText.text = ""``,
+    which Converse rejects with a bare ``InternalServerException`` — a
+    multi-turn run then dies at the first turn that replays it (verified
+    live on gpt-5.6-luna via aiwf, 2026-08-20: 3/3 runs died at turn 3,
+    and ``fail_on_error=False`` reported them as ``status: success`` with
+    ``results: null``). Replaying the real ``redactedContent`` bytes
+    verbatim does work, so preserving them is the richer fix if a caller
+    ever needs reasoning carried across turns.
+
+    Remove when upstream models redacted reasoning.
     """
     try:
         from typing import Optional
@@ -272,9 +283,8 @@ def _patch_bedrock_redacted_reasoning() -> None:
     rc.__pydantic_fields__["reasoningText"] = FieldInfo(
         annotation=Optional[_bedrock.ConverseReasoningText], default=None
     )
-    rc.__pydantic_fields__["redactedContent"] = FieldInfo(
-        annotation=Optional[bytes], default=None
-    )
+    # No redactedContent field needed: pydantic's default extra="ignore" lets
+    # the payload parse once reasoningText is optional, and we drop the block.
     rc.model_rebuild(force=True)
     # Parents cache the child's core schema — rebuild the chain.
     for name in ("ConverseMessageContent", "ConverseMessage", "ConverseOutput", "ConverseResponse"):
@@ -284,13 +294,13 @@ def _patch_bedrock_redacted_reasoning() -> None:
 
     original = _bedrock.model_output_from_response
 
-    def _model_output_tolerating_redacted(model, response, tools):
-        for c in response.output.message.content:
-            if c.reasoningContent is not None and c.reasoningContent.reasoningText is None:
-                c.reasoningContent.reasoningText = _bedrock.ConverseReasoningText(text="")
+    def _model_output_dropping_redacted(model, response, tools):
+        content = response.output.message.content
+        content[:] = [c for c in content if c.reasoningContent is None
+                      or c.reasoningContent.reasoningText is not None]
         return original(model, response, tools)
 
-    _bedrock.model_output_from_response = _model_output_tolerating_redacted
+    _bedrock.model_output_from_response = _model_output_dropping_redacted
 
 
 # Apply on import so a generated task file gets the patch simply by importing

--- a/eval_mcp/tools/multiturn_benchmarks.py
+++ b/eval_mcp/tools/multiturn_benchmarks.py
@@ -194,7 +194,10 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
             "--adaptive-connections",
             "true",
             "--no-log-images",
-            "--no-fail-on-error",
+            # fail_on_error stays ON: these benchmarks run ONE sample per model,
+            # so there are no sibling samples for --no-fail-on-error to protect.
+            # All it did was relabel a dead run's status from "error" to
+            # "success" (verified live 2026-08-20 on gpt-5.6-luna aiwf).
             "--log-shared",
             "10",
         ]
@@ -208,6 +211,16 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
             # Comma-joined: -T passes one scalar; the task splits it back.
             # Model ids never contain commas.
             cmd.extend(["-T", f"judge_models={','.join(judge_models)}"])
+
+        # Snapshot existing logs so the post-run scored-nothing check below only
+        # inspects the logs this run produces.
+        try:
+            from inspect_ai._view.common import list_eval_logs_async
+
+            pre_existing = {i.name for i in await list_eval_logs_async(log_dir_str)}
+        except Exception as e:  # pragma: no cover - listing shape changed upstream
+            logger.warning("Could not snapshot logs (%s); skipping scored-nothing check.", e)
+            pre_existing = None
 
         process = await asyncio.create_subprocess_exec(
             *cmd,
@@ -253,21 +266,33 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
             logger.warning("precompute failed: %s", e)
 
         if process.returncode != 0:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "success": False,
-                            "evalId": eval_id,
-                            "task": task,
-                            "error": f"Benchmark failed with exit code {process.returncode}",
-                            "stderr": stderr_str[:2000],
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            return [_err(
+                f"Benchmark failed with exit code {process.returncode}",
+                eval_id, task, stderr=stderr_str[:2000],
+            )]
+
+        # Inspect exits 0 even when a sample errors, so the returncode check above
+        # cannot see a dead run — the log is the only signal.
+        if pre_existing is not None:
+            try:
+                from inspect_ai.log import read_eval_log_async
+
+                dead = [
+                    f"{h.eval.model} ({h.status})"
+                    for info in await list_eval_logs_async(log_dir_str)
+                    if info.name not in pre_existing
+                    for h in [await read_eval_log_async(info.name, header_only=True)]
+                    if h.results is None
+                ]
+            except Exception as e:  # pragma: no cover - log shape changed upstream
+                logger.warning("Result check failed (%s); reporting run as-is.", e)
+                dead = []
+            if dead:
+                return [_err(
+                    "Benchmark scored nothing for: " + ", ".join(dead)
+                    + ". Read the sample's error field in the .eval log for the cause.",
+                    eval_id, task,
+                )]
 
         return [
             TextContent(
@@ -299,8 +324,15 @@ async def handle_run_multiturn_benchmark(args: Dict[str, Any]) -> List[TextConte
         return [_err(f"Benchmark failed: {e}", eval_id)]
 
 
-def _err(message: str, eval_id: str, task: Optional[str] = None) -> TextContent:
+def _err(
+    message: str,
+    eval_id: str,
+    task: Optional[str] = None,
+    stderr: Optional[str] = None,
+) -> TextContent:
     payload: Dict[str, Any] = {"success": False, "evalId": eval_id, "error": message}
     if task:
         payload["task"] = task
+    if stderr:
+        payload["stderr"] = stderr
     return TextContent(type="text", text=json.dumps(payload, indent=2))

--- a/tests/test_inspect_patches_redacted_reasoning.py
+++ b/tests/test_inspect_patches_redacted_reasoning.py
@@ -1,0 +1,139 @@
+"""Tests for the redacted-reasoning patch on the Converse path.
+
+GPT-5.x returns its chain of thought as ``reasoningContent.redactedContent`` —
+an encrypted blob — where Claude returns readable ``reasoningText``. Upstream's
+schema requires ``reasoningText``, so the raw response cannot even be parsed.
+
+The patch makes ``reasoningText`` optional and DROPS redacted-only blocks. The
+drop is the load-bearing part: an earlier version substituted an empty
+``reasoningText`` instead, which parsed fine but left a contentless reasoning
+block in the message history. On the next turn Inspect serialized it back as
+``reasoningText.text = ""`` and Converse rejected the request with a bare
+``InternalServerException``. Verified live on gpt-5.6-luna (aiwf, 2026-08-20):
+3/3 runs died at turn 3, and because ``fail_on_error`` was disabled they all
+reported ``status: success`` with ``results: null``.
+
+So these tests pin both directions — parse in, and nothing empty back out.
+"""
+
+import asyncio
+
+import eval_mcp.inspect_patches  # noqa: F401 — applies on import
+from inspect_ai.model._providers.bedrock import (
+    ConverseMessage,
+    ConverseMessageContent,
+    ConverseMetrics,
+    ConverseOutput,
+    ConverseResponse,
+    ConverseUsage,
+    converse_contents,
+    model_output_from_response,
+)
+
+REDACTED_BLOB = b"\x01\x02encrypted-reasoning-blob"
+
+
+def _response(*content: dict) -> ConverseResponse:
+    """A minimal assistant Converse response carrying `content` blocks."""
+    return ConverseResponse(
+        output=ConverseOutput(
+            message=ConverseMessage(
+                role="assistant",
+                content=[ConverseMessageContent(**c) for c in content],
+            )
+        ),
+        stopReason="end_turn",
+        usage=ConverseUsage(inputTokens=1, outputTokens=1, totalTokens=2),
+        metrics=ConverseMetrics(latencyMs=1),
+    )
+
+
+# ----- inbound: the payload must parse at all -----
+
+
+def test_redacted_only_payload_parses() -> None:
+    """Unpatched this raises ValidationError: reasoningText is required and
+    there is no redactedContent field."""
+    block = ConverseMessageContent(
+        reasoningContent={"redactedContent": REDACTED_BLOB}
+    )
+    assert block.reasoningContent is not None
+    assert block.reasoningContent.reasoningText is None
+
+
+def test_readable_reasoning_still_parses() -> None:
+    """Making reasoningText optional must not stop normal reasoning parsing."""
+    block = ConverseMessageContent(
+        reasoningContent={"reasoningText": {"text": "step one"}}
+    )
+    assert block.reasoningContent.reasoningText.text == "step one"
+
+
+# ----- inbound: redacted blocks are dropped, not emptied -----
+
+
+def test_redacted_block_is_dropped_from_output() -> None:
+    response = _response(
+        {"reasoningContent": {"redactedContent": REDACTED_BLOB}},
+        {"text": "Workshop day is Tuesday."},
+    )
+    out = model_output_from_response("bedrock/us.openai.gpt-5.6-luna", response, [])
+    content = out.choices[0].message.content
+    types = [c.type for c in content] if isinstance(content, list) else ["text"]
+    assert "reasoning" not in types, (
+        "a redacted block must be dropped, not turned into empty reasoning — "
+        "an empty reasoning block poisons the next turn's history"
+    )
+    assert "text" in types
+
+
+def test_readable_reasoning_is_preserved_in_output() -> None:
+    """Only redacted-only blocks are dropped; real reasoning survives."""
+    response = _response(
+        {"reasoningContent": {"reasoningText": {"text": "thinking hard"}}},
+        {"text": "Answer."},
+    )
+    out = model_output_from_response("bedrock/us.anthropic.claude-sonnet-5", response, [])
+    content = out.choices[0].message.content
+    reasoning = [c for c in content if c.type == "reasoning"]
+    assert len(reasoning) == 1
+    assert reasoning[0].reasoning == "thinking hard"
+
+
+# ----- outbound: the actual regression -----
+
+
+def test_no_empty_reasoning_block_is_ever_sent_back() -> None:
+    """The round trip that used to crash: parse a redacted response, then
+    re-serialize that message for the following turn. The outbound payload
+    must contain no reasoningContent at all — Converse answers an empty
+    reasoningText with InternalServerException."""
+    response = _response(
+        {"reasoningContent": {"redactedContent": REDACTED_BLOB}},
+        {"text": "Workshop day is Tuesday."},
+    )
+    out = model_output_from_response("bedrock/us.openai.gpt-5.6-luna", response, [])
+
+    replayed = asyncio.run(converse_contents(out.choices[0].message.content))
+
+    assert all(b.reasoningContent is None for b in replayed), (
+        "replaying a reasoning block built from redacted content is what "
+        "produced the live InternalServerException at turn 3"
+    )
+    assert any(b.text for b in replayed), "the spoken text must still be replayed"
+
+
+def test_readable_reasoning_round_trips_outbound() -> None:
+    """Guard against over-dropping: Claude's readable reasoning must still be
+    sent back, since that path was never broken."""
+    response = _response(
+        {"reasoningContent": {"reasoningText": {"text": "thinking hard"}}},
+        {"text": "Answer."},
+    )
+    out = model_output_from_response("bedrock/us.anthropic.claude-sonnet-5", response, [])
+
+    replayed = asyncio.run(converse_contents(out.choices[0].message.content))
+
+    emitted = [b.reasoningContent for b in replayed if b.reasoningContent is not None]
+    assert len(emitted) == 1
+    assert emitted[0].reasoningText.text == "thinking hard"

--- a/tests/test_multiturn_benchmark_runner.py
+++ b/tests/test_multiturn_benchmark_runner.py
@@ -166,3 +166,17 @@ async def test_inspect_evals_branch_rejects_judge_params_loudly():
         res = json.loads(out[0].text)
         assert not res["success"], key
         assert key in res["error"], res["error"]
+
+
+@pytest.mark.asyncio
+async def test_fail_on_error_is_not_disabled():
+    """These benchmarks run ONE sample per model, so --no-fail-on-error has no
+    sibling samples to protect. All it did was relabel a dead run's status from
+    "error" to "success": three gpt-5.6-luna aiwf runs died at turn 3 and every
+    one reported as a pass (live, 2026-08-20). Verified live that dropping the
+    flag does not cost sibling models — a broken Luna and a healthy Haiku ran
+    together and Haiku still scored."""
+    captured = {}
+    res = await _run({"providers": ["bedrock/x"]}, captured)
+    assert res["success"], res
+    assert "--no-fail-on-error" not in captured["cmd"]


### PR DESCRIPTION
… dead runs

The redacted-reasoning patch substituted an empty reasoningText for GPT-5.x's encrypted reasoning. That parses, but leaves a contentless reasoning block in the message history; the next turn serializes it back as reasoningText.text="" and Converse rejects the request with a bare InternalServerException. Verified live on gpt-5.6-luna (aiwf, 2026-08-20): 3/3 runs died at turn 3. Replaying the real redactedContent bytes verbatim works, and stripping the block works — only the empty husk fails, so drop it.

- drop redacted-only reasoning blocks rather than emptying them
- remove the redactedContent schema field: nothing reads it, and pydantic's default extra="ignore" already lets the payload parse
- stop passing --no-fail-on-error: these benchmarks run one sample per model, so it had no sibling samples to protect and only relabeled a dead run's status from "error" to "success". Verified a broken Luna alongside a healthy Haiku still scores Haiku.
- report runs that wrote no results block as failures. Inspect exits 0 whether a run scored, errored, or died mid-conversation, so the returncode check cannot see this; the log is the only signal.
- reuse _err() for both failure paths

aiwf on gpt-5.6-luna now completes: pass_rate 1.000 over 12 turns.

Tests: the two regression tests fail on the prior behaviour and pass after. The scored-nothing check is verified against real .eval logs rather than mocks, per CLAUDE.md.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
